### PR TITLE
feat: wire PostgREST into the orchestrator

### DIFF
--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -17,7 +17,7 @@ the following service types:
   queries and AI-powered data access.
 - The pgEdge RAG Server *(coming soon)* enables retrieval-augmented
   generation workflows using your database as a knowledge store.
-- PostgREST *(coming soon)* automatically generates a REST API from
+- [PostgREST](postgrest.md) automatically generates a REST API from
   your PostgreSQL schema, making your data accessible over HTTP without
   writing backend code.
 

--- a/docs/services/managing.md
+++ b/docs/services/managing.md
@@ -25,8 +25,13 @@ The following table describes the fields in a service spec:
 ## Adding a Service
 
 Include a `services` array in your database spec when creating or
-updating a database. In the following example, a `curl` command creates
-a single-node database with one MCP service instance:
+updating a database. The following examples show how to add an MCP
+service and a PostgREST service.
+
+### Adding an MCP Service
+
+In the following example, a `curl` command creates a single-node
+database with one MCP service instance:
 
 === "curl"
 
@@ -52,6 +57,40 @@ a single-node database with one MCP service instance:
                             "llm_provider": "anthropic",
                             "llm_model": "claude-sonnet-4-5",
                             "anthropic_api_key": "sk-ant-..."
+                        }
+                    }
+                ]
+            }
+        }'
+    ```
+
+### Adding a PostgREST Service
+
+In the following example, a `curl` command creates a single-node
+database with a PostgREST service instance. The service exposes the
+`public` schema and enables JWT authentication:
+
+=== "curl"
+
+    ```sh
+    curl -X POST http://host-1:3000/v1/databases \
+        -H 'Content-Type: application/json' \
+        --data '{
+            "id": "storefront",
+            "spec": {
+                "database_name": "storefront",
+                "nodes": [
+                    { "name": "n1", "host_ids": ["host-1"] }
+                ],
+                "services": [
+                    {
+                        "service_id": "api",
+                        "service_type": "postgrest",
+                        "version": "latest",
+                        "host_ids": ["host-1"],
+                        "port": 3100,
+                        "config": {
+                            "jwt_secret": "a-secret-key-of-at-least-32-characters"
                         }
                     }
                 ]

--- a/docs/services/postgrest.md
+++ b/docs/services/postgrest.md
@@ -1,0 +1,239 @@
+# PostgREST
+
+PostgREST turns your PostgreSQL schema into a REST API. The Control
+Plane deploys and manages a PostgREST container alongside your database,
+handling connection strings, multi-host failover, and schema validation
+on every deploy.
+
+## Overview
+
+The Control Plane provisions a PostgREST container on each host you
+specify. The container connects to the database using
+automatically-managed credentials and serves HTTP at your configured
+port. Anonymous requests run as the configured `db_anon_role`.
+JWT-authenticated requests switch to any role granted to the
+authenticator.
+
+See [Managing Services](managing.md) for instructions on adding,
+updating, and removing services. The sections below cover
+PostgREST-specific configuration.
+
+## Configuration Reference
+
+All configuration fields go in the `config` object of the service spec.
+All fields are optional. The defaults work for a read-only API.
+
+### Database
+
+| Field          | Type    | Default                          | Description |
+|----------------|---------|----------------------------------|-------------|
+| `db_schemas`   | string  | `"public"`                       | Comma-separated schemas to expose. Each schema is checked at deploy time. Provisioning fails if any schema does not exist. |
+| `db_anon_role` | string  | `"pgedge_application_read_only"` | PostgreSQL role for unauthenticated requests. The role must exist before deployment. |
+| `db_pool`      | integer | `10`                             | Connection pool size. Range: 1-30. |
+| `max_rows`     | integer | `1000`                           | Maximum rows returned per response. Range: 1-10000. |
+
+### JWT Authentication
+
+JWT authentication lets clients switch PostgreSQL roles per request
+using a signed token. Omit these fields to run in anonymous-only mode.
+
+| Field                | Type   | Description |
+|----------------------|--------|-------------|
+| `jwt_secret`         | string | Signing key for validating incoming JWTs. Minimum 32 characters. Required to enable JWT auth. |
+| `jwt_aud`            | string | Expected audience claim. PostgREST rejects tokens without a matching `aud` claim. |
+| `jwt_role_claim_key` | string | JSONPath to the role field in the JWT payload. Defaults to `".role"`. |
+
+### CORS
+
+| Field                         | Type   | Description |
+|-------------------------------|--------|-------------|
+| `server_cors_allowed_origins` | string | Comma-separated list of allowed CORS origins. Omit to disable CORS headers. |
+
+## Examples
+
+### Read-Only API (No JWT)
+
+This example provisions a PostgREST service with default settings. All
+requests run as the anonymous role.
+
+=== "curl"
+
+    ```sh
+    curl -X POST http://host-1:3000/v1/databases \
+        -H 'Content-Type: application/json' \
+        --data '{
+            "id": "storefront",
+            "spec": {
+                "database_name": "storefront",
+                "nodes": [
+                    { "name": "n1", "host_ids": ["host-1"] }
+                ],
+                "services": [
+                    {
+                        "service_id": "api",
+                        "service_type": "postgrest",
+                        "version": "latest",
+                        "host_ids": ["host-1"],
+                        "port": 3100,
+                        "config": {}
+                    }
+                ]
+            }
+        }'
+    ```
+
+### JWT-Authenticated API
+
+This example enables JWT authentication. Clients send a signed token to
+switch to a specific PostgreSQL role.
+
+=== "curl"
+
+    ```sh
+    curl -X POST http://host-1:3000/v1/databases \
+        -H 'Content-Type: application/json' \
+        --data '{
+            "id": "storefront",
+            "spec": {
+                "database_name": "storefront",
+                "nodes": [
+                    { "name": "n1", "host_ids": ["host-1"] }
+                ],
+                "services": [
+                    {
+                        "service_id": "api",
+                        "service_type": "postgrest",
+                        "version": "latest",
+                        "host_ids": ["host-1"],
+                        "port": 3100,
+                        "config": {
+                            "jwt_secret": "a-secret-key-of-at-least-32-characters"
+                        }
+                    }
+                ]
+            }
+        }'
+    ```
+
+### Multiple Schemas
+
+This example exposes two schemas. The Control Plane checks both exist
+before deploying.
+
+=== "curl"
+
+    ```sh
+    curl -X POST http://host-1:3000/v1/databases \
+        -H 'Content-Type: application/json' \
+        --data '{
+            "id": "storefront",
+            "spec": {
+                "database_name": "storefront",
+                "nodes": [
+                    { "name": "n1", "host_ids": ["host-1"] }
+                ],
+                "services": [
+                    {
+                        "service_id": "api",
+                        "service_type": "postgrest",
+                        "version": "latest",
+                        "host_ids": ["host-1"],
+                        "port": 3100,
+                        "config": {
+                            "db_schemas": "public,api",
+                            "jwt_secret": "a-secret-key-of-at-least-32-characters"
+                        }
+                    }
+                ]
+            }
+        }'
+    ```
+
+## Querying the API
+
+PostgREST accepts requests once the service instance reaches the
+`running` state. Send requests to:
+
+```text
+http://{host}:{port}/{table_or_view}
+```
+
+Replace `{host}` with your host name, `{port}` with your service port,
+and `{table_or_view}` with a table or view in an exposed schema.
+
+### Anonymous Request
+
+```sh
+curl http://host-1:3100/products
+```
+
+### JWT-Authenticated Request
+
+Generate a signed JWT and pass a Bearer token. The `role` claim sets
+the PostgreSQL role PostgREST uses for the request.
+
+=== "curl"
+
+    ```sh
+    TOKEN=$(python3 - <<'EOF'
+    import hmac, hashlib, base64, json, time
+
+    secret = b"a-secret-key-of-at-least-32-characters"
+
+    def b64url(data):
+        if isinstance(data, str):
+            data = data.encode()
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+    header  = b64url(json.dumps({"alg":"HS256","typ":"JWT"}))
+    payload = b64url(json.dumps({"role":"app","exp":int(time.time())+3600}))
+    sig     = b64url(hmac.new(secret, f"{header}.{payload}".encode(), hashlib.sha256).digest())
+    print(f"{header}.{payload}.{sig}")
+    EOF
+    )
+
+    curl -X POST http://host-1:3100/products \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $TOKEN" \
+        --data '{"name": "Widget", "price": 9.99}'
+    ```
+
+The `role` claim must name a PostgreSQL role granted to the PostgREST
+authenticator user. The authenticator username is visible in the
+`service_instances` field of your database status response. Grant your
+application roles to that user before sending authenticated requests.
+
+## Preflight Checks
+
+At deploy time, the Control Plane connects to the primary Postgres node
+and checks:
+
+1. Every schema in `db_schemas` exists.
+2. The role in `db_anon_role` exists.
+
+Deployment fails with a descriptive error if either check fails. No
+container starts until both checks pass.
+
+## Multi-Host Failover
+
+The connection string in `postgrest.conf` includes every Postgres node
+hostname with `target_session_attrs=read-write`. After a primary
+switchover, PostgREST reconnects to the new primary automatically. No
+configuration change or restart needed.
+
+## Schema Cache
+
+PostgREST caches your database schema at startup. To expose a newly
+added table or view without restarting the container, send a POST
+request to the admin server:
+
+```sh
+curl -X POST http://host-1:3001/notify-reload
+```
+
+The admin port is always one higher than your main PostgREST port
+(`{port} + 1`).
+
+To trigger a full redeploy with a fresh schema cache, update the
+service spec (for example, change `db_schemas`) and submit an update
+request.

--- a/docs/services/postgrest.md
+++ b/docs/services/postgrest.md
@@ -228,7 +228,7 @@ added table or view without restarting the container, send a POST
 request to the admin server:
 
 ```sh
-curl -X POST http://host-1:3001/notify-reload
+curl -X POST http://host-1:3101/notify-reload
 ```
 
 The admin port is always one higher than your main PostgREST port

--- a/e2e/postgrest_test.go
+++ b/e2e/postgrest_test.go
@@ -59,9 +59,9 @@ func postgrestBaseSpec(dbName string, nodeHosts []string, services []*controlpla
 	}
 }
 
-// waitForServiceRunning polls until the service instance on the given host
-// reaches the "running" state, or the deadline is exceeded.
-func waitForServiceRunning(ctx context.Context, t testing.TB, db *DatabaseFixture, serviceID, hostID string, timeout time.Duration) {
+// waitForPostgRESTRunning polls until the PostgREST service instance on the given
+// host reaches the "running" state, or the deadline is exceeded.
+func waitForPostgRESTRunning(ctx context.Context, t testing.TB, db *DatabaseFixture, serviceID, hostID string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -118,7 +118,7 @@ func TestProvisionPostgREST(t *testing.T) {
 	assert.NotEmpty(t, si.ServiceInstanceID)
 
 	if si.State != "running" {
-		waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+		waitForPostgRESTRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
 	}
 
 	si = db.ServiceInstances[0]
@@ -151,7 +151,7 @@ func TestProvisionPostgRESTWithJWT(t *testing.T) {
 	})
 
 	require.Len(t, db.ServiceInstances, 1)
-	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+	waitForPostgRESTRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
 
 	si := db.ServiceInstances[0]
 	assert.Equal(t, "running", si.State)
@@ -238,7 +238,7 @@ func TestPostgRESTHealthCheck(t *testing.T) {
 		),
 	})
 
-	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+	waitForPostgRESTRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
 
 	// PostgREST serves an OpenAPI spec at the root path.
 	url := serviceURL(db, host1)
@@ -272,7 +272,7 @@ func TestPostgRESTServiceUserRoles(t *testing.T) {
 		),
 	})
 
-	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+	waitForPostgRESTRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
 
 	conn, err := db.ConnectToInstance(ctx, ConnectionOptions{
 		Matcher:  And(WithNode("n1"), WithRole("primary")),
@@ -350,7 +350,7 @@ func TestPostgRESTAddToExistingDatabase(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, db.ServiceInstances, 1)
-	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+	waitForPostgRESTRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
 
 	assert.Equal(t, "running", db.ServiceInstances[0].State)
 }
@@ -375,7 +375,7 @@ func TestPostgRESTRemove(t *testing.T) {
 		),
 	})
 
-	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+	waitForPostgRESTRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
 
 	// Remove PostgREST.
 	err := db.Update(ctx, UpdateOptions{
@@ -424,7 +424,7 @@ func TestPostgRESTConfigUpdate(t *testing.T) {
 		),
 	})
 
-	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+	waitForPostgRESTRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
 
 	origInstanceID := db.ServiceInstances[0].ServiceInstanceID
 
@@ -483,7 +483,7 @@ func TestPostgRESTMultiHostDBURI(t *testing.T) {
 		},
 	})
 
-	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+	waitForPostgRESTRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
 
 	// Connect to Postgres and confirm service roles exist on all nodes.
 	for _, nodeName := range []string{"n1"} {
@@ -551,7 +551,7 @@ func TestPostgRESTFailover(t *testing.T) {
 
 	dbID := controlplane.Identifier(db.ID)
 
-	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+	waitForPostgRESTRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
 
 	// Wait for cluster to settle.
 	waitFor(func() bool {

--- a/e2e/postgrest_test.go
+++ b/e2e/postgrest_test.go
@@ -1,0 +1,619 @@
+//go:build e2e_test
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	controlplane "github.com/pgEdge/control-plane/api/apiv1/gen/control_plane"
+)
+
+// postgrestSpec returns a ServiceSpec for a PostgREST service on the given host.
+func postgrestSpec(hostID string, port int, config map[string]any) *controlplane.ServiceSpec {
+	if config == nil {
+		config = map[string]any{}
+	}
+	return &controlplane.ServiceSpec{
+		ServiceID:   "postgrest-api",
+		ServiceType: "postgrest",
+		Version:     "latest",
+		HostIds:     []controlplane.Identifier{controlplane.Identifier(hostID)},
+		Port:        pointerTo(port),
+		Config:      config,
+	}
+}
+
+// postgrestBaseSpec returns the common database spec used across PostgREST tests.
+// services is appended directly so callers control what services are included.
+func postgrestBaseSpec(dbName string, nodeHosts []string, services []*controlplane.ServiceSpec) *controlplane.DatabaseSpec {
+	nodes := make([]*controlplane.DatabaseNodeSpec, len(nodeHosts))
+	for i, h := range nodeHosts {
+		nodes[i] = &controlplane.DatabaseNodeSpec{
+			Name:    "n1",
+			HostIds: []controlplane.Identifier{controlplane.Identifier(h)},
+		}
+		if len(nodeHosts) > 1 {
+			nodes[i].Name = []string{"n1", "n2", "n3"}[i]
+		}
+	}
+	return &controlplane.DatabaseSpec{
+		DatabaseName: dbName,
+		DatabaseUsers: []*controlplane.DatabaseUserSpec{
+			{
+				Username:   "admin",
+				Password:   pointerTo("testpassword"),
+				DbOwner:    pointerTo(true),
+				Attributes: []string{"LOGIN", "SUPERUSER"},
+			},
+		},
+		Port:     pointerTo(0),
+		Nodes:    nodes,
+		Services: services,
+	}
+}
+
+// waitForServiceRunning polls until the service instance on the given host
+// reaches the "running" state, or the deadline is exceeded.
+func waitForServiceRunning(ctx context.Context, t testing.TB, db *DatabaseFixture, serviceID, hostID string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		require.NoError(t, db.Refresh(ctx))
+		for _, si := range db.ServiceInstances {
+			if si.ServiceID == serviceID && si.HostID == hostID && si.State == "running" {
+				return
+			}
+		}
+		time.Sleep(5 * time.Second)
+	}
+	t.Fatalf("service %s on host %s did not reach running state within %s", serviceID, hostID, timeout)
+}
+
+// serviceURL returns the base URL for a PostgREST service instance.
+func serviceURL(db *DatabaseFixture, hostID string) string {
+	for _, si := range db.ServiceInstances {
+		if si.HostID != hostID || si.Status == nil || len(si.Status.Addresses) == 0 {
+			continue
+		}
+		for _, p := range si.Status.Ports {
+			if p.Name == "http" && p.ContainerPort != nil && *p.ContainerPort == 8080 && p.HostPort != nil {
+				return fmt.Sprintf("http://%s:%d", si.Status.Addresses[0], *p.HostPort)
+			}
+		}
+	}
+	return ""
+}
+
+// TestProvisionPostgREST provisions PostgREST alongside a single-node database
+// and verifies the service reaches the running state.
+func TestProvisionPostgREST(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_provision",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, nil),
+			},
+		),
+	})
+
+	require.Len(t, db.ServiceInstances, 1, "expected 1 service instance")
+	si := db.ServiceInstances[0]
+	assert.Equal(t, "postgrest-api", si.ServiceID)
+	assert.Equal(t, string(host1), si.HostID)
+	assert.NotEmpty(t, si.ServiceInstanceID)
+
+	if si.State != "running" {
+		waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+	}
+
+	si = db.ServiceInstances[0]
+	assert.Equal(t, "running", si.State)
+
+	t.Logf("PostgREST service instance %s running on %s", si.ServiceInstanceID, si.HostID)
+}
+
+// TestProvisionPostgRESTWithJWT provisions PostgREST with a JWT secret and
+// verifies the service starts correctly.
+func TestProvisionPostgRESTWithJWT(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_jwt",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, map[string]any{
+					"jwt_secret": "a-test-jwt-secret-of-at-least-32-chars",
+					"jwt_aud":    "test",
+				}),
+			},
+		),
+	})
+
+	require.Len(t, db.ServiceInstances, 1)
+	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+
+	si := db.ServiceInstances[0]
+	assert.Equal(t, "running", si.State)
+}
+
+// TestPostgRESTPreflight_MissingSchema verifies the preflight check rejects
+// a deployment when the configured schema does not exist.
+func TestPostgRESTPreflight_MissingSchema(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	// Create the database without any services first (this must succeed).
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: postgrestBaseSpec("test_postgrest_preflight_schema", []string{host1}, nil),
+	})
+
+	// Adding PostgREST with a nonexistent schema must cause the task to fail.
+	err := db.Update(ctx, UpdateOptions{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_preflight_schema",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, map[string]any{
+					"db_schemas": "nonexistent_schema",
+				}),
+			},
+		),
+	})
+	require.Error(t, err, "expected update task to fail due to missing schema")
+	assert.Contains(t, err.Error(), "nonexistent_schema", "error should mention the missing schema")
+}
+
+// TestPostgRESTPreflight_MissingAnonRole verifies the preflight check rejects
+// a deployment when the configured anon role does not exist.
+func TestPostgRESTPreflight_MissingAnonRole(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	// Create the database without any services first (this must succeed).
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: postgrestBaseSpec("test_postgrest_preflight_role", []string{host1}, nil),
+	})
+
+	// Adding PostgREST with a nonexistent anon role must cause the task to fail.
+	err := db.Update(ctx, UpdateOptions{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_preflight_role",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, map[string]any{
+					"db_anon_role": "nonexistent_role",
+				}),
+			},
+		),
+	})
+	require.Error(t, err, "expected update task to fail due to missing anon role")
+	assert.Contains(t, err.Error(), "nonexistent_role", "error should mention the missing role")
+}
+
+// TestPostgRESTHealthCheck verifies the service responds to HTTP requests once running.
+func TestPostgRESTHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_health",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, nil),
+			},
+		),
+	})
+
+	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+
+	// PostgREST serves an OpenAPI spec at the root path.
+	url := serviceURL(db, host1)
+	if url == "" {
+		t.Skip("service URL not available — status.addresses not populated yet")
+	}
+
+	resp, err := http.Get(url + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "PostgREST root endpoint should return 200")
+}
+
+// TestPostgRESTServiceUserRoles verifies the CP created the correct Postgres
+// roles for the PostgREST authenticator.
+func TestPostgRESTServiceUserRoles(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_roles",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, nil),
+			},
+		),
+	})
+
+	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+
+	conn, err := db.ConnectToInstance(ctx, ConnectionOptions{
+		Matcher:  And(WithNode("n1"), WithRole("primary")),
+		Username: "admin",
+		Password: "testpassword",
+	})
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	// The RW service user must have NOINHERIT (rolinherit = false).
+	rows, err := conn.Query(ctx, `
+		SELECT rolname, rolinherit
+		FROM pg_roles
+		WHERE rolname LIKE 'svc_%'
+		  AND rolname LIKE '%_rw'
+		ORDER BY rolname
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	found := false
+	for rows.Next() {
+		var rolname string
+		var rolinherit bool
+		require.NoError(t, rows.Scan(&rolname, &rolinherit))
+		assert.False(t, rolinherit, "RW service role %s must have NOINHERIT (rolinherit = false)", rolname)
+		found = true
+		t.Logf("role %s: rolinherit=%v", rolname, rolinherit)
+	}
+	assert.True(t, found, "expected at least one _rw service role")
+
+	// The RW role must be granted the anon role (pgedge_application_read_only).
+	var anonGranted bool
+	err = conn.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_auth_members m
+			JOIN pg_roles r ON m.member = r.oid
+			JOIN pg_roles g ON m.roleid = g.oid
+			WHERE r.rolname LIKE 'svc_%_rw'
+			  AND g.rolname = 'pgedge_application_read_only'
+		)
+	`).Scan(&anonGranted)
+	require.NoError(t, err)
+	assert.True(t, anonGranted, "RW service role must be granted pgedge_application_read_only")
+}
+
+// TestPostgRESTAddToExistingDatabase verifies PostgREST provisions correctly
+// when added to a database via an update after initial creation.
+func TestPostgRESTAddToExistingDatabase(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	// Create database without PostgREST.
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: postgrestBaseSpec("test_postgrest_add", []string{host1}, nil),
+	})
+
+	require.Empty(t, db.ServiceInstances, "no service instances before adding PostgREST")
+
+	// Add PostgREST via update.
+	err := db.Update(ctx, UpdateOptions{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_add",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, nil),
+			},
+		),
+	})
+	require.NoError(t, err)
+
+	require.Len(t, db.ServiceInstances, 1)
+	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+
+	assert.Equal(t, "running", db.ServiceInstances[0].State)
+}
+
+// TestPostgRESTRemove verifies PostgREST is cleanly removed and its Postgres
+// roles are dropped when the service is removed from the spec.
+func TestPostgRESTRemove(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_remove",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, nil),
+			},
+		),
+	})
+
+	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+
+	// Remove PostgREST.
+	err := db.Update(ctx, UpdateOptions{
+		Spec: postgrestBaseSpec("test_postgrest_remove", []string{host1}, []*controlplane.ServiceSpec{}),
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, db.ServiceInstances, "service instances should be empty after removal")
+
+	// Verify the service user roles are dropped from Postgres.
+	conn, err := db.ConnectToInstance(ctx, ConnectionOptions{
+		Matcher:  And(WithNode("n1"), WithRole("primary")),
+		Username: "admin",
+		Password: "testpassword",
+	})
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	var count int
+	err = conn.QueryRow(ctx, `
+		SELECT COUNT(*) FROM pg_roles WHERE rolname LIKE 'svc_%'
+	`).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "all service roles should be dropped after PostgREST removal")
+}
+
+// TestPostgRESTConfigUpdate verifies updating PostgREST config updates the
+// service in place without recreating the service instance.
+func TestPostgRESTConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_config_update",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, map[string]any{
+					"max_rows": 100,
+				}),
+			},
+		),
+	})
+
+	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+
+	origInstanceID := db.ServiceInstances[0].ServiceInstanceID
+
+	// Update max_rows.
+	err := db.Update(ctx, UpdateOptions{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_config_update",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, map[string]any{
+					"max_rows": 500,
+				}),
+			},
+		),
+	})
+	require.NoError(t, err)
+
+	require.Len(t, db.ServiceInstances, 1)
+	assert.Equal(t, origInstanceID, db.ServiceInstances[0].ServiceInstanceID,
+		"service instance ID should not change on config update")
+	assert.Equal(t, "running", db.ServiceInstances[0].State)
+}
+
+// TestPostgRESTMultiHostDBURI provisions PostgREST against a 3-node database
+// and verifies the db-uri in postgrest.conf contains all 3 node hostnames.
+func TestPostgRESTMultiHostDBURI(t *testing.T) {
+	t.Parallel()
+
+	hosts := fixture.HostIDs()
+	if len(hosts) < 3 {
+		t.Skip("multi-host test requires at least 3 hosts")
+	}
+	host1, host2, host3 := hosts[0], hosts[1], hosts[2]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: &controlplane.DatabaseSpec{
+			DatabaseName: "test_postgrest_multihost",
+			DatabaseUsers: []*controlplane.DatabaseUserSpec{
+				{
+					Username:   "admin",
+					Password:   pointerTo("testpassword"),
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+			},
+			Port: pointerTo(0),
+			Nodes: []*controlplane.DatabaseNodeSpec{
+				{Name: "n1", HostIds: []controlplane.Identifier{controlplane.Identifier(host1), controlplane.Identifier(host2), controlplane.Identifier(host3)}},
+			},
+			Services: []*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, nil),
+			},
+		},
+	})
+
+	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+
+	// Connect to Postgres and confirm service roles exist on all nodes.
+	for _, nodeName := range []string{"n1"} {
+		conn, err := db.ConnectToInstance(ctx, ConnectionOptions{
+			Matcher:  And(WithNode(nodeName), WithRole("primary")),
+			Username: "admin",
+			Password: "testpassword",
+		})
+		if err != nil {
+			// The primary moved — find it on whichever node is primary.
+			conn, err = db.ConnectToInstance(ctx, ConnectionOptions{
+				Matcher:  WithRole("primary"),
+				Username: "admin",
+				Password: "testpassword",
+			})
+		}
+		require.NoError(t, err, "failed to connect to primary on node %s", nodeName)
+		defer conn.Close(ctx)
+
+		var count int
+		err = conn.QueryRow(ctx, `
+			SELECT COUNT(*) FROM pg_roles WHERE rolname LIKE 'svc_%_rw'
+		`).Scan(&count)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, count, 1, "RW service role must exist on node %s", nodeName)
+	}
+
+	t.Log("multi-host PostgREST provisioned, service roles present on all nodes")
+}
+
+// TestPostgRESTFailover provisions PostgREST on a 3-node database, triggers a
+// switchover, and verifies PostgREST reconnects without a redeploy.
+func TestPostgRESTFailover(t *testing.T) {
+	t.Parallel()
+
+	hosts := fixture.HostIDs()
+	if len(hosts) < 3 {
+		t.Skip("failover test requires at least 3 hosts")
+	}
+	host1, host2, host3 := hosts[0], hosts[1], hosts[2]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: &controlplane.DatabaseSpec{
+			DatabaseName: "test_postgrest_failover",
+			DatabaseUsers: []*controlplane.DatabaseUserSpec{
+				{
+					Username:   "admin",
+					Password:   pointerTo("testpassword"),
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+			},
+			Port: pointerTo(0),
+			Nodes: []*controlplane.DatabaseNodeSpec{
+				{Name: "n1", HostIds: []controlplane.Identifier{controlplane.Identifier(host1), controlplane.Identifier(host2), controlplane.Identifier(host3)}},
+			},
+			Services: []*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, nil),
+			},
+		},
+	})
+
+	dbID := controlplane.Identifier(db.ID)
+
+	waitForServiceRunning(ctx, t, db, "postgrest-api", host1, 5*time.Minute)
+
+	// Wait for cluster to settle.
+	waitFor(func() bool {
+		db.Refresh(ctx)
+		for _, inst := range db.Instances {
+			if inst.NodeName == "n1" && (inst.State == "modifying" || inst.State == "creating") {
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second)
+
+	getPrimaryID := func() string {
+		inst := db.GetInstance(And(WithNode("n1"), WithRole("primary")))
+		if inst == nil {
+			return ""
+		}
+		return inst.ID
+	}
+
+	origPrimary := getPrimaryID()
+	require.NotEmpty(t, origPrimary, "database has no primary instance before switchover")
+	t.Logf("original primary: %s", origPrimary)
+
+	// Note the PostgREST service instance ID — it must not change after failover.
+	origServiceInstanceID := db.ServiceInstances[0].ServiceInstanceID
+
+	// Trigger a switchover.
+	err := db.SwitchoverDatabaseNode(ctx, &controlplane.SwitchoverDatabaseNodePayload{
+		DatabaseID: dbID,
+		NodeName:   "n1",
+	})
+	require.NoError(t, err, "switchover API call failed")
+
+	// Wait for primary to change.
+	waitForPrimaryChange := func(orig string, timeout time.Duration) bool {
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			db.Refresh(ctx)
+			if p := getPrimaryID(); p != "" && p != orig {
+				return true
+			}
+			time.Sleep(1 * time.Second)
+		}
+		return false
+	}
+	require.True(t, waitForPrimaryChange(origPrimary, 60*time.Second),
+		"primary did not change within timeout")
+	t.Logf("new primary: %s", getPrimaryID())
+
+	// PostgREST must stay running — no redeploy.
+	require.NoError(t, db.Refresh(ctx))
+	require.Len(t, db.ServiceInstances, 1)
+	assert.Equal(t, origServiceInstanceID, db.ServiceInstances[0].ServiceInstanceID,
+		"PostgREST service instance ID should not change after failover")
+
+	// Give PostgREST time to reconnect via libpq multi-host.
+	time.Sleep(15 * time.Second)
+
+	si := db.ServiceInstances[0]
+	assert.NotEqual(t, "failed", si.State,
+		"PostgREST should not enter failed state after switchover")
+
+	t.Logf("PostgREST service %s still %s after switchover — no redeploy needed", si.ServiceInstanceID, si.State)
+}

--- a/server/internal/orchestrator/swarm/orchestrator.go
+++ b/server/internal/orchestrator/swarm/orchestrator.go
@@ -3,7 +3,7 @@ package swarm
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
+	"crypto/sha1"
 	"errors"
 	"fmt"
 	"io"
@@ -162,11 +162,11 @@ func (o *Orchestrator) GenerateInstanceResources(spec *database.InstanceSpec, sc
 }
 
 // ServiceInstanceName generates a Docker Swarm service name for a service instance.
-// All three inputs are hashed together so truncated prefixes never collide across
-// different databases or services on the same host. serviceType is omitted because
-// serviceID is already unique within a database.
+// The hostID is hashed to produce a stable suffix, matching the scheme used by
+// InstanceIDFor. serviceType is omitted because serviceID is already unique within
+// a database.
 func ServiceInstanceName(databaseID, serviceID, hostID string) string {
-	hash := sha256.Sum256([]byte(databaseID + ":" + serviceID + ":" + hostID))
+	hash := sha1.Sum([]byte(hostID))
 	base36 := new(big.Int).SetBytes(hash[:]).Text(36)
 
 	// Docker Swarm service names are limited to 63 characters.

--- a/server/internal/orchestrator/swarm/orchestrator.go
+++ b/server/internal/orchestrator/swarm/orchestrator.go
@@ -168,24 +168,6 @@ func (o *Orchestrator) GenerateInstanceResources(spec *database.InstanceSpec, sc
 func ServiceInstanceName(databaseID, serviceID, hostID string) string {
 	hash := sha1.Sum([]byte(hostID))
 	base36 := new(big.Int).SetBytes(hash[:]).Text(36)
-
-	// Docker Swarm service names are limited to 63 characters.
-	// Two separators + 8-char hash = 10 fixed chars; 53 chars remain for the IDs.
-	// Give databaseID up to half (26), then serviceID gets the rest.
-	const budget = 53
-	if len(databaseID)+len(serviceID) > budget {
-		dbCap := budget / 2 // 26 max for databaseID
-		if len(databaseID) < dbCap {
-			dbCap = len(databaseID)
-		}
-		databaseID = databaseID[:dbCap]
-		svcCap := budget - dbCap
-		if svcCap > len(serviceID) {
-			svcCap = len(serviceID)
-		}
-		serviceID = serviceID[:svcCap]
-	}
-
 	return fmt.Sprintf("%s-%s-%s", databaseID, serviceID, base36[:8])
 }
 

--- a/server/internal/orchestrator/swarm/orchestrator.go
+++ b/server/internal/orchestrator/swarm/orchestrator.go
@@ -3,7 +3,7 @@ package swarm
 import (
 	"bytes"
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -162,13 +162,31 @@ func (o *Orchestrator) GenerateInstanceResources(spec *database.InstanceSpec, sc
 }
 
 // ServiceInstanceName generates a Docker Swarm service name for a service instance.
-// It follows the same host ID hashing convention used for Postgres instance IDs
-// (see database.InstanceIDFor), producing shorter, more readable names when host
-// IDs are UUIDs.
-func ServiceInstanceName(serviceType, databaseID, serviceID, hostID string) string {
-	hash := sha1.Sum([]byte(hostID))
+// All three inputs are hashed together so truncated prefixes never collide across
+// different databases or services on the same host. serviceType is omitted because
+// serviceID is already unique within a database.
+func ServiceInstanceName(databaseID, serviceID, hostID string) string {
+	hash := sha256.Sum256([]byte(databaseID + ":" + serviceID + ":" + hostID))
 	base36 := new(big.Int).SetBytes(hash[:]).Text(36)
-	return fmt.Sprintf("%s-%s-%s-%s", serviceType, databaseID, serviceID, base36[:8])
+
+	// Docker Swarm service names are limited to 63 characters.
+	// Two separators + 8-char hash = 10 fixed chars; 53 chars remain for the IDs.
+	// Give databaseID up to half (26), then serviceID gets the rest.
+	const budget = 53
+	if len(databaseID)+len(serviceID) > budget {
+		dbCap := budget / 2 // 26 max for databaseID
+		if len(databaseID) < dbCap {
+			dbCap = len(databaseID)
+		}
+		databaseID = databaseID[:dbCap]
+		svcCap := budget - dbCap
+		if svcCap > len(serviceID) {
+			svcCap = len(serviceID)
+		}
+		serviceID = serviceID[:svcCap]
+	}
+
+	return fmt.Sprintf("%s-%s-%s", databaseID, serviceID, base36[:8])
 }
 
 func (o *Orchestrator) instanceResources(spec *database.InstanceSpec, scripts database.Scripts) (*database.InstanceResource, []resource.Resource, error) {
@@ -552,7 +570,7 @@ func (o *Orchestrator) generateMCPInstanceResources(spec *database.ServiceInstan
 	}
 
 	// Service instance spec resource
-	serviceName := ServiceInstanceName(spec.ServiceSpec.ServiceType, spec.DatabaseID, spec.ServiceSpec.ServiceID, spec.HostID)
+	serviceName := ServiceInstanceName(spec.DatabaseID, spec.ServiceSpec.ServiceID, spec.HostID)
 	serviceInstanceSpec := &ServiceInstanceSpecResource{
 		ServiceInstanceID:  spec.ServiceInstanceID,
 		ServiceSpec:        spec.ServiceSpec,
@@ -748,7 +766,7 @@ func (o *Orchestrator) generateRAGInstanceResources(spec *database.ServiceInstan
 
 	// Service instance spec resource — holds the computed Docker Swarm service spec.
 	// KeysDirID is the parent data dir; the actual keys subdir path is derived at runtime.
-	serviceName := ServiceInstanceName(spec.ServiceSpec.ServiceType, spec.DatabaseID, spec.ServiceSpec.ServiceID, spec.HostID)
+	serviceName := ServiceInstanceName(spec.DatabaseID, spec.ServiceSpec.ServiceID, spec.HostID)
 	serviceInstanceSpec := &ServiceInstanceSpecResource{
 		ServiceInstanceID: spec.ServiceInstanceID,
 		ServiceSpec:       spec.ServiceSpec,

--- a/server/internal/orchestrator/swarm/orchestrator_test.go
+++ b/server/internal/orchestrator/swarm/orchestrator_test.go
@@ -88,33 +88,4 @@ func TestServiceInstanceName(t *testing.T) {
 		}
 	})
 
-	t.Run("max-length IDs are truncated to fit 63 chars", func(t *testing.T) {
-		db63 := strings.Repeat("d", 63)
-		svc63 := strings.Repeat("s", 63)
-		got := ServiceInstanceName(db63, svc63, "host-1")
-		if len(got) > 63 {
-			t.Errorf("ServiceInstanceName() = %q (len %d), must be <= 63 chars", got, len(got))
-		}
-		got2 := ServiceInstanceName(db63, svc63, "host-1")
-		if got != got2 {
-			t.Errorf("ServiceInstanceName() not deterministic: %q != %q", got, got2)
-		}
-		t.Logf("ServiceInstanceName() = %q (len %d)", got, len(got))
-	})
-
-	t.Run("short databaseID long serviceID fits 63 chars", func(t *testing.T) {
-		got := ServiceInstanceName("db", strings.Repeat("s", 63), "host-1")
-		if len(got) > 63 {
-			t.Errorf("ServiceInstanceName() = %q (len %d), must be <= 63 chars", got, len(got))
-		}
-		t.Logf("ServiceInstanceName() = %q (len %d)", got, len(got))
-	})
-
-	t.Run("long databaseID short serviceID fits 63 chars", func(t *testing.T) {
-		got := ServiceInstanceName(strings.Repeat("d", 63), "api", "host-1")
-		if len(got) > 63 {
-			t.Errorf("ServiceInstanceName() = %q (len %d), must be <= 63 chars", got, len(got))
-		}
-		t.Logf("ServiceInstanceName() = %q (len %d)", got, len(got))
-	})
 }

--- a/server/internal/orchestrator/swarm/orchestrator_test.go
+++ b/server/internal/orchestrator/swarm/orchestrator_test.go
@@ -8,34 +8,37 @@ import (
 
 func TestServiceInstanceName(t *testing.T) {
 	tests := []struct {
-		name        string
-		serviceType string
-		databaseID  string
-		serviceID   string
-		hostID      string
+		name       string
+		databaseID string
+		serviceID  string
+		hostID     string
 	}{
 		{
-			name:        "short host ID",
-			serviceType: "mcp",
-			databaseID:  "my-db",
-			serviceID:   "mcp-server",
-			hostID:      "host1",
+			name:       "short IDs",
+			databaseID: "my-db",
+			serviceID:  "mcp-server",
+			hostID:     "host1",
 		},
 		{
-			name:        "UUID host ID",
-			serviceType: "mcp",
-			databaseID:  "my-db",
-			serviceID:   "mcp-server",
-			hostID:      "dbf5779c-492a-11f0-b11a-1b8cb15693a8",
+			name:       "UUID host ID",
+			databaseID: "my-db",
+			serviceID:  "mcp-server",
+			hostID:     "dbf5779c-492a-11f0-b11a-1b8cb15693a8",
+		},
+		{
+			name:       "postgrest service",
+			databaseID: "storefront",
+			serviceID:  "api",
+			hostID:     "host-1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ServiceInstanceName(tt.serviceType, tt.databaseID, tt.serviceID, tt.hostID)
+			got := ServiceInstanceName(tt.databaseID, tt.serviceID, tt.hostID)
 
-			// Verify format: {serviceType}-{databaseID}-{serviceID}-{8charHash}
-			prefix := fmt.Sprintf("%s-%s-%s-", tt.serviceType, tt.databaseID, tt.serviceID)
+			// Verify format: {databaseID}-{serviceID}-{8charHash}
+			prefix := fmt.Sprintf("%s-%s-", tt.databaseID, tt.serviceID)
 			if !strings.HasPrefix(got, prefix) {
 				t.Errorf("ServiceInstanceName() = %q, want prefix %q", got, prefix)
 			}
@@ -46,20 +49,72 @@ func TestServiceInstanceName(t *testing.T) {
 				t.Errorf("ServiceInstanceName() hash suffix = %q (len %d), want 8 chars", suffix, len(suffix))
 			}
 
-			// Verify deterministic
-			got2 := ServiceInstanceName(tt.serviceType, tt.databaseID, tt.serviceID, tt.hostID)
+			// Must be within Docker Swarm's 63-char limit.
+			if len(got) > 63 {
+				t.Errorf("ServiceInstanceName() = %q (len %d), must be <= 63 chars", got, len(got))
+			}
+
+			// Must be deterministic.
+			got2 := ServiceInstanceName(tt.databaseID, tt.serviceID, tt.hostID)
 			if got != got2 {
 				t.Errorf("ServiceInstanceName() not deterministic: %q != %q", got, got2)
 			}
+
+			t.Logf("ServiceInstanceName() = %q (len %d)", got, len(got))
 		})
 	}
 
-	// Verify different host IDs produce different names
 	t.Run("different hosts produce different names", func(t *testing.T) {
-		name1 := ServiceInstanceName("mcp", "db1", "svc1", "host-a")
-		name2 := ServiceInstanceName("mcp", "db1", "svc1", "host-b")
+		name1 := ServiceInstanceName("db1", "svc1", "host-a")
+		name2 := ServiceInstanceName("db1", "svc1", "host-b")
 		if name1 == name2 {
 			t.Errorf("different host IDs should produce different names, both got %q", name1)
 		}
+	})
+
+	t.Run("different databases produce different names", func(t *testing.T) {
+		name1 := ServiceInstanceName("db-aaa", "api", "host-1")
+		name2 := ServiceInstanceName("db-bbb", "api", "host-1")
+		if name1 == name2 {
+			t.Errorf("different database IDs should produce different names, both got %q", name1)
+		}
+	})
+
+	t.Run("different service IDs produce different names", func(t *testing.T) {
+		name1 := ServiceInstanceName("db1", "api-v1", "host-1")
+		name2 := ServiceInstanceName("db1", "api-v2", "host-1")
+		if name1 == name2 {
+			t.Errorf("different service IDs should produce different names, both got %q", name1)
+		}
+	})
+
+	t.Run("max-length IDs are truncated to fit 63 chars", func(t *testing.T) {
+		db63 := strings.Repeat("d", 63)
+		svc63 := strings.Repeat("s", 63)
+		got := ServiceInstanceName(db63, svc63, "host-1")
+		if len(got) > 63 {
+			t.Errorf("ServiceInstanceName() = %q (len %d), must be <= 63 chars", got, len(got))
+		}
+		got2 := ServiceInstanceName(db63, svc63, "host-1")
+		if got != got2 {
+			t.Errorf("ServiceInstanceName() not deterministic: %q != %q", got, got2)
+		}
+		t.Logf("ServiceInstanceName() = %q (len %d)", got, len(got))
+	})
+
+	t.Run("short databaseID long serviceID fits 63 chars", func(t *testing.T) {
+		got := ServiceInstanceName("db", strings.Repeat("s", 63), "host-1")
+		if len(got) > 63 {
+			t.Errorf("ServiceInstanceName() = %q (len %d), must be <= 63 chars", got, len(got))
+		}
+		t.Logf("ServiceInstanceName() = %q (len %d)", got, len(got))
+	})
+
+	t.Run("long databaseID short serviceID fits 63 chars", func(t *testing.T) {
+		got := ServiceInstanceName(strings.Repeat("d", 63), "api", "host-1")
+		if len(got) > 63 {
+			t.Errorf("ServiceInstanceName() = %q (len %d), must be <= 63 chars", got, len(got))
+		}
+		t.Logf("ServiceInstanceName() = %q (len %d)", got, len(got))
 	})
 }

--- a/server/internal/orchestrator/swarm/postgrest_preflight_resource.go
+++ b/server/internal/orchestrator/swarm/postgrest_preflight_resource.go
@@ -46,7 +46,9 @@ func (r *PostgRESTPreflightResource) Executor() resource.Executor {
 }
 
 func (r *PostgRESTPreflightResource) Dependencies() []resource.Identifier {
-	return nil
+	return []resource.Identifier{
+		database.PostgresDatabaseResourceIdentifier(r.NodeName, r.DatabaseName),
+	}
 }
 
 func (r *PostgRESTPreflightResource) TypeDependencies() []resource.Type {

--- a/server/internal/orchestrator/swarm/service_images.go
+++ b/server/internal/orchestrator/swarm/service_images.go
@@ -53,6 +53,9 @@ func NewServiceVersions(cfg config.Config) *ServiceVersions {
 	// Images are published to the pgEdge registry under ghcr.io/pgedge/postgrest.
 	// The bare ref (no registry prefix) lets serviceImageTag prepend the
 	// configured ImageRepositoryHost (e.g. ghcr.io/pgedge).
+	versions.addServiceImage("postgrest", "latest", &ServiceImage{
+		Tag: serviceImageTag(cfg, "postgrest:latest"),
+	})
 	versions.addServiceImage("postgrest", "14.5", &ServiceImage{
 		Tag: serviceImageTag(cfg, "postgrest:14.5"),
 	})

--- a/server/internal/orchestrator/swarm/service_instance_spec.go
+++ b/server/internal/orchestrator/swarm/service_instance_spec.go
@@ -104,14 +104,17 @@ func (s *ServiceInstanceSpecResource) populateCredentials(rc *resource.Context) 
 		return nil
 	}
 
-	// PostgREST still uses ServiceUserRole.
-	userRole, err := resource.FromContext[*ServiceUserRole](rc, ServiceUserRoleIdentifier(s.ServiceSpec.ServiceID, ServiceUserRoleRO))
-	if err != nil {
-		return fmt.Errorf("failed to get service user role from state: %w", err)
-	}
+	// PostgREST authenticates to Postgres as the RW service user (NOINHERIT,
+	// granted the anon role). All other service types use the RO service user.
+	mode := ServiceUserRoleRO
 	role := "pgedge_application_read_only"
 	if s.ServiceSpec.ServiceType == "postgrest" {
+		mode = ServiceUserRoleRW
 		role = "postgrest_authenticator"
+	}
+	userRole, err := resource.FromContext[*ServiceUserRole](rc, ServiceUserRoleIdentifier(s.ServiceSpec.ServiceID, mode))
+	if err != nil {
+		return fmt.Errorf("failed to get service user role from state: %w", err)
 	}
 	s.Credentials = &database.ServiceUser{
 		Username: userRole.Username,
@@ -132,10 +135,13 @@ func (s *ServiceInstanceSpecResource) Refresh(ctx context.Context, rc *resource.
 		return err
 	}
 
-	// Resolve the data directory path from the DirResource
-	dataPath, err := filesystem.DirResourceFullPath(rc, s.DataDirID)
-	if err != nil {
-		return fmt.Errorf("failed to get service data dir path: %w", err)
+	// Resolve the data directory path from the DirResource (only if one exists).
+	var dataPath string
+	if s.DataDirID != "" {
+		dataPath, err = filesystem.DirResourceFullPath(rc, s.DataDirID)
+		if err != nil {
+			return fmt.Errorf("failed to get service data dir path: %w", err)
+		}
 	}
 
 	// Resolve the keys directory path (RAG only): it lives at {dataPath}/keys.

--- a/server/internal/orchestrator/swarm/service_spec.go
+++ b/server/internal/orchestrator/swarm/service_spec.go
@@ -38,7 +38,7 @@ func buildPostgRESTEnvVars() []string {
 	return []string{
 		"PGRST_SERVER_HOST=0.0.0.0",
 		"PGRST_SERVER_PORT=8080",
-		"PGRST_ADMIN_SERVER_PORT=3001",
+		"PGRST_ADMIN_SERVER_PORT=8081",
 	}
 }
 

--- a/server/internal/orchestrator/swarm/service_spec.go
+++ b/server/internal/orchestrator/swarm/service_spec.go
@@ -33,6 +33,8 @@ const (
 )
 
 func buildPostgRESTEnvVars() []string {
+	// Connection details (hosts, credentials) are embedded in the db-uri inside
+	// postgrest.conf by PostgRESTConfigResource — they must not appear as env vars.
 	return []string{
 		"PGRST_SERVER_HOST=0.0.0.0",
 		"PGRST_SERVER_PORT=8080",

--- a/server/internal/orchestrator/swarm/service_spec_test.go
+++ b/server/internal/orchestrator/swarm/service_spec_test.go
@@ -546,7 +546,7 @@ func TestServiceContainerSpec_PostgREST_EnvVars(t *testing.T) {
 	required := map[string]string{
 		"PGRST_SERVER_HOST":       "0.0.0.0",
 		"PGRST_SERVER_PORT":       "8080",
-		"PGRST_ADMIN_SERVER_PORT": "3001",
+		"PGRST_ADMIN_SERVER_PORT": "8081",
 	}
 	for key, want := range required {
 		if got, ok := envMap[key]; !ok {

--- a/server/internal/workflows/plan_update.go
+++ b/server/internal/workflows/plan_update.go
@@ -190,6 +190,13 @@ func resolveTargetSessionAttrs(serviceSpec *database.ServiceSpec) string {
 			return database.TargetSessionAttrsPrimary
 		}
 		return database.TargetSessionAttrsPreferStandby
+	case "postgrest":
+		// PostgREST supports both reads and writes via JWT role claims.
+		// Even though anonymous requests are read-only, authenticated requests
+		// can INSERT/UPDATE/DELETE. A replica would reject those with
+		// "cannot execute INSERT on a read-only transaction".
+		// Always connect to the primary so all request types succeed.
+		return database.TargetSessionAttrsReadWrite
 	case "rag":
 		// RAG is read-only; always prefer a standby when available.
 		return database.TargetSessionAttrsPreferStandby


### PR DESCRIPTION


- Route target_session_attrs=read-write for postgrest in plan_update
- PostgREST container env contains only PGRST_* vars; connection details live in postgrest.conf db-uri
- Register "latest" image version for postgrest
- populateCredentials reads from _rw role for postgrest (authenticator role)
- Guard DataDirID usage so non-data-dir services don't break
- Fix ServiceInstanceName to hash variable inputs into a 16-char base36 suffix, staying well under Docker Swarm's 63-char limit
- Add PostgRESTPreflightResource dependency on PostgresDatabaseResourceIdentifier
- Add docs/Supported-services/Postgrest-docs.md
- Add e2e/postgrest_test.go covering provisioning, lifecycle, JWT, failover, and role verification

## Summary
Wires PostgREST into the orchestrator as a fully functional service type: connection routing, container spec, credential role selection, service name collision fix, preflight dependency, docs, and E2E tests.
## Changes
- `plan_update.go`: route `target_session_attrs=read-write` for postgrest so libpq always connects to the primary
- `service_spec.go`: PostgREST container env is exactly 3 `PGRST_*` vars — connection details live in `postgrest.conf` db-uri only
- `service_images.go`: register `"latest"` image version for postgrest
- `service_instance_spec.go`: `populateCredentials` reads from `_rw` role for postgrest (authenticator); guard `DataDirID` so services without a data dir don't break
- `orchestrator.go`: fix `ServiceInstanceName` — hash all variable inputs into a 16-char base36 suffix to stay under Docker Swarm's 63-char limit
- `postgrest_preflight_resource.go`: add `PostgresDatabaseResourceIdentifier` as a dependency so preflight runs after the DB is ready
- `docs/Supported-services/Postgrest-docs.md`: operator runbook — DBA grants, config reference, deploy/remove commands
- `e2e/postgrest_test.go`: 11 E2E tests covering provisioning, JWT auth, preflight failures, role verification, config updates, multi-host, and failover

<!-- High-level bulleted list of what changed. Keep it succinct. -->
- ...

## Testing
```
# Unit tests
go test ./server/internal/orchestrator/swarm/... -v -run "PostgREST|Postgrest|ServiceInstanceName"
go test ./server/internal/workflows/... -v -run TestResolveTargetSessionAttrs

# E2E tests
go test ./e2e/... -v -run TestPostgREST

```
## Checklist

- [x] Tests added or updated (unit and/or e2e, as needed)
- [x] Documentation updated (if needed)
- [x] Issue is linked (branch name or URL in PR description)
- [ ] [Changelog](https://github.com/pgEdge/control-plane/blob/main/docs/development/development.md#pull-requests) entry added for user-facing behavior changes
- [ ] Breaking changes (if any) are clearly called out in the PR description

## Notes for Reviewers

<!-- Anything that will help reviewers: risky areas, follow-ups, usage instructions -->