### PR TITLE
fix: validate service port conflicts on same host

### DIFF
--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -131,6 +131,8 @@ func validateDatabaseSpec(spec *api.DatabaseSpec) error {
 
 	// Validate services
 	seenServiceIDs := make(ds.Set[string], len(spec.Services))
+	portOwner := make(servicePortOwnerMap)
+
 	for i, svc := range spec.Services {
 		svcPath := []string{"services", arrayIndexPath(i)}
 
@@ -141,6 +143,7 @@ func validateDatabaseSpec(spec *api.DatabaseSpec) error {
 		}
 		seenServiceIDs.Add(string(svc.ServiceID))
 
+		errs = append(errs, validateServicePortConflicts(svc, svcPath, portOwner)...)
 		errs = append(errs, validateServiceSpec(svc, svcPath, false, seenNodeNames)...)
 	}
 
@@ -199,9 +202,12 @@ func validateDatabaseUpdate(old *database.Spec, new *api.DatabaseSpec) error {
 	// Validate each service. Pass isUpdate=false for services being added for the
 	// first time so that bootstrap-only fields are accepted. For service types that
 	// have no bootstrap fields (e.g. postgrest) the flag has no effect.
+	portOwner := make(servicePortOwnerMap)
 	for i, svc := range new.Services {
 		svcPath := []string{"services", arrayIndexPath(i)}
 		isExistingService := existingServiceIDs.Has(string(svc.ServiceID))
+
+		errs = append(errs, validateServicePortConflicts(svc, svcPath, portOwner)...)
 		errs = append(errs, validateServiceSpec(svc, svcPath, isExistingService, newNodeNames)...)
 	}
 
@@ -475,6 +481,38 @@ func validateUsers(users []*api.DatabaseUserSpec, path []string) []error {
 		}
 	}
 
+	return errs
+}
+
+// hostPort identifies a unique (host, port) binding for cross-service
+// port conflict detection.
+type hostPort struct {
+	hostID string
+	port   int
+}
+
+// servicePortOwnerMap tracks which service owns a given (host, port) pair.
+// Callers create one map and pass it to validateServicePortConflicts for
+// each service in the spec.
+type servicePortOwnerMap map[hostPort]string
+
+// validateServicePortConflicts checks that the service's explicit port (if any)
+// does not collide with a port already claimed by another service on the same host.
+func validateServicePortConflicts(svc *api.ServiceSpec, path []string, owner servicePortOwnerMap) []error {
+	if svc.Port == nil || *svc.Port <= 0 {
+		return nil
+	}
+
+	var errs []error
+	for _, hostID := range svc.HostIds {
+		key := hostPort{hostID: string(hostID), port: *svc.Port}
+		if prev, exists := owner[key]; exists {
+			err := fmt.Errorf("port %d conflicts with service %q on the same host", *svc.Port, prev)
+			errs = append(errs, newValidationError(err, appendPath(path, "port")))
+		} else {
+			owner[key] = string(svc.ServiceID)
+		}
+	}
 	return errs
 }
 

--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -129,10 +129,11 @@ func validateDatabaseSpec(spec *api.DatabaseSpec) error {
 	// Validate orchestrator_opts (spec-level)
 	errs = append(errs, validateOrchestratorOpts(spec.OrchestratorOpts, []string{"orchestrator_opts"})...)
 
-	// Validate services
-	seenServiceIDs := make(ds.Set[string], len(spec.Services))
+	// Validate services — seed portOwner with Postgres ports so services can't collide with the database.
 	portOwner := make(servicePortOwnerMap)
+	seedPostgresPorts(spec, portOwner)
 
+	seenServiceIDs := make(ds.Set[string], len(spec.Services))
 	for i, svc := range spec.Services {
 		svcPath := []string{"services", arrayIndexPath(i)}
 
@@ -199,10 +200,13 @@ func validateDatabaseUpdate(old *database.Spec, new *api.DatabaseSpec) error {
 		existingServiceIDs.Add(svc.ServiceID)
 	}
 
+	// Seed portOwner with Postgres ports so services can't collide with the database.
+	portOwner := make(servicePortOwnerMap)
+	seedPostgresPorts(new, portOwner)
+
 	// Validate each service. Pass isUpdate=false for services being added for the
 	// first time so that bootstrap-only fields are accepted. For service types that
 	// have no bootstrap fields (e.g. postgrest) the flag has no effect.
-	portOwner := make(servicePortOwnerMap)
 	for i, svc := range new.Services {
 		svcPath := []string{"services", arrayIndexPath(i)}
 		isExistingService := existingServiceIDs.Has(string(svc.ServiceID))
@@ -482,6 +486,24 @@ func validateUsers(users []*api.DatabaseUserSpec, path []string) []error {
 	}
 
 	return errs
+}
+
+// seedPostgresPorts registers each node's effective Postgres port in the
+// portOwner map so that service port validation can detect collisions with
+// the database. A node-level port override (node.Port) takes precedence
+// over the spec-level default (spec.Port).
+func seedPostgresPorts(spec *api.DatabaseSpec, owner servicePortOwnerMap) {
+	for _, node := range spec.Nodes {
+		pgPort := utils.FromPointer(spec.Port)
+		if node.Port != nil {
+			pgPort = *node.Port
+		}
+		if pgPort > 0 {
+			for _, hostID := range node.HostIds {
+				owner[hostPort{hostID: string(hostID), port: pgPort}] = "postgres"
+			}
+		}
+	}
 }
 
 // hostPort identifies a unique (host, port) binding for cross-service

--- a/server/internal/api/apiv1/validate_test.go
+++ b/server/internal/api/apiv1/validate_test.go
@@ -818,6 +818,99 @@ func TestValidateDatabaseSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid service port conflicts with postgres port",
+			spec: &api.DatabaseSpec{
+				DatabaseName:    "testdb",
+				PostgresVersion: utils.PointerTo("17.6"),
+				Port:            utils.PointerTo(5432),
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name:    "n1",
+						HostIds: []api.Identifier{"host-1"},
+					},
+				},
+				Services: []*api.ServiceSpec{
+					{
+						ServiceID:   "mcp-server",
+						ServiceType: "mcp",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-1"},
+						Port:        utils.PointerTo(5432),
+						Config: map[string]any{
+							"llm_enabled":       true,
+							"llm_provider":      "anthropic",
+							"llm_model":         "claude-sonnet-4-5",
+							"anthropic_api_key": "sk-ant-...",
+						},
+					},
+				},
+			},
+			expected: []string{
+				`port 5432 conflicts with service "postgres" on the same host`,
+			},
+		},
+		{
+			name: "invalid service port conflicts with node-level postgres port override",
+			spec: &api.DatabaseSpec{
+				DatabaseName:    "testdb",
+				PostgresVersion: utils.PointerTo("17.6"),
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name:    "n1",
+						HostIds: []api.Identifier{"host-1"},
+						Port:    utils.PointerTo(5433),
+					},
+				},
+				Services: []*api.ServiceSpec{
+					{
+						ServiceID:   "mcp-server",
+						ServiceType: "mcp",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-1"},
+						Port:        utils.PointerTo(5433),
+						Config: map[string]any{
+							"llm_enabled":       true,
+							"llm_provider":      "anthropic",
+							"llm_model":         "claude-sonnet-4-5",
+							"anthropic_api_key": "sk-ant-...",
+						},
+					},
+				},
+			},
+			expected: []string{
+				`port 5433 conflicts with service "postgres" on the same host`,
+			},
+		},
+		{
+			name: "valid service port on different host than postgres",
+			spec: &api.DatabaseSpec{
+				DatabaseName:    "testdb",
+				PostgresVersion: utils.PointerTo("17.6"),
+				Port:            utils.PointerTo(5432),
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name:    "n1",
+						HostIds: []api.Identifier{"host-1"},
+					},
+				},
+				Services: []*api.ServiceSpec{
+					{
+						ServiceID:   "mcp-server",
+						ServiceType: "mcp",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-2"},
+						Port:        utils.PointerTo(5432),
+						Config: map[string]any{
+							"llm_enabled":       true,
+							"llm_provider":      "anthropic",
+							"llm_model":         "claude-sonnet-4-5",
+							"anthropic_api_key": "sk-ant-...",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "invalid with service validation errors",
 			spec: &api.DatabaseSpec{
 				DatabaseName:    "testdb",

--- a/server/internal/api/apiv1/validate_test.go
+++ b/server/internal/api/apiv1/validate_test.go
@@ -645,6 +645,179 @@ func TestValidateDatabaseSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid with service port conflict on same host",
+			spec: &api.DatabaseSpec{
+				DatabaseName:    "testdb",
+				PostgresVersion: utils.PointerTo("17.6"),
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name:    "n1",
+						HostIds: []api.Identifier{"host-1"},
+					},
+				},
+				Services: []*api.ServiceSpec{
+					{
+						ServiceID:   "mcp-server",
+						ServiceType: "mcp",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-1"},
+						Port:        utils.PointerTo(8080),
+						Config: map[string]any{
+							"llm_enabled":       true,
+							"llm_provider":      "anthropic",
+							"llm_model":         "claude-sonnet-4-5",
+							"anthropic_api_key": "sk-ant-...",
+						},
+					},
+					{
+						ServiceID:   "postgrest-server",
+						ServiceType: "postgrest",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-1"},
+						Port:        utils.PointerTo(8080),
+						Config:      map[string]any{},
+					},
+				},
+			},
+			expected: []string{
+				`services[1].port: port 8080 conflicts with service "mcp-server" on the same host`,
+			},
+		},
+		{
+			name: "valid services with same port on different hosts",
+			spec: &api.DatabaseSpec{
+				DatabaseName:    "testdb",
+				PostgresVersion: utils.PointerTo("17.6"),
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name:    "n1",
+						HostIds: []api.Identifier{"host-1"},
+					},
+				},
+				Services: []*api.ServiceSpec{
+					{
+						ServiceID:   "mcp-server",
+						ServiceType: "mcp",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-1"},
+						Port:        utils.PointerTo(8080),
+						Config: map[string]any{
+							"llm_enabled":       true,
+							"llm_provider":      "anthropic",
+							"llm_model":         "claude-sonnet-4-5",
+							"anthropic_api_key": "sk-ant-...",
+						},
+					},
+					{
+						ServiceID:   "postgrest-server",
+						ServiceType: "postgrest",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-2"},
+						Port:        utils.PointerTo(8080),
+						Config:      map[string]any{},
+					},
+				},
+			},
+		},
+		{
+			name: "valid single service on multiple hosts with same port",
+			spec: &api.DatabaseSpec{
+				DatabaseName:    "testdb",
+				PostgresVersion: utils.PointerTo("17.6"),
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name:    "n1",
+						HostIds: []api.Identifier{"host-1", "host-2"},
+					},
+				},
+				Services: []*api.ServiceSpec{
+					{
+						ServiceID:   "mcp-server",
+						ServiceType: "mcp",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-1", "host-2"},
+						Port:        utils.PointerTo(8080),
+						Config: map[string]any{
+							"llm_enabled":       true,
+							"llm_provider":      "anthropic",
+							"llm_model":         "claude-sonnet-4-5",
+							"anthropic_api_key": "sk-ant-...",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid services with nil port do not conflict",
+			spec: &api.DatabaseSpec{
+				DatabaseName:    "testdb",
+				PostgresVersion: utils.PointerTo("17.6"),
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name:    "n1",
+						HostIds: []api.Identifier{"host-1"},
+					},
+				},
+				Services: []*api.ServiceSpec{
+					{
+						ServiceID:   "mcp-server",
+						ServiceType: "mcp",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-1"},
+						Config: map[string]any{
+							"llm_enabled":       true,
+							"llm_provider":      "anthropic",
+							"llm_model":         "claude-sonnet-4-5",
+							"anthropic_api_key": "sk-ant-...",
+						},
+					},
+					{
+						ServiceID:   "postgrest-server",
+						ServiceType: "postgrest",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-1"},
+						Config:      map[string]any{},
+					},
+				},
+			},
+		},
+		{
+			name: "valid services with port 0 do not conflict",
+			spec: &api.DatabaseSpec{
+				DatabaseName:    "testdb",
+				PostgresVersion: utils.PointerTo("17.6"),
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name:    "n1",
+						HostIds: []api.Identifier{"host-1"},
+					},
+				},
+				Services: []*api.ServiceSpec{
+					{
+						ServiceID:   "mcp-server",
+						ServiceType: "mcp",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-1"},
+						Port:        utils.PointerTo(0),
+						Config: map[string]any{
+							"llm_enabled":       true,
+							"llm_provider":      "anthropic",
+							"llm_model":         "claude-sonnet-4-5",
+							"anthropic_api_key": "sk-ant-...",
+						},
+					},
+					{
+						ServiceID:   "postgrest-server",
+						ServiceType: "postgrest",
+						Version:     "1.0.0",
+						HostIds:     []api.Identifier{"host-1"},
+						Port:        utils.PointerTo(0),
+						Config:      map[string]any{},
+					},
+				},
+			},
+		},
+		{
 			name: "invalid with service validation errors",
 			spec: &api.DatabaseSpec{
 				DatabaseName:    "testdb",
@@ -1581,6 +1754,33 @@ func TestValidateDatabaseUpdate_ServiceBootstrapFields(t *testing.T) {
 				Services: []*api.ServiceSpec{
 					newMCPService("appmcp", validMCPConfig),
 				},
+			},
+		},
+		{
+			name: "port conflict on update-database",
+			old:  &database.Spec{},
+			new: &api.DatabaseSpec{
+				Services: []*api.ServiceSpec{
+					{
+						ServiceID:   "mcp-server",
+						ServiceType: "mcp",
+						Version:     "latest",
+						HostIds:     []api.Identifier{"host-1"},
+						Port:        utils.PointerTo(8080),
+						Config:      validMCPConfig,
+					},
+					{
+						ServiceID:   "postgrest-server",
+						ServiceType: "postgrest",
+						Version:     "latest",
+						HostIds:     []api.Identifier{"host-1"},
+						Port:        utils.PointerTo(8080),
+						Config:      map[string]any{},
+					},
+				},
+			},
+			expected: []string{
+				`port 8080 conflicts with service "mcp-server" on the same host`,
 			},
 		},
 	} {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                             
                                                                                                           
  - Add cross-service port conflict validation to both create-database and update-database paths                                                                                                                                         
  - Track `(hostID, port)` pairs across all services and reject duplicates where port > 0                                                                                                                                                
  - Nil ports (no publish) and port 0 (Docker random assignment) are excluded from checking                                                                                                                                              
                                                                                                                                                                                                                                         
## Test plan                                                                                                                                                                                                                           
                                                                                                                                                                                                                                         
  - [ ] `make test` passes                                                                                 
  - [ ] Create database with two services using same port on same host — should return validation error
  - [ ] Create database with two services using same port on different hosts — should succeed                                                                                                                                            
  - [ ] Create database with services using nil/zero ports on same host — should succeed                                                                                                                                                 
  - [ ] Update database adding a service that conflicts with existing service port — should return validation error                                                                                                                      
                                                                                                                                                                                                                                         
PLAT-531                                                                                                 
