### PR TITLE
fix: add allowlist validation for RAG pipeline names

### DIFF
--- a/server/internal/database/rag_service_config.go
+++ b/server/internal/database/rag_service_config.go
@@ -13,11 +13,12 @@ import (
 // ragPipelineNamePatternText is the allowlist pattern for RAG pipeline names.
 // It is kept as a const so that the compiled regexp and the error message both
 // reference the same literal and cannot drift apart.
-const ragPipelineNamePatternText = `^[a-z0-9_-]+$`
+const ragPipelineNamePatternText = `^[a-z0-9_][a-z0-9_-]*$`
 
 // ragPipelineNamePattern restricts pipeline names to lowercase alphanumeric
-// characters, hyphens, and underscores. This keeps key filenames
-// ({name}_embedding.key / {name}_rag.key) safe and auditable.
+// characters, hyphens, and underscores. The first character must not be a
+// hyphen so that names are safe as filename components and cannot be
+// misinterpreted as CLI flags if ever passed to a command.
 var ragPipelineNamePattern = regexp.MustCompile(ragPipelineNamePatternText)
 
 // RAGPipelineLLMConfig represents LLM configuration for an embedding or RAG step.

--- a/server/internal/database/rag_service_config.go
+++ b/server/internal/database/rag_service_config.go
@@ -10,10 +10,15 @@ import (
 	"strings"
 )
 
+// ragPipelineNamePatternText is the allowlist pattern for RAG pipeline names.
+// It is kept as a const so that the compiled regexp and the error message both
+// reference the same literal and cannot drift apart.
+const ragPipelineNamePatternText = `^[a-z0-9_-]+$`
+
 // ragPipelineNamePattern restricts pipeline names to lowercase alphanumeric
 // characters, hyphens, and underscores. This keeps key filenames
 // ({name}_embedding.key / {name}_rag.key) safe and auditable.
-var ragPipelineNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
+var ragPipelineNamePattern = regexp.MustCompile(ragPipelineNamePatternText)
 
 // RAGPipelineLLMConfig represents LLM configuration for an embedding or RAG step.
 type RAGPipelineLLMConfig struct {
@@ -136,7 +141,7 @@ func validateRAGPipeline(p RAGPipeline, i int, seenNames map[string]bool) []erro
 	if p.Name == "" {
 		errs = append(errs, fmt.Errorf("%s.name is required", prefix))
 	} else if !ragPipelineNamePattern.MatchString(p.Name) {
-		errs = append(errs, fmt.Errorf("%s.name %q is invalid: must match ^[a-z0-9_-]+$", prefix, p.Name))
+		errs = append(errs, fmt.Errorf("%s.name %q is invalid: must match %s", prefix, p.Name, ragPipelineNamePatternText))
 	} else if seenNames[p.Name] {
 		errs = append(errs, fmt.Errorf("pipelines contains duplicate name %q", p.Name))
 	} else {

--- a/server/internal/database/rag_service_config.go
+++ b/server/internal/database/rag_service_config.go
@@ -4,10 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
 )
+
+// ragPipelineNamePattern restricts pipeline names to lowercase alphanumeric
+// characters, hyphens, and underscores. This keeps key filenames
+// ({name}_embedding.key / {name}_rag.key) safe and auditable.
+var ragPipelineNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
 // RAGPipelineLLMConfig represents LLM configuration for an embedding or RAG step.
 type RAGPipelineLLMConfig struct {
@@ -126,9 +132,11 @@ func validateRAGPipeline(p RAGPipeline, i int, seenNames map[string]bool) []erro
 	var errs []error
 	prefix := fmt.Sprintf("pipelines[%d]", i)
 
-	// name (required, unique)
+	// name (required, allowlist, unique)
 	if p.Name == "" {
 		errs = append(errs, fmt.Errorf("%s.name is required", prefix))
+	} else if !ragPipelineNamePattern.MatchString(p.Name) {
+		errs = append(errs, fmt.Errorf("%s.name %q is invalid: must match ^[a-z0-9_-]+$", prefix, p.Name))
 	} else if seenNames[p.Name] {
 		errs = append(errs, fmt.Errorf("pipelines contains duplicate name %q", p.Name))
 	} else {

--- a/server/internal/database/rag_service_config_test.go
+++ b/server/internal/database/rag_service_config_test.go
@@ -384,6 +384,49 @@ func TestParseRAGServiceConfig_MissingRAGLLM(t *testing.T) {
 	assert.Contains(t, errs[0].Error(), "rag_llm.provider")
 }
 
+func TestParseRAGServiceConfig_PipelineNameAllowlist(t *testing.T) {
+	validNames := []string{
+		"default",
+		"my-pipeline",
+		"my_pipeline",
+		"pipeline-1",
+		"a",
+		"abc123",
+		"a-b_c-1",
+	}
+	for _, name := range validNames {
+		t.Run("valid/"+name, func(t *testing.T) {
+			config := minimalRAGConfig()
+			config["pipelines"].([]any)[0].(map[string]any)["name"] = name
+			_, errs := database.ParseRAGServiceConfig(config, false)
+			assert.Empty(t, errs, "name %q should be valid", name)
+		})
+	}
+
+	invalidNames := []string{
+		"My Pipeline",          // uppercase + space
+		"pipeline name",        // space
+		"pipeline/name",        // slash
+		"../etc/passwd",        // path traversal
+		"UPPER",                // uppercase
+		"pipe🔥line",           // unicode emoji
+		"pipeline.name",        // dot
+		"",                     // empty (covered separately, but included for completeness)
+	}
+	for _, name := range invalidNames {
+		if name == "" {
+			continue // empty name is a separate "required" error
+		}
+		t.Run("invalid/"+name, func(t *testing.T) {
+			config := minimalRAGConfig()
+			config["pipelines"].([]any)[0].(map[string]any)["name"] = name
+			_, errs := database.ParseRAGServiceConfig(config, false)
+			require.NotEmpty(t, errs, "name %q should be invalid", name)
+			assert.Contains(t, errs[0].Error(), "must match ^[a-z0-9_-]+$")
+		})
+	}
+}
+
 func TestParseRAGServiceConfig_MultiplePipelines(t *testing.T) {
 	config := map[string]any{
 		"pipelines": []any{

--- a/server/internal/database/rag_service_config_test.go
+++ b/server/internal/database/rag_service_config_test.go
@@ -411,6 +411,7 @@ func TestParseRAGServiceConfig_PipelineNameAllowlist(t *testing.T) {
 		"UPPER",                // uppercase
 		"pipe🔥line",           // unicode emoji
 		"pipeline.name",        // dot
+		"-pipeline",            // leading hyphen (could be misread as a CLI flag)
 		"",                     // empty (covered separately, but included for completeness)
 	}
 	for _, name := range invalidNames {
@@ -422,7 +423,7 @@ func TestParseRAGServiceConfig_PipelineNameAllowlist(t *testing.T) {
 			config["pipelines"].([]any)[0].(map[string]any)["name"] = name
 			_, errs := database.ParseRAGServiceConfig(config, false)
 			require.NotEmpty(t, errs, "name %q should be invalid", name)
-			assert.Contains(t, errs[0].Error(), "must match ^[a-z0-9_-]+$")
+			assert.Contains(t, errs[0].Error(), "must match ^[a-z0-9_][a-z0-9_-]*$")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
This PR adds allowlist validation for RAG pipeline names, rejecting names that don't match `^[a-z0-9_-]+$` at the API layer before any resources are provisioned. 

## Changes
- Add `ragPipelineNamePattern` regex (`^[a-z0-9_-]+$`) to `server/internal/database/rag_service_config.go`
- Validate pipeline names against the allowlist in `validateRAGPipeline`, producing a clear error message on rejection
- Add `TestParseRAGServiceConfig_PipelineNameAllowlist` covering 7 valid and 7 invalid name variants (spaces, uppercase, slashes, path traversal, dots, Unicode)


## Testing
1. Create cluster 
2. Create DB with invalid pipeline name

```
restish control-plane-local-1 create-database '{
    "spec": {
      "database_name": "test_invalid_name",
      "database_users": [{"username":"admin","password":"pw","db_owner":true,"attributes":["LOGIN","SUPERUSER"]}],
      "port": 0,
      "nodes": [{"name":"n1","host_ids":["host-1"]}],
      "services": [{
        "service_id": "rag", "service_type": "rag", "version": "latest",
        "host_ids": ["host-1"], "port": 0,
        "config": {
          "pipelines": [{
            "name": "My Pipeline",
            "tables": [{"table":"docs","text_column":"content","vector_column":"embedding"}],
            "embedding_llm": {"provider":"openai","model":"text-embedding-3-small","api_key":"sk-test"},
            "rag_llm": {"provider":"anthropic","model":"claude-haiku-4-5-20251001","api_key":"sk-ant-test"}
          }]
        }
      }]
    }
  }' | jq .

{
  "message": "services[0].config: pipelines[0].name \"My Pipeline\" is invalid: must match ^[a-z0-9_-]+$",
  "name": "invalid_input"
}

```

## Checklist

- [x] Tests added 

[PLAT-536](https://pgedge.atlassian.net/browse/PLAT-536)

[PLAT-536]: https://pgedge.atlassian.net/browse/PLAT-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ