### PR TITLE
feat: user-defined sql scripts

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -98,6 +98,44 @@ SOFTWARE.
 
 ```
 
+## github.com/antlr4-go/antlr/v4
+
+* Name: github.com/antlr4-go/antlr/v4
+* Version: v4.13.1
+* License: [BSD-3-Clause](https://github.com/antlr4-go/antlr/blob/v4.13.1/LICENSE)
+
+```
+Copyright (c) 2012-2023 The ANTLR Project. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither name of copyright holders nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+
 ## github.com/benbjohnson/clock
 
 * Name: github.com/benbjohnson/clock
@@ -10420,6 +10458,207 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ```
 
+## github.com/valkdb/postgresparser
+
+* Name: github.com/valkdb/postgresparser
+* Version: v1.1.9
+* License: [Apache-2.0](https://github.com/valkdb/postgresparser/blob/v1.1.9/LICENSE)
+
+```
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 ValkDB
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+```
+
 ## github.com/wI2L/jsondiff
 
 * Name: github.com/wI2L/jsondiff
@@ -15491,6 +15730,43 @@ copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
    * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+
+## golang.org/x/exp
+
+* Name: golang.org/x/exp
+* Version: v0.0.0-20240506185415-9bf2ced13842
+* License: [BSD-3-Clause](https://cs.opensource.google/go/x/exp/+/9bf2ced1:LICENSE)
+
+```
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/api/apiv1/design/database.go
+++ b/api/apiv1/design/database.go
@@ -547,6 +547,40 @@ var RestoreConfigSpec = g.Type("RestoreConfigSpec", func() {
 	g.Required("source_database_id", "source_node_name", "source_database_name", "repository")
 })
 
+var SQLScript = g.Type("SQLScript", g.ArrayOf(g.String), func() {
+	g.Description("Each element of this array is an individual SQL statement.")
+	g.MinLength(0)
+	g.MaxLength(256)
+	g.Elem(func() {
+		g.MinLength(1)
+		g.MaxLength(1024)
+	})
+	g.Example([]string{
+		"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+		"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+		"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app",
+	})
+})
+
+var DatabaseScripts = g.Type("DatabaseScripts", func() {
+	g.Attribute("post_init", SQLScript, func() {
+		g.Description("The `post_init` script runs on each primary instance of each node after the instance is created for the first time. Each element of the array is single SQL statement. These statements run within a transaction in the `postgres` database before the users are created, so this feature can be used to create nologin roles that can be assigned to the database users via their `roles` field.")
+		g.Example([]string{
+			"CREATE ROLE accounting_admin NOLOGIN",
+		})
+		g.Meta("struct:tag:json", "post_init,omitempty")
+	})
+	g.Attribute("post_database_create", SQLScript, func() {
+		g.Description("The `post_database_create` script runs once on each primary instance of each node after the application database is created for the first time. Each element of the array is a single SQL statement. These statements run within a transaction in the application database after Spock is initialized, but before subscriptions are created.")
+		g.Example([]string{
+			"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+			"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+			"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app",
+		})
+		g.Meta("struct:tag:json", "post_database_create,omitempty")
+	})
+})
+
 var DatabaseSpec = g.Type("DatabaseSpec", func() {
 	g.Attribute("database_name", g.String, func() {
 		g.Description("The name of the Postgres database.")
@@ -630,6 +664,10 @@ var DatabaseSpec = g.Type("DatabaseSpec", func() {
 	g.Attribute("orchestrator_opts", OrchestratorOpts, func() {
 		g.Description("Orchestrator-specific configuration options.")
 		g.Meta("struct:tag:json", "orchestrator_opts,omitempty")
+	})
+	g.Attribute("scripts", DatabaseScripts, func() {
+		g.Description("User-defined SQL scripts that run at different points during the database creation process. Once a database has been successfully created, changes to these scripts will have no effect.")
+		g.Meta("struct:tag:json", "scripts,omitempty")
 	})
 
 	g.Required("database_name", "nodes")
@@ -968,8 +1006,8 @@ var CreateDatabaseRequest = g.Type("CreateDatabaseRequest", func() {
 		})
 	})
 
-	g.Example("Built-in roles", func() {
-		g.Description("The Control Plane can create multiple users on your behalf, and it includes some built-in roles that make it easy to assign limited permissions.")
+	g.Example("User-defined SQL scripts", func() {
+		g.Description("The Control Plane can run custom SQL scripts at different points in the database creation process.")
 		g.Value(map[string]any{
 			"id": "storefront",
 			"spec": map[string]any{
@@ -983,22 +1021,30 @@ var CreateDatabaseRequest = g.Type("CreateDatabaseRequest", func() {
 						"attributes": []string{"LOGIN", "SUPERUSER"},
 					},
 					{
-						"username":   "storefront_app",
-						"password":   "password",
-						"attributes": []string{"LOGIN"},
-						"roles":      []string{"pgedge_application"},
+						"username": "storefront",
+						"password": "password",
+						"roles":    []string{"read_write"},
 					},
 					{
-						"username":   "business_intelligence_app",
-						"password":   "password",
-						"attributes": []string{"LOGIN"},
-						"roles":      []string{"pgedge_application_read_only"},
+						"username": "accounting",
+						"password": "password",
+						"roles":    []string{"read_write"},
 					},
 				},
 				"nodes": []map[string]any{
 					{"name": "n1", "host_ids": []string{"us-east-1"}},
 					{"name": "n2", "host_ids": []string{"ap-south-1"}},
 					{"name": "n3", "host_ids": []string{"eu-central-1"}},
+				},
+				"scripts": map[string]any{
+					"post_init": []string{
+						"CREATE ROLE read_write NOLOGIN",
+					},
+					"post_database_create": []string{
+						"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO read_write",
+						"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO read_write",
+						"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO read_write",
+					},
 				},
 			},
 		})

--- a/api/apiv1/gen/control_plane/service.go
+++ b/api/apiv1/gen/control_plane/service.go
@@ -378,6 +378,22 @@ type DatabaseNodeSpec struct {
 	SourceNode *string `json:"source_node,omitempty"`
 }
 
+type DatabaseScripts struct {
+	// The `post_init` script runs on each primary instance of each node after the
+	// instance is created for the first time. Each element of the array is single
+	// SQL statement. These statements run within a transaction in the `postgres`
+	// database before the users are created, so this feature can be used to create
+	// nologin roles that can be assigned to the database users via their `roles`
+	// field.
+	PostInit SQLScript `json:"post_init,omitempty"`
+	// The `post_database_create` script runs once on each primary instance of each
+	// node after the application database is created for the first time. Each
+	// element of the array is a single SQL statement. These statements run within
+	// a transaction in the application database after Spock is initialized, but
+	// before subscriptions are created.
+	PostDatabaseCreate SQLScript `json:"post_database_create,omitempty"`
+}
+
 type DatabaseSpec struct {
 	// The name of the Postgres database.
 	DatabaseName string `json:"database_name"`
@@ -417,6 +433,10 @@ type DatabaseSpec struct {
 	PostgresqlConf map[string]any `json:"postgresql_conf,omitempty"`
 	// Orchestrator-specific configuration options.
 	OrchestratorOpts *OrchestratorOpts `json:"orchestrator_opts,omitempty"`
+	// User-defined SQL scripts that run at different points during the database
+	// creation process. Once a database has been successfully created, changes to
+	// these scripts will have no effect.
+	Scripts *DatabaseScripts `json:"scripts,omitempty"`
 }
 
 type DatabaseSummary struct {
@@ -924,6 +944,9 @@ type RestoreRepositorySpec struct {
 	// Additional options to apply to this repository.
 	CustomOptions map[string]string `json:"custom_options,omitempty"`
 }
+
+// Each element of this array is an individual SQL statement.
+type SQLScript []string
 
 // A service instance running on a host alongside the database.
 type ServiceInstance struct {

--- a/api/apiv1/gen/http/control_plane/client/encode_decode.go
+++ b/api/apiv1/gen/http/control_plane/client/encode_decode.go
@@ -4376,6 +4376,9 @@ func marshalControlplaneDatabaseSpecToDatabaseSpecRequestBody(v *controlplane.Da
 	if v.OrchestratorOpts != nil {
 		res.OrchestratorOpts = marshalControlplaneOrchestratorOptsToOrchestratorOptsRequestBody(v.OrchestratorOpts)
 	}
+	if v.Scripts != nil {
+		res.Scripts = marshalControlplaneDatabaseScriptsToDatabaseScriptsRequestBody(v.Scripts)
+	}
 
 	return res
 }
@@ -4758,6 +4761,30 @@ func marshalControlplaneDatabaseConnectionToDatabaseConnectionRequestBody(v *con
 	return res
 }
 
+// marshalControlplaneDatabaseScriptsToDatabaseScriptsRequestBody builds a
+// value of type *DatabaseScriptsRequestBody from a value of type
+// *controlplane.DatabaseScripts.
+func marshalControlplaneDatabaseScriptsToDatabaseScriptsRequestBody(v *controlplane.DatabaseScripts) *DatabaseScriptsRequestBody {
+	if v == nil {
+		return nil
+	}
+	res := &DatabaseScriptsRequestBody{}
+	if v.PostInit != nil {
+		res.PostInit = make([]string, len(v.PostInit))
+		for i, val := range v.PostInit {
+			res.PostInit[i] = val
+		}
+	}
+	if v.PostDatabaseCreate != nil {
+		res.PostDatabaseCreate = make([]string, len(v.PostDatabaseCreate))
+		for i, val := range v.PostDatabaseCreate {
+			res.PostDatabaseCreate[i] = val
+		}
+	}
+
+	return res
+}
+
 // marshalDatabaseSpecRequestBodyToControlplaneDatabaseSpec builds a value of
 // type *controlplane.DatabaseSpec from a value of type
 // *DatabaseSpecRequestBody.
@@ -4819,6 +4846,9 @@ func marshalDatabaseSpecRequestBodyToControlplaneDatabaseSpec(v *DatabaseSpecReq
 	}
 	if v.OrchestratorOpts != nil {
 		res.OrchestratorOpts = marshalOrchestratorOptsRequestBodyToControlplaneOrchestratorOpts(v.OrchestratorOpts)
+	}
+	if v.Scripts != nil {
+		res.Scripts = marshalDatabaseScriptsRequestBodyToControlplaneDatabaseScripts(v.Scripts)
 	}
 
 	return res
@@ -5202,6 +5232,30 @@ func marshalDatabaseConnectionRequestBodyToControlplaneDatabaseConnection(v *Dat
 	return res
 }
 
+// marshalDatabaseScriptsRequestBodyToControlplaneDatabaseScripts builds a
+// value of type *controlplane.DatabaseScripts from a value of type
+// *DatabaseScriptsRequestBody.
+func marshalDatabaseScriptsRequestBodyToControlplaneDatabaseScripts(v *DatabaseScriptsRequestBody) *controlplane.DatabaseScripts {
+	if v == nil {
+		return nil
+	}
+	res := &controlplane.DatabaseScripts{}
+	if v.PostInit != nil {
+		res.PostInit = make([]string, len(v.PostInit))
+		for i, val := range v.PostInit {
+			res.PostInit[i] = val
+		}
+	}
+	if v.PostDatabaseCreate != nil {
+		res.PostDatabaseCreate = make([]string, len(v.PostDatabaseCreate))
+		for i, val := range v.PostDatabaseCreate {
+			res.PostDatabaseCreate[i] = val
+		}
+	}
+
+	return res
+}
+
 // unmarshalDatabaseResponseBodyToControlplaneDatabase builds a value of type
 // *controlplane.Database from a value of type *DatabaseResponseBody.
 func unmarshalDatabaseResponseBodyToControlplaneDatabase(v *DatabaseResponseBody) *controlplane.Database {
@@ -5393,6 +5447,9 @@ func unmarshalDatabaseSpecResponseBodyToControlplaneDatabaseSpec(v *DatabaseSpec
 	}
 	if v.OrchestratorOpts != nil {
 		res.OrchestratorOpts = unmarshalOrchestratorOptsResponseBodyToControlplaneOrchestratorOpts(v.OrchestratorOpts)
+	}
+	if v.Scripts != nil {
+		res.Scripts = unmarshalDatabaseScriptsResponseBodyToControlplaneDatabaseScripts(v.Scripts)
 	}
 
 	return res
@@ -5762,6 +5819,30 @@ func unmarshalDatabaseConnectionResponseBodyToControlplaneDatabaseConnection(v *
 	return res
 }
 
+// unmarshalDatabaseScriptsResponseBodyToControlplaneDatabaseScripts builds a
+// value of type *controlplane.DatabaseScripts from a value of type
+// *DatabaseScriptsResponseBody.
+func unmarshalDatabaseScriptsResponseBodyToControlplaneDatabaseScripts(v *DatabaseScriptsResponseBody) *controlplane.DatabaseScripts {
+	if v == nil {
+		return nil
+	}
+	res := &controlplane.DatabaseScripts{}
+	if v.PostInit != nil {
+		res.PostInit = make([]string, len(v.PostInit))
+		for i, val := range v.PostInit {
+			res.PostInit[i] = val
+		}
+	}
+	if v.PostDatabaseCreate != nil {
+		res.PostDatabaseCreate = make([]string, len(v.PostDatabaseCreate))
+		for i, val := range v.PostDatabaseCreate {
+			res.PostDatabaseCreate[i] = val
+		}
+	}
+
+	return res
+}
+
 // marshalControlplaneDatabaseSpecToDatabaseSpecRequestBodyRequestBody builds a
 // value of type *DatabaseSpecRequestBodyRequestBody from a value of type
 // *controlplane.DatabaseSpec.
@@ -5823,6 +5904,9 @@ func marshalControlplaneDatabaseSpecToDatabaseSpecRequestBodyRequestBody(v *cont
 	}
 	if v.OrchestratorOpts != nil {
 		res.OrchestratorOpts = marshalControlplaneOrchestratorOptsToOrchestratorOptsRequestBodyRequestBody(v.OrchestratorOpts)
+	}
+	if v.Scripts != nil {
+		res.Scripts = marshalControlplaneDatabaseScriptsToDatabaseScriptsRequestBodyRequestBody(v.Scripts)
 	}
 
 	return res
@@ -6208,6 +6292,30 @@ func marshalControlplaneDatabaseConnectionToDatabaseConnectionRequestBodyRequest
 	return res
 }
 
+// marshalControlplaneDatabaseScriptsToDatabaseScriptsRequestBodyRequestBody
+// builds a value of type *DatabaseScriptsRequestBodyRequestBody from a value
+// of type *controlplane.DatabaseScripts.
+func marshalControlplaneDatabaseScriptsToDatabaseScriptsRequestBodyRequestBody(v *controlplane.DatabaseScripts) *DatabaseScriptsRequestBodyRequestBody {
+	if v == nil {
+		return nil
+	}
+	res := &DatabaseScriptsRequestBodyRequestBody{}
+	if v.PostInit != nil {
+		res.PostInit = make([]string, len(v.PostInit))
+		for i, val := range v.PostInit {
+			res.PostInit[i] = val
+		}
+	}
+	if v.PostDatabaseCreate != nil {
+		res.PostDatabaseCreate = make([]string, len(v.PostDatabaseCreate))
+		for i, val := range v.PostDatabaseCreate {
+			res.PostDatabaseCreate[i] = val
+		}
+	}
+
+	return res
+}
+
 // marshalDatabaseSpecRequestBodyRequestBodyToControlplaneDatabaseSpec builds a
 // value of type *controlplane.DatabaseSpec from a value of type
 // *DatabaseSpecRequestBodyRequestBody.
@@ -6269,6 +6377,9 @@ func marshalDatabaseSpecRequestBodyRequestBodyToControlplaneDatabaseSpec(v *Data
 	}
 	if v.OrchestratorOpts != nil {
 		res.OrchestratorOpts = marshalOrchestratorOptsRequestBodyRequestBodyToControlplaneOrchestratorOpts(v.OrchestratorOpts)
+	}
+	if v.Scripts != nil {
+		res.Scripts = marshalDatabaseScriptsRequestBodyRequestBodyToControlplaneDatabaseScripts(v.Scripts)
 	}
 
 	return res
@@ -6648,6 +6759,30 @@ func marshalDatabaseConnectionRequestBodyRequestBodyToControlplaneDatabaseConnec
 		res.TargetNodes = make([]string, len(v.TargetNodes))
 		for i, val := range v.TargetNodes {
 			res.TargetNodes[i] = val
+		}
+	}
+
+	return res
+}
+
+// marshalDatabaseScriptsRequestBodyRequestBodyToControlplaneDatabaseScripts
+// builds a value of type *controlplane.DatabaseScripts from a value of type
+// *DatabaseScriptsRequestBodyRequestBody.
+func marshalDatabaseScriptsRequestBodyRequestBodyToControlplaneDatabaseScripts(v *DatabaseScriptsRequestBodyRequestBody) *controlplane.DatabaseScripts {
+	if v == nil {
+		return nil
+	}
+	res := &controlplane.DatabaseScripts{}
+	if v.PostInit != nil {
+		res.PostInit = make([]string, len(v.PostInit))
+		for i, val := range v.PostInit {
+			res.PostInit[i] = val
+		}
+	}
+	if v.PostDatabaseCreate != nil {
+		res.PostDatabaseCreate = make([]string, len(v.PostDatabaseCreate))
+		for i, val := range v.PostDatabaseCreate {
+			res.PostDatabaseCreate[i] = val
 		}
 	}
 

--- a/api/apiv1/gen/http/control_plane/client/types.go
+++ b/api/apiv1/gen/http/control_plane/client/types.go
@@ -1842,6 +1842,10 @@ type DatabaseSpecRequestBody struct {
 	PostgresqlConf map[string]any `json:"postgresql_conf,omitempty"`
 	// Orchestrator-specific configuration options.
 	OrchestratorOpts *OrchestratorOptsRequestBody `json:"orchestrator_opts,omitempty"`
+	// User-defined SQL scripts that run at different points during the database
+	// creation process. Once a database has been successfully created, changes to
+	// these scripts will have no effect.
+	Scripts *DatabaseScriptsRequestBody `json:"scripts,omitempty"`
 }
 
 // DatabaseNodeSpecRequestBody is used to define fields on request body types.
@@ -2119,6 +2123,23 @@ type DatabaseConnectionRequestBody struct {
 	TargetSessionAttrs *string `json:"target_session_attrs,omitempty"`
 }
 
+// DatabaseScriptsRequestBody is used to define fields on request body types.
+type DatabaseScriptsRequestBody struct {
+	// The `post_init` script runs on each primary instance of each node after the
+	// instance is created for the first time. Each element of the array is single
+	// SQL statement. These statements run within a transaction in the `postgres`
+	// database before the users are created, so this feature can be used to create
+	// nologin roles that can be assigned to the database users via their `roles`
+	// field.
+	PostInit []string `json:"post_init,omitempty"`
+	// The `post_database_create` script runs once on each primary instance of each
+	// node after the application database is created for the first time. Each
+	// element of the array is a single SQL statement. These statements run within
+	// a transaction in the application database after Spock is initialized, but
+	// before subscriptions are created.
+	PostDatabaseCreate []string `json:"post_database_create,omitempty"`
+}
+
 // DatabaseResponseBody is used to define fields on response body types.
 type DatabaseResponseBody struct {
 	// Unique identifier for the database.
@@ -2241,6 +2262,10 @@ type DatabaseSpecResponseBody struct {
 	PostgresqlConf map[string]any `json:"postgresql_conf,omitempty"`
 	// Orchestrator-specific configuration options.
 	OrchestratorOpts *OrchestratorOptsResponseBody `json:"orchestrator_opts,omitempty"`
+	// User-defined SQL scripts that run at different points during the database
+	// creation process. Once a database has been successfully created, changes to
+	// these scripts will have no effect.
+	Scripts *DatabaseScriptsResponseBody `json:"scripts,omitempty"`
 }
 
 // DatabaseNodeSpecResponseBody is used to define fields on response body types.
@@ -2521,6 +2546,23 @@ type DatabaseConnectionResponseBody struct {
 	TargetSessionAttrs *string `json:"target_session_attrs,omitempty"`
 }
 
+// DatabaseScriptsResponseBody is used to define fields on response body types.
+type DatabaseScriptsResponseBody struct {
+	// The `post_init` script runs on each primary instance of each node after the
+	// instance is created for the first time. Each element of the array is single
+	// SQL statement. These statements run within a transaction in the `postgres`
+	// database before the users are created, so this feature can be used to create
+	// nologin roles that can be assigned to the database users via their `roles`
+	// field.
+	PostInit []string `json:"post_init,omitempty"`
+	// The `post_database_create` script runs once on each primary instance of each
+	// node after the application database is created for the first time. Each
+	// element of the array is a single SQL statement. These statements run within
+	// a transaction in the application database after Spock is initialized, but
+	// before subscriptions are created.
+	PostDatabaseCreate []string `json:"post_database_create,omitempty"`
+}
+
 // DatabaseSpecRequestBodyRequestBody is used to define fields on request body
 // types.
 type DatabaseSpecRequestBodyRequestBody struct {
@@ -2562,6 +2604,10 @@ type DatabaseSpecRequestBodyRequestBody struct {
 	PostgresqlConf map[string]any `json:"postgresql_conf,omitempty"`
 	// Orchestrator-specific configuration options.
 	OrchestratorOpts *OrchestratorOptsRequestBodyRequestBody `json:"orchestrator_opts,omitempty"`
+	// User-defined SQL scripts that run at different points during the database
+	// creation process. Once a database has been successfully created, changes to
+	// these scripts will have no effect.
+	Scripts *DatabaseScriptsRequestBodyRequestBody `json:"scripts,omitempty"`
 }
 
 // DatabaseNodeSpecRequestBodyRequestBody is used to define fields on request
@@ -2848,6 +2894,24 @@ type DatabaseConnectionRequestBodyRequestBody struct {
 	// derived from the service config. Valid values: primary, prefer-standby,
 	// standby, read-write, any.
 	TargetSessionAttrs *string `json:"target_session_attrs,omitempty"`
+}
+
+// DatabaseScriptsRequestBodyRequestBody is used to define fields on request
+// body types.
+type DatabaseScriptsRequestBodyRequestBody struct {
+	// The `post_init` script runs on each primary instance of each node after the
+	// instance is created for the first time. Each element of the array is single
+	// SQL statement. These statements run within a transaction in the `postgres`
+	// database before the users are created, so this feature can be used to create
+	// nologin roles that can be assigned to the database users via their `roles`
+	// field.
+	PostInit []string `json:"post_init,omitempty"`
+	// The `post_database_create` script runs once on each primary instance of each
+	// node after the application database is created for the first time. Each
+	// element of the array is a single SQL statement. These statements run within
+	// a transaction in the application database after Spock is initialized, but
+	// before subscriptions are created.
+	PostDatabaseCreate []string `json:"post_database_create,omitempty"`
 }
 
 // TaskLogEntryResponseBody is used to define fields on response body types.
@@ -5753,6 +5817,11 @@ func ValidateDatabaseSpecRequestBody(body *DatabaseSpecRequestBody) (err error) 
 			err = goa.MergeErrors(err, err2)
 		}
 	}
+	if body.Scripts != nil {
+		if err2 := ValidateDatabaseScriptsRequestBody(body.Scripts); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
 	return
 }
 
@@ -6307,6 +6376,40 @@ func ValidateDatabaseConnectionRequestBody(body *DatabaseConnectionRequestBody) 
 	return
 }
 
+// ValidateDatabaseScriptsRequestBody runs the validations defined on
+// DatabaseScriptsRequestBody
+func ValidateDatabaseScriptsRequestBody(body *DatabaseScriptsRequestBody) (err error) {
+	if len(body.PostInit) < 0 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init", body.PostInit, len(body.PostInit), 0, true))
+	}
+	if len(body.PostInit) > 256 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init", body.PostInit, len(body.PostInit), 256, false))
+	}
+	for _, e := range body.PostInit {
+		if utf8.RuneCountInString(e) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init[*]", e, utf8.RuneCountInString(e), 1, true))
+		}
+		if utf8.RuneCountInString(e) > 1024 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init[*]", e, utf8.RuneCountInString(e), 1024, false))
+		}
+	}
+	if len(body.PostDatabaseCreate) < 0 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create", body.PostDatabaseCreate, len(body.PostDatabaseCreate), 0, true))
+	}
+	if len(body.PostDatabaseCreate) > 256 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create", body.PostDatabaseCreate, len(body.PostDatabaseCreate), 256, false))
+	}
+	for _, e := range body.PostDatabaseCreate {
+		if utf8.RuneCountInString(e) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create[*]", e, utf8.RuneCountInString(e), 1, true))
+		}
+		if utf8.RuneCountInString(e) > 1024 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create[*]", e, utf8.RuneCountInString(e), 1024, false))
+		}
+	}
+	return
+}
+
 // ValidateDatabaseResponseBody runs a no-op validation on DatabaseResponseBody
 func ValidateDatabaseResponseBody(body *DatabaseResponseBody) (err error) {
 	return
@@ -6420,6 +6523,12 @@ func ValidateDatabaseConnectionResponseBody(body *DatabaseConnectionResponseBody
 	return
 }
 
+// ValidateDatabaseScriptsResponseBody runs a no-op validation on
+// DatabaseScriptsResponseBody
+func ValidateDatabaseScriptsResponseBody(body *DatabaseScriptsResponseBody) (err error) {
+	return
+}
+
 // ValidateDatabaseSpecRequestBodyRequestBody runs the validations defined on
 // DatabaseSpecRequestBodyRequestBody
 func ValidateDatabaseSpecRequestBodyRequestBody(body *DatabaseSpecRequestBodyRequestBody) (err error) {
@@ -6511,6 +6620,11 @@ func ValidateDatabaseSpecRequestBodyRequestBody(body *DatabaseSpecRequestBodyReq
 	}
 	if body.OrchestratorOpts != nil {
 		if err2 := ValidateOrchestratorOptsRequestBodyRequestBody(body.OrchestratorOpts); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	if body.Scripts != nil {
+		if err2 := ValidateDatabaseScriptsRequestBodyRequestBody(body.Scripts); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
@@ -7063,6 +7177,40 @@ func ValidateDatabaseConnectionRequestBodyRequestBody(body *DatabaseConnectionRe
 	if body.TargetSessionAttrs != nil {
 		if !(*body.TargetSessionAttrs == "primary" || *body.TargetSessionAttrs == "prefer-standby" || *body.TargetSessionAttrs == "standby" || *body.TargetSessionAttrs == "read-write" || *body.TargetSessionAttrs == "any") {
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.target_session_attrs", *body.TargetSessionAttrs, []any{"primary", "prefer-standby", "standby", "read-write", "any"}))
+		}
+	}
+	return
+}
+
+// ValidateDatabaseScriptsRequestBodyRequestBody runs the validations defined
+// on DatabaseScriptsRequestBodyRequestBody
+func ValidateDatabaseScriptsRequestBodyRequestBody(body *DatabaseScriptsRequestBodyRequestBody) (err error) {
+	if len(body.PostInit) < 0 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init", body.PostInit, len(body.PostInit), 0, true))
+	}
+	if len(body.PostInit) > 256 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init", body.PostInit, len(body.PostInit), 256, false))
+	}
+	for _, e := range body.PostInit {
+		if utf8.RuneCountInString(e) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init[*]", e, utf8.RuneCountInString(e), 1, true))
+		}
+		if utf8.RuneCountInString(e) > 1024 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init[*]", e, utf8.RuneCountInString(e), 1024, false))
+		}
+	}
+	if len(body.PostDatabaseCreate) < 0 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create", body.PostDatabaseCreate, len(body.PostDatabaseCreate), 0, true))
+	}
+	if len(body.PostDatabaseCreate) > 256 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create", body.PostDatabaseCreate, len(body.PostDatabaseCreate), 256, false))
+	}
+	for _, e := range body.PostDatabaseCreate {
+		if utf8.RuneCountInString(e) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create[*]", e, utf8.RuneCountInString(e), 1, true))
+		}
+		if utf8.RuneCountInString(e) > 1024 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create[*]", e, utf8.RuneCountInString(e), 1024, false))
 		}
 	}
 	return

--- a/api/apiv1/gen/http/control_plane/server/encode_decode.go
+++ b/api/apiv1/gen/http/control_plane/server/encode_decode.go
@@ -3753,6 +3753,9 @@ func unmarshalDatabaseSpecRequestBodyToControlplaneDatabaseSpec(v *DatabaseSpecR
 	if v.OrchestratorOpts != nil {
 		res.OrchestratorOpts = unmarshalOrchestratorOptsRequestBodyToControlplaneOrchestratorOpts(v.OrchestratorOpts)
 	}
+	if v.Scripts != nil {
+		res.Scripts = unmarshalDatabaseScriptsRequestBodyToControlplaneDatabaseScripts(v.Scripts)
+	}
 
 	return res
 }
@@ -4121,6 +4124,30 @@ func unmarshalDatabaseConnectionRequestBodyToControlplaneDatabaseConnection(v *D
 	return res
 }
 
+// unmarshalDatabaseScriptsRequestBodyToControlplaneDatabaseScripts builds a
+// value of type *controlplane.DatabaseScripts from a value of type
+// *DatabaseScriptsRequestBody.
+func unmarshalDatabaseScriptsRequestBodyToControlplaneDatabaseScripts(v *DatabaseScriptsRequestBody) *controlplane.DatabaseScripts {
+	if v == nil {
+		return nil
+	}
+	res := &controlplane.DatabaseScripts{}
+	if v.PostInit != nil {
+		res.PostInit = make([]string, len(v.PostInit))
+		for i, val := range v.PostInit {
+			res.PostInit[i] = val
+		}
+	}
+	if v.PostDatabaseCreate != nil {
+		res.PostDatabaseCreate = make([]string, len(v.PostDatabaseCreate))
+		for i, val := range v.PostDatabaseCreate {
+			res.PostDatabaseCreate[i] = val
+		}
+	}
+
+	return res
+}
+
 // marshalControlplaneDatabaseToDatabaseResponseBody builds a value of type
 // *DatabaseResponseBody from a value of type *controlplane.Database.
 func marshalControlplaneDatabaseToDatabaseResponseBody(v *controlplane.Database) *DatabaseResponseBody {
@@ -4316,6 +4343,9 @@ func marshalControlplaneDatabaseSpecToDatabaseSpecResponseBody(v *controlplane.D
 	}
 	if v.OrchestratorOpts != nil {
 		res.OrchestratorOpts = marshalControlplaneOrchestratorOptsToOrchestratorOptsResponseBody(v.OrchestratorOpts)
+	}
+	if v.Scripts != nil {
+		res.Scripts = marshalControlplaneDatabaseScriptsToDatabaseScriptsResponseBody(v.Scripts)
 	}
 
 	return res
@@ -4699,6 +4729,30 @@ func marshalControlplaneDatabaseConnectionToDatabaseConnectionResponseBody(v *co
 	return res
 }
 
+// marshalControlplaneDatabaseScriptsToDatabaseScriptsResponseBody builds a
+// value of type *DatabaseScriptsResponseBody from a value of type
+// *controlplane.DatabaseScripts.
+func marshalControlplaneDatabaseScriptsToDatabaseScriptsResponseBody(v *controlplane.DatabaseScripts) *DatabaseScriptsResponseBody {
+	if v == nil {
+		return nil
+	}
+	res := &DatabaseScriptsResponseBody{}
+	if v.PostInit != nil {
+		res.PostInit = make([]string, len(v.PostInit))
+		for i, val := range v.PostInit {
+			res.PostInit[i] = val
+		}
+	}
+	if v.PostDatabaseCreate != nil {
+		res.PostDatabaseCreate = make([]string, len(v.PostDatabaseCreate))
+		for i, val := range v.PostDatabaseCreate {
+			res.PostDatabaseCreate[i] = val
+		}
+	}
+
+	return res
+}
+
 // unmarshalDatabaseSpecRequestBodyRequestBodyToControlplaneDatabaseSpec builds
 // a value of type *controlplane.DatabaseSpec from a value of type
 // *DatabaseSpecRequestBodyRequestBody.
@@ -4756,6 +4810,9 @@ func unmarshalDatabaseSpecRequestBodyRequestBodyToControlplaneDatabaseSpec(v *Da
 	}
 	if v.OrchestratorOpts != nil {
 		res.OrchestratorOpts = unmarshalOrchestratorOptsRequestBodyRequestBodyToControlplaneOrchestratorOpts(v.OrchestratorOpts)
+	}
+	if v.Scripts != nil {
+		res.Scripts = unmarshalDatabaseScriptsRequestBodyRequestBodyToControlplaneDatabaseScripts(v.Scripts)
 	}
 
 	return res
@@ -5121,6 +5178,30 @@ func unmarshalDatabaseConnectionRequestBodyRequestBodyToControlplaneDatabaseConn
 		res.TargetNodes = make([]string, len(v.TargetNodes))
 		for i, val := range v.TargetNodes {
 			res.TargetNodes[i] = val
+		}
+	}
+
+	return res
+}
+
+// unmarshalDatabaseScriptsRequestBodyRequestBodyToControlplaneDatabaseScripts
+// builds a value of type *controlplane.DatabaseScripts from a value of type
+// *DatabaseScriptsRequestBodyRequestBody.
+func unmarshalDatabaseScriptsRequestBodyRequestBodyToControlplaneDatabaseScripts(v *DatabaseScriptsRequestBodyRequestBody) *controlplane.DatabaseScripts {
+	if v == nil {
+		return nil
+	}
+	res := &controlplane.DatabaseScripts{}
+	if v.PostInit != nil {
+		res.PostInit = make([]string, len(v.PostInit))
+		for i, val := range v.PostInit {
+			res.PostInit[i] = val
+		}
+	}
+	if v.PostDatabaseCreate != nil {
+		res.PostDatabaseCreate = make([]string, len(v.PostDatabaseCreate))
+		for i, val := range v.PostDatabaseCreate {
+			res.PostDatabaseCreate[i] = val
 		}
 	}
 

--- a/api/apiv1/gen/http/control_plane/server/types.go
+++ b/api/apiv1/gen/http/control_plane/server/types.go
@@ -1924,6 +1924,10 @@ type DatabaseSpecResponseBody struct {
 	PostgresqlConf map[string]any `json:"postgresql_conf,omitempty"`
 	// Orchestrator-specific configuration options.
 	OrchestratorOpts *OrchestratorOptsResponseBody `json:"orchestrator_opts,omitempty"`
+	// User-defined SQL scripts that run at different points during the database
+	// creation process. Once a database has been successfully created, changes to
+	// these scripts will have no effect.
+	Scripts *DatabaseScriptsResponseBody `json:"scripts,omitempty"`
 }
 
 // DatabaseNodeSpecResponseBody is used to define fields on response body types.
@@ -2204,6 +2208,23 @@ type DatabaseConnectionResponseBody struct {
 	TargetSessionAttrs *string `json:"target_session_attrs,omitempty"`
 }
 
+// DatabaseScriptsResponseBody is used to define fields on response body types.
+type DatabaseScriptsResponseBody struct {
+	// The `post_init` script runs on each primary instance of each node after the
+	// instance is created for the first time. Each element of the array is single
+	// SQL statement. These statements run within a transaction in the `postgres`
+	// database before the users are created, so this feature can be used to create
+	// nologin roles that can be assigned to the database users via their `roles`
+	// field.
+	PostInit []string `json:"post_init,omitempty"`
+	// The `post_database_create` script runs once on each primary instance of each
+	// node after the application database is created for the first time. Each
+	// element of the array is a single SQL statement. These statements run within
+	// a transaction in the application database after Spock is initialized, but
+	// before subscriptions are created.
+	PostDatabaseCreate []string `json:"post_database_create,omitempty"`
+}
+
 // TaskLogEntryResponseBody is used to define fields on response body types.
 type TaskLogEntryResponseBody struct {
 	// The timestamp of the log entry.
@@ -2254,6 +2275,10 @@ type DatabaseSpecRequestBody struct {
 	PostgresqlConf map[string]any `json:"postgresql_conf,omitempty"`
 	// Orchestrator-specific configuration options.
 	OrchestratorOpts *OrchestratorOptsRequestBody `json:"orchestrator_opts,omitempty"`
+	// User-defined SQL scripts that run at different points during the database
+	// creation process. Once a database has been successfully created, changes to
+	// these scripts will have no effect.
+	Scripts *DatabaseScriptsRequestBody `json:"scripts,omitempty"`
 }
 
 // DatabaseNodeSpecRequestBody is used to define fields on request body types.
@@ -2531,6 +2556,23 @@ type DatabaseConnectionRequestBody struct {
 	TargetSessionAttrs *string `json:"target_session_attrs,omitempty"`
 }
 
+// DatabaseScriptsRequestBody is used to define fields on request body types.
+type DatabaseScriptsRequestBody struct {
+	// The `post_init` script runs on each primary instance of each node after the
+	// instance is created for the first time. Each element of the array is single
+	// SQL statement. These statements run within a transaction in the `postgres`
+	// database before the users are created, so this feature can be used to create
+	// nologin roles that can be assigned to the database users via their `roles`
+	// field.
+	PostInit []string `json:"post_init,omitempty"`
+	// The `post_database_create` script runs once on each primary instance of each
+	// node after the application database is created for the first time. Each
+	// element of the array is a single SQL statement. These statements run within
+	// a transaction in the application database after Spock is initialized, but
+	// before subscriptions are created.
+	PostDatabaseCreate []string `json:"post_database_create,omitempty"`
+}
+
 // DatabaseSpecRequestBodyRequestBody is used to define fields on request body
 // types.
 type DatabaseSpecRequestBodyRequestBody struct {
@@ -2572,6 +2614,10 @@ type DatabaseSpecRequestBodyRequestBody struct {
 	PostgresqlConf map[string]any `json:"postgresql_conf,omitempty"`
 	// Orchestrator-specific configuration options.
 	OrchestratorOpts *OrchestratorOptsRequestBodyRequestBody `json:"orchestrator_opts,omitempty"`
+	// User-defined SQL scripts that run at different points during the database
+	// creation process. Once a database has been successfully created, changes to
+	// these scripts will have no effect.
+	Scripts *DatabaseScriptsRequestBodyRequestBody `json:"scripts,omitempty"`
 }
 
 // DatabaseNodeSpecRequestBodyRequestBody is used to define fields on request
@@ -2858,6 +2904,24 @@ type DatabaseConnectionRequestBodyRequestBody struct {
 	// derived from the service config. Valid values: primary, prefer-standby,
 	// standby, read-write, any.
 	TargetSessionAttrs *string `json:"target_session_attrs,omitempty"`
+}
+
+// DatabaseScriptsRequestBodyRequestBody is used to define fields on request
+// body types.
+type DatabaseScriptsRequestBodyRequestBody struct {
+	// The `post_init` script runs on each primary instance of each node after the
+	// instance is created for the first time. Each element of the array is single
+	// SQL statement. These statements run within a transaction in the `postgres`
+	// database before the users are created, so this feature can be used to create
+	// nologin roles that can be assigned to the database users via their `roles`
+	// field.
+	PostInit []string `json:"post_init,omitempty"`
+	// The `post_database_create` script runs once on each primary instance of each
+	// node after the application database is created for the first time. Each
+	// element of the array is a single SQL statement. These statements run within
+	// a transaction in the application database after Spock is initialized, but
+	// before subscriptions are created.
+	PostDatabaseCreate []string `json:"post_database_create,omitempty"`
 }
 
 // NewInitClusterResponseBody builds the HTTP response body from the result of
@@ -5180,6 +5244,11 @@ func ValidateDatabaseSpecRequestBody(body *DatabaseSpecRequestBody) (err error) 
 			err = goa.MergeErrors(err, err2)
 		}
 	}
+	if body.Scripts != nil {
+		if err2 := ValidateDatabaseScriptsRequestBody(body.Scripts); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
 	return
 }
 
@@ -5818,6 +5887,40 @@ func ValidateDatabaseConnectionRequestBody(body *DatabaseConnectionRequestBody) 
 	return
 }
 
+// ValidateDatabaseScriptsRequestBody runs the validations defined on
+// DatabaseScriptsRequestBody
+func ValidateDatabaseScriptsRequestBody(body *DatabaseScriptsRequestBody) (err error) {
+	if len(body.PostInit) < 0 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init", body.PostInit, len(body.PostInit), 0, true))
+	}
+	if len(body.PostInit) > 256 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init", body.PostInit, len(body.PostInit), 256, false))
+	}
+	for _, e := range body.PostInit {
+		if utf8.RuneCountInString(e) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init[*]", e, utf8.RuneCountInString(e), 1, true))
+		}
+		if utf8.RuneCountInString(e) > 1024 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init[*]", e, utf8.RuneCountInString(e), 1024, false))
+		}
+	}
+	if len(body.PostDatabaseCreate) < 0 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create", body.PostDatabaseCreate, len(body.PostDatabaseCreate), 0, true))
+	}
+	if len(body.PostDatabaseCreate) > 256 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create", body.PostDatabaseCreate, len(body.PostDatabaseCreate), 256, false))
+	}
+	for _, e := range body.PostDatabaseCreate {
+		if utf8.RuneCountInString(e) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create[*]", e, utf8.RuneCountInString(e), 1, true))
+		}
+		if utf8.RuneCountInString(e) > 1024 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create[*]", e, utf8.RuneCountInString(e), 1024, false))
+		}
+	}
+	return
+}
+
 // ValidateDatabaseSpecRequestBodyRequestBody runs the validations defined on
 // DatabaseSpecRequestBodyRequestBody
 func ValidateDatabaseSpecRequestBodyRequestBody(body *DatabaseSpecRequestBodyRequestBody) (err error) {
@@ -5916,6 +6019,11 @@ func ValidateDatabaseSpecRequestBodyRequestBody(body *DatabaseSpecRequestBodyReq
 	}
 	if body.OrchestratorOpts != nil {
 		if err2 := ValidateOrchestratorOptsRequestBodyRequestBody(body.OrchestratorOpts); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	if body.Scripts != nil {
+		if err2 := ValidateDatabaseScriptsRequestBodyRequestBody(body.Scripts); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
@@ -6552,6 +6660,40 @@ func ValidateDatabaseConnectionRequestBodyRequestBody(body *DatabaseConnectionRe
 	if body.TargetSessionAttrs != nil {
 		if !(*body.TargetSessionAttrs == "primary" || *body.TargetSessionAttrs == "prefer-standby" || *body.TargetSessionAttrs == "standby" || *body.TargetSessionAttrs == "read-write" || *body.TargetSessionAttrs == "any") {
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.target_session_attrs", *body.TargetSessionAttrs, []any{"primary", "prefer-standby", "standby", "read-write", "any"}))
+		}
+	}
+	return
+}
+
+// ValidateDatabaseScriptsRequestBodyRequestBody runs the validations defined
+// on DatabaseScriptsRequestBodyRequestBody
+func ValidateDatabaseScriptsRequestBodyRequestBody(body *DatabaseScriptsRequestBodyRequestBody) (err error) {
+	if len(body.PostInit) < 0 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init", body.PostInit, len(body.PostInit), 0, true))
+	}
+	if len(body.PostInit) > 256 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init", body.PostInit, len(body.PostInit), 256, false))
+	}
+	for _, e := range body.PostInit {
+		if utf8.RuneCountInString(e) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init[*]", e, utf8.RuneCountInString(e), 1, true))
+		}
+		if utf8.RuneCountInString(e) > 1024 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_init[*]", e, utf8.RuneCountInString(e), 1024, false))
+		}
+	}
+	if len(body.PostDatabaseCreate) < 0 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create", body.PostDatabaseCreate, len(body.PostDatabaseCreate), 0, true))
+	}
+	if len(body.PostDatabaseCreate) > 256 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create", body.PostDatabaseCreate, len(body.PostDatabaseCreate), 256, false))
+	}
+	for _, e := range body.PostDatabaseCreate {
+		if utf8.RuneCountInString(e) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create[*]", e, utf8.RuneCountInString(e), 1, true))
+		}
+		if utf8.RuneCountInString(e) > 1024 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.post_database_create[*]", e, utf8.RuneCountInString(e), 1024, false))
 		}
 	}
 	return

--- a/api/apiv1/gen/http/openapi.json
+++ b/api/apiv1/gen/http/openapi.json
@@ -2626,7 +2626,7 @@
           },
           "additionalProperties": {
             "type": "string",
-            "example": "Ratione asperiores iusto nostrum commodi quidem occaecati."
+            "example": "Quidem occaecati."
           }
         },
         "backup_options": {
@@ -4151,6 +4151,58 @@
         "host_ids"
       ]
     },
+    "DatabaseScripts": {
+      "title": "DatabaseScripts",
+      "type": "object",
+      "properties": {
+        "post_database_create": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "r0",
+            "minLength": 1,
+            "maxLength": 1024
+          },
+          "description": "The `post_database_create` script runs once on each primary instance of each node after the application database is created for the first time. Each element of the array is a single SQL statement. These statements run within a transaction in the application database after Spock is initialized, but before subscriptions are created.",
+          "example": [
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+          ],
+          "minItems": 0,
+          "maxItems": 256
+        },
+        "post_init": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "p",
+            "minLength": 1,
+            "maxLength": 1024
+          },
+          "description": "The `post_init` script runs on each primary instance of each node after the instance is created for the first time. Each element of the array is single SQL statement. These statements run within a transaction in the `postgres` database before the users are created, so this feature can be used to create nologin roles that can be assigned to the database users via their `roles` field.",
+          "example": [
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+          ],
+          "minItems": 0,
+          "maxItems": 256
+        }
+      },
+      "example": {
+        "post_database_create": [
+          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+        ],
+        "post_init": [
+          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+        ]
+      }
+    },
     "DatabaseSpec": {
       "title": "DatabaseSpec",
       "type": "object",
@@ -4653,6 +4705,9 @@
         },
         "restore_config": {
           "$ref": "#/definitions/RestoreConfigSpec"
+        },
+        "scripts": {
+          "$ref": "#/definitions/DatabaseScripts"
         },
         "services": {
           "type": "array",
@@ -5243,7 +5298,97 @@
           "source_database_name": "northwind",
           "source_node_name": "n1"
         },
+        "scripts": {
+          "post_database_create": [
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+          ],
+          "post_init": [
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+          ]
+        },
         "services": [
+          {
+            "config": {
+              "llm_model": "gpt-4",
+              "llm_provider": "openai",
+              "openai_api_key": "sk-..."
+            },
+            "cpus": "500m",
+            "database_connection": {
+              "target_nodes": [
+                "n1",
+                "n2"
+              ],
+              "target_session_attrs": "primary"
+            },
+            "host_ids": [
+              "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "76f9b8c0-4958-11f0-a489-3bb29577c696"
+            ],
+            "memory": "512M",
+            "orchestrator_opts": {
+              "swarm": {
+                "extra_labels": {
+                  "traefik.enable": "true",
+                  "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                },
+                "extra_networks": [
+                  {
+                    "aliases": [
+                      "pg-db",
+                      "db-alias"
+                    ],
+                    "driver_opts": {
+                      "com.docker.network.endpoint.expose": "true"
+                    },
+                    "id": "traefik-public"
+                  },
+                  {
+                    "aliases": [
+                      "pg-db",
+                      "db-alias"
+                    ],
+                    "driver_opts": {
+                      "com.docker.network.endpoint.expose": "true"
+                    },
+                    "id": "traefik-public"
+                  },
+                  {
+                    "aliases": [
+                      "pg-db",
+                      "db-alias"
+                    ],
+                    "driver_opts": {
+                      "com.docker.network.endpoint.expose": "true"
+                    },
+                    "id": "traefik-public"
+                  }
+                ],
+                "extra_volumes": [
+                  {
+                    "destination_path": "/backups/container",
+                    "host_path": "/Users/user/backups/host"
+                  },
+                  {
+                    "destination_path": "/backups/container",
+                    "host_path": "/Users/user/backups/host"
+                  },
+                  {
+                    "destination_path": "/backups/container",
+                    "host_path": "/Users/user/backups/host"
+                  }
+                ]
+              }
+            },
+            "port": 0,
+            "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+            "service_type": "rag",
+            "version": "latest"
+          },
           {
             "config": {
               "llm_model": "gpt-4",

--- a/api/apiv1/gen/http/openapi.yaml
+++ b/api/apiv1/gen/http/openapi.yaml
@@ -1843,7 +1843,7 @@ definitions:
           key: value
         additionalProperties:
           type: string
-          example: Ratione asperiores iusto nostrum commodi quidem occaecati.
+          example: Quidem occaecati.
       backup_options:
         type: object
         description: Options for the backup.
@@ -2953,6 +2953,47 @@ definitions:
     required:
       - name
       - host_ids
+  DatabaseScripts:
+    title: DatabaseScripts
+    type: object
+    properties:
+      post_database_create:
+        type: array
+        items:
+          type: string
+          example: r0
+          minLength: 1
+          maxLength: 1024
+        description: The `post_database_create` script runs once on each primary instance of each node after the application database is created for the first time. Each element of the array is a single SQL statement. These statements run within a transaction in the application database after Spock is initialized, but before subscriptions are created.
+        example:
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+        minItems: 0
+        maxItems: 256
+      post_init:
+        type: array
+        items:
+          type: string
+          example: p
+          minLength: 1
+          maxLength: 1024
+        description: The `post_init` script runs on each primary instance of each node after the instance is created for the first time. Each element of the array is single SQL statement. These statements run within a transaction in the `postgres` database before the users are created, so this feature can be used to create nologin roles that can be assigned to the database users via their `roles` field.
+        example:
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+        minItems: 0
+        maxItems: 256
+    example:
+      post_database_create:
+        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+      post_init:
+        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
   DatabaseSpec:
     title: DatabaseSpec
     type: object
@@ -3329,6 +3370,8 @@ definitions:
         additionalProperties: true
       restore_config:
         $ref: '#/definitions/RestoreConfigSpec'
+      scripts:
+        $ref: '#/definitions/DatabaseScripts'
       services:
         type: array
         items:
@@ -3746,7 +3789,65 @@ definitions:
         source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
         source_database_name: northwind
         source_node_name: n1
+      scripts:
+        post_database_create:
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+        post_init:
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
       services:
+        - config:
+            llm_model: gpt-4
+            llm_provider: openai
+            openai_api_key: sk-...
+          cpus: 500m
+          database_connection:
+            target_nodes:
+              - n1
+              - n2
+            target_session_attrs: primary
+          host_ids:
+            - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            - 76f9b8c0-4958-11f0-a489-3bb29577c696
+          memory: 512M
+          orchestrator_opts:
+            swarm:
+              extra_labels:
+                traefik.enable: "true"
+                traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+              extra_networks:
+                - aliases:
+                    - pg-db
+                    - db-alias
+                  driver_opts:
+                    com.docker.network.endpoint.expose: "true"
+                  id: traefik-public
+                - aliases:
+                    - pg-db
+                    - db-alias
+                  driver_opts:
+                    com.docker.network.endpoint.expose: "true"
+                  id: traefik-public
+                - aliases:
+                    - pg-db
+                    - db-alias
+                  driver_opts:
+                    com.docker.network.endpoint.expose: "true"
+                  id: traefik-public
+              extra_volumes:
+                - destination_path: /backups/container
+                  host_path: /Users/user/backups/host
+                - destination_path: /backups/container
+                  host_path: /Users/user/backups/host
+                - destination_path: /backups/container
+                  host_path: /Users/user/backups/host
+          port: 0
+          service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+          service_type: rag
+          version: latest
         - config:
             llm_model: gpt-4
             llm_provider: openai

--- a/api/apiv1/gen/http/openapi3.json
+++ b/api/apiv1/gen/http/openapi3.json
@@ -820,68 +820,6 @@
                 "$ref": "#/components/schemas/CreateDatabaseRequest2"
               },
               "examples": {
-                "Built-in roles": {
-                  "summary": "Built-in roles",
-                  "description": "The Control Plane can create multiple users on your behalf, and it includes some built-in roles that make it easy to assign limited permissions.",
-                  "value": {
-                    "id": "storefront",
-                    "spec": {
-                      "database_name": "storefront",
-                      "database_users": [
-                        {
-                          "attributes": [
-                            "LOGIN",
-                            "SUPERUSER"
-                          ],
-                          "db_owner": true,
-                          "password": "password",
-                          "username": "admin"
-                        },
-                        {
-                          "attributes": [
-                            "LOGIN"
-                          ],
-                          "password": "password",
-                          "roles": [
-                            "pgedge_application"
-                          ],
-                          "username": "storefront_app"
-                        },
-                        {
-                          "attributes": [
-                            "LOGIN"
-                          ],
-                          "password": "password",
-                          "roles": [
-                            "pgedge_application_read_only"
-                          ],
-                          "username": "business_intelligence_app"
-                        }
-                      ],
-                      "nodes": [
-                        {
-                          "host_ids": [
-                            "us-east-1"
-                          ],
-                          "name": "n1"
-                        },
-                        {
-                          "host_ids": [
-                            "ap-south-1"
-                          ],
-                          "name": "n2"
-                        },
-                        {
-                          "host_ids": [
-                            "eu-central-1"
-                          ],
-                          "name": "n3"
-                        }
-                      ],
-                      "port": 5432
-                    }
-                  }
-                },
                 "Creating from an existing backup": {
                   "summary": "Creating from an existing backup",
                   "description": "A configuration that creates a database from an existing backup in S3.",
@@ -1017,6 +955,72 @@
                         }
                       ],
                       "port": 5432
+                    }
+                  }
+                },
+                "User-defined SQL scripts": {
+                  "summary": "User-defined SQL scripts",
+                  "description": "The Control Plane can run custom SQL scripts at different points in the database creation process.",
+                  "value": {
+                    "id": "storefront",
+                    "spec": {
+                      "database_name": "storefront",
+                      "database_users": [
+                        {
+                          "attributes": [
+                            "LOGIN",
+                            "SUPERUSER"
+                          ],
+                          "db_owner": true,
+                          "password": "password",
+                          "username": "admin"
+                        },
+                        {
+                          "password": "password",
+                          "roles": [
+                            "read_write"
+                          ],
+                          "username": "storefront"
+                        },
+                        {
+                          "password": "password",
+                          "roles": [
+                            "read_write"
+                          ],
+                          "username": "accounting"
+                        }
+                      ],
+                      "nodes": [
+                        {
+                          "host_ids": [
+                            "us-east-1"
+                          ],
+                          "name": "n1"
+                        },
+                        {
+                          "host_ids": [
+                            "ap-south-1"
+                          ],
+                          "name": "n2"
+                        },
+                        {
+                          "host_ids": [
+                            "eu-central-1"
+                          ],
+                          "name": "n3"
+                        }
+                      ],
+                      "port": 5432,
+                      "scripts": {
+                        "post_database_create": [
+                          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO read_write",
+                          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO read_write",
+                          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO read_write"
+                        ],
+                        "post_init": [
+                          "CREATE ROLE read_write NOLOGIN"
+                        ]
+                      }
                     }
                   }
                 },
@@ -1746,17 +1750,20 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "example": "Cupiditate molestiae."
+                "example": "Doloribus consequatur voluptatibus sed et nisi."
               },
               "description": "Host IDs to treat as removed during this update. Events targeting these hosts will be skipped.",
               "example": [
-                "Accusamus quia dolores.",
-                "Laboriosam placeat distinctio atque dolor autem."
+                "Perspiciatis et veniam blanditiis et.",
+                "Repellat fuga occaecati optio accusantium.",
+                "Voluptatibus sunt deserunt sapiente doloribus est."
               ]
             },
             "example": [
-              "Excepturi sapiente neque doloribus consequatur voluptatibus.",
-              "Et nisi nihil corporis."
+              "Officiis sint.",
+              "Ad aut velit distinctio sed.",
+              "Rem voluptas qui.",
+              "Voluptatem nesciunt dignissimos voluptas vel earum."
             ]
           },
           {
@@ -6869,13 +6876,13 @@
                   ],
                   "port": 5432
                 },
-                "created_at": "1971-07-18T16:52:12Z",
+                "created_at": "1970-12-24T01:48:39Z",
                 "error": "failed to get patroni status: connection refused",
                 "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                 "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                 "node_name": "n1",
                 "postgres": {
-                  "patroni_paused": false,
+                  "patroni_paused": true,
                   "patroni_state": "unknown",
                   "pending_restart": true,
                   "role": "primary",
@@ -6893,18 +6900,13 @@
                       "name": "sub_n1n2",
                       "provider_node": "n2",
                       "status": "down"
-                    },
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
                     }
                   ],
                   "version": "4.10.0"
                 },
-                "state": "deleting",
-                "status_updated_at": "1999-09-23T18:53:48Z",
-                "updated_at": "2013-04-06T16:38:09Z"
+                "state": "unknown",
+                "status_updated_at": "1978-12-17T01:14:06Z",
+                "updated_at": "2010-08-13T18:38:44Z"
               },
               {
                 "connection_info": {
@@ -6914,13 +6916,13 @@
                   ],
                   "port": 5432
                 },
-                "created_at": "1971-07-18T16:52:12Z",
+                "created_at": "1970-12-24T01:48:39Z",
                 "error": "failed to get patroni status: connection refused",
                 "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                 "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                 "node_name": "n1",
                 "postgres": {
-                  "patroni_paused": false,
+                  "patroni_paused": true,
                   "patroni_state": "unknown",
                   "pending_restart": true,
                   "role": "primary",
@@ -6938,6 +6940,41 @@
                       "name": "sub_n1n2",
                       "provider_node": "n2",
                       "status": "down"
+                    }
+                  ],
+                  "version": "4.10.0"
+                },
+                "state": "unknown",
+                "status_updated_at": "1978-12-17T01:14:06Z",
+                "updated_at": "2010-08-13T18:38:44Z"
+              },
+              {
+                "connection_info": {
+                  "addresses": [
+                    "10.24.34.2",
+                    "i-0123456789abcdef.ec2.internal"
+                  ],
+                  "port": 5432
+                },
+                "created_at": "1970-12-24T01:48:39Z",
+                "error": "failed to get patroni status: connection refused",
+                "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+                "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
+                "node_name": "n1",
+                "postgres": {
+                  "patroni_paused": true,
+                  "patroni_state": "unknown",
+                  "pending_restart": true,
+                  "role": "primary",
+                  "version": "18.1"
+                },
+                "spock": {
+                  "read_only": "off",
+                  "subscriptions": [
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
                     },
                     {
                       "name": "sub_n1n2",
@@ -6947,9 +6984,9 @@
                   ],
                   "version": "4.10.0"
                 },
-                "state": "deleting",
-                "status_updated_at": "1999-09-23T18:53:48Z",
-                "updated_at": "2013-04-06T16:38:09Z"
+                "state": "unknown",
+                "status_updated_at": "1978-12-17T01:14:06Z",
+                "updated_at": "2010-08-13T18:38:44Z"
               }
             ]
           },
@@ -6991,38 +7028,6 @@
                       "container_port": 8080,
                       "host_port": 8080,
                       "name": "web-client"
-                    }
-                  ],
-                  "service_ready": true
-                },
-                "updated_at": "2025-01-28T10:05:00Z"
-              },
-              {
-                "created_at": "2025-01-28T10:00:00Z",
-                "database_id": "production",
-                "error": "failed to start container: image not found",
-                "host_id": "host-1",
-                "service_id": "mcp-server",
-                "service_instance_id": "mcp-server-host-1",
-                "state": "running",
-                "status": {
-                  "addresses": [
-                    "10.24.34.2",
-                    "i-0123456789abcdef.ec2.internal"
-                  ],
-                  "container_id": "a1b2c3d4e5f6",
-                  "health_check": {
-                    "checked_at": "2025-01-28T10:00:00Z",
-                    "message": "Connection refused",
-                    "status": "healthy"
-                  },
-                  "image_version": "1.0.0",
-                  "last_health_at": "2025-01-28T10:00:00Z",
-                  "ports": [
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
                     },
                     {
                       "container_port": 8080,
@@ -7061,38 +7066,6 @@
                       "host_port": 8080,
                       "name": "web-client"
                     },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    }
-                  ],
-                  "service_ready": true
-                },
-                "updated_at": "2025-01-28T10:05:00Z"
-              },
-              {
-                "created_at": "2025-01-28T10:00:00Z",
-                "database_id": "production",
-                "error": "failed to start container: image not found",
-                "host_id": "host-1",
-                "service_id": "mcp-server",
-                "service_instance_id": "mcp-server-host-1",
-                "state": "running",
-                "status": {
-                  "addresses": [
-                    "10.24.34.2",
-                    "i-0123456789abcdef.ec2.internal"
-                  ],
-                  "container_id": "a1b2c3d4e5f6",
-                  "health_check": {
-                    "checked_at": "2025-01-28T10:00:00Z",
-                    "message": "Connection refused",
-                    "status": "healthy"
-                  },
-                  "image_version": "1.0.0",
-                  "last_health_at": "2025-01-28T10:00:00Z",
-                  "ports": [
                     {
                       "container_port": 8080,
                       "host_port": 8080,
@@ -7116,7 +7089,7 @@
           "state": {
             "type": "string",
             "description": "Current state of the database.",
-            "example": "modifying",
+            "example": "available",
             "enum": [
               "creating",
               "modifying",
@@ -7416,6 +7389,51 @@
                 "state": "available",
                 "status_updated_at": "1993-04-25T23:06:28Z",
                 "updated_at": "1981-08-22T23:20:01Z"
+              },
+              {
+                "connection_info": {
+                  "addresses": [
+                    "10.24.34.2",
+                    "i-0123456789abcdef.ec2.internal"
+                  ],
+                  "port": 5432
+                },
+                "created_at": "2011-03-15T17:48:48Z",
+                "error": "failed to get patroni status: connection refused",
+                "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+                "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
+                "node_name": "n1",
+                "postgres": {
+                  "patroni_paused": false,
+                  "patroni_state": "unknown",
+                  "pending_restart": true,
+                  "role": "primary",
+                  "version": "18.1"
+                },
+                "spock": {
+                  "read_only": "off",
+                  "subscriptions": [
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    },
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    },
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    }
+                  ],
+                  "version": "4.10.0"
+                },
+                "state": "available",
+                "status_updated_at": "1993-04-25T23:06:28Z",
+                "updated_at": "1981-08-22T23:20:01Z"
               }
             ]
           },
@@ -7426,6 +7444,53 @@
             },
             "description": "Service instances running alongside this database.",
             "example": [
+              {
+                "created_at": "2025-01-28T10:00:00Z",
+                "database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "error": "failed to start container: image not found",
+                "host_id": "host-1",
+                "service_id": "mcp-server",
+                "service_instance_id": "mcp-server-host-1",
+                "state": "running",
+                "status": {
+                  "addresses": [
+                    "10.24.34.2",
+                    "i-0123456789abcdef.ec2.internal"
+                  ],
+                  "container_id": "a1b2c3d4e5f6",
+                  "health_check": {
+                    "checked_at": "2025-01-28T10:00:00Z",
+                    "message": "Connection refused",
+                    "status": "healthy"
+                  },
+                  "image_version": "1.0.0",
+                  "last_health_at": "2025-01-28T10:00:00Z",
+                  "ports": [
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    }
+                  ],
+                  "service_ready": true
+                },
+                "updated_at": "2025-01-28T10:05:00Z"
+              },
               {
                 "created_at": "2025-01-28T10:00:00Z",
                 "database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
@@ -8023,100 +8088,6 @@
                   "service_ready": true
                 },
                 "updated_at": "2025-01-28T10:05:00Z"
-              },
-              {
-                "created_at": "2025-01-28T10:00:00Z",
-                "database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "error": "failed to start container: image not found",
-                "host_id": "host-1",
-                "service_id": "mcp-server",
-                "service_instance_id": "mcp-server-host-1",
-                "state": "running",
-                "status": {
-                  "addresses": [
-                    "10.24.34.2",
-                    "i-0123456789abcdef.ec2.internal"
-                  ],
-                  "container_id": "a1b2c3d4e5f6",
-                  "health_check": {
-                    "checked_at": "2025-01-28T10:00:00Z",
-                    "message": "Connection refused",
-                    "status": "healthy"
-                  },
-                  "image_version": "1.0.0",
-                  "last_health_at": "2025-01-28T10:00:00Z",
-                  "ports": [
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    }
-                  ],
-                  "service_ready": true
-                },
-                "updated_at": "2025-01-28T10:05:00Z"
-              },
-              {
-                "created_at": "2025-01-28T10:00:00Z",
-                "database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "error": "failed to start container: image not found",
-                "host_id": "host-1",
-                "service_id": "mcp-server",
-                "service_instance_id": "mcp-server-host-1",
-                "state": "running",
-                "status": {
-                  "addresses": [
-                    "10.24.34.2",
-                    "i-0123456789abcdef.ec2.internal"
-                  ],
-                  "container_id": "a1b2c3d4e5f6",
-                  "health_check": {
-                    "checked_at": "2025-01-28T10:00:00Z",
-                    "message": "Connection refused",
-                    "status": "healthy"
-                  },
-                  "image_version": "1.0.0",
-                  "last_health_at": "2025-01-28T10:00:00Z",
-                  "ports": [
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    }
-                  ],
-                  "service_ready": true
-                },
-                "updated_at": "2025-01-28T10:05:00Z"
               }
             ]
           },
@@ -8126,7 +8097,7 @@
           "state": {
             "type": "string",
             "description": "Current state of the database.",
-            "example": "unknown",
+            "example": "degraded",
             "enum": [
               "creating",
               "modifying",
@@ -8471,6 +8442,51 @@
                 "state": "available",
                 "status_updated_at": "1993-04-25T23:06:28Z",
                 "updated_at": "1981-08-22T23:20:01Z"
+              },
+              {
+                "connection_info": {
+                  "addresses": [
+                    "10.24.34.2",
+                    "i-0123456789abcdef.ec2.internal"
+                  ],
+                  "port": 5432
+                },
+                "created_at": "2011-03-15T17:48:48Z",
+                "error": "failed to get patroni status: connection refused",
+                "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+                "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
+                "node_name": "n1",
+                "postgres": {
+                  "patroni_paused": false,
+                  "patroni_state": "unknown",
+                  "pending_restart": true,
+                  "role": "primary",
+                  "version": "18.1"
+                },
+                "spock": {
+                  "read_only": "off",
+                  "subscriptions": [
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    },
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    },
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    }
+                  ],
+                  "version": "4.10.0"
+                },
+                "state": "available",
+                "status_updated_at": "1993-04-25T23:06:28Z",
+                "updated_at": "1981-08-22T23:20:01Z"
               }
             ]
           },
@@ -8574,6 +8590,100 @@
                   "service_ready": true
                 },
                 "updated_at": "2025-01-28T10:05:00Z"
+              },
+              {
+                "created_at": "2025-01-28T10:00:00Z",
+                "database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "error": "failed to start container: image not found",
+                "host_id": "host-1",
+                "service_id": "mcp-server",
+                "service_instance_id": "mcp-server-host-1",
+                "state": "running",
+                "status": {
+                  "addresses": [
+                    "10.24.34.2",
+                    "i-0123456789abcdef.ec2.internal"
+                  ],
+                  "container_id": "a1b2c3d4e5f6",
+                  "health_check": {
+                    "checked_at": "2025-01-28T10:00:00Z",
+                    "message": "Connection refused",
+                    "status": "healthy"
+                  },
+                  "image_version": "1.0.0",
+                  "last_health_at": "2025-01-28T10:00:00Z",
+                  "ports": [
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    }
+                  ],
+                  "service_ready": true
+                },
+                "updated_at": "2025-01-28T10:05:00Z"
+              },
+              {
+                "created_at": "2025-01-28T10:00:00Z",
+                "database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "error": "failed to start container: image not found",
+                "host_id": "host-1",
+                "service_id": "mcp-server",
+                "service_instance_id": "mcp-server-host-1",
+                "state": "running",
+                "status": {
+                  "addresses": [
+                    "10.24.34.2",
+                    "i-0123456789abcdef.ec2.internal"
+                  ],
+                  "container_id": "a1b2c3d4e5f6",
+                  "health_check": {
+                    "checked_at": "2025-01-28T10:00:00Z",
+                    "message": "Connection refused",
+                    "status": "healthy"
+                  },
+                  "image_version": "1.0.0",
+                  "last_health_at": "2025-01-28T10:00:00Z",
+                  "ports": [
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    }
+                  ],
+                  "service_ready": true
+                },
+                "updated_at": "2025-01-28T10:05:00Z"
               }
             ]
           },
@@ -8583,7 +8693,7 @@
           "state": {
             "type": "string",
             "description": "Current state of the database.",
-            "example": "unknown",
+            "example": "modifying",
             "enum": [
               "creating",
               "modifying",
@@ -9076,53 +9186,6 @@
                   "service_ready": true
                 },
                 "updated_at": "2025-01-28T10:05:00Z"
-              },
-              {
-                "created_at": "2025-01-28T10:00:00Z",
-                "database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "error": "failed to start container: image not found",
-                "host_id": "host-1",
-                "service_id": "mcp-server",
-                "service_instance_id": "mcp-server-host-1",
-                "state": "running",
-                "status": {
-                  "addresses": [
-                    "10.24.34.2",
-                    "i-0123456789abcdef.ec2.internal"
-                  ],
-                  "container_id": "a1b2c3d4e5f6",
-                  "health_check": {
-                    "checked_at": "2025-01-28T10:00:00Z",
-                    "message": "Connection refused",
-                    "status": "healthy"
-                  },
-                  "image_version": "1.0.0",
-                  "last_health_at": "2025-01-28T10:00:00Z",
-                  "ports": [
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    }
-                  ],
-                  "service_ready": true
-                },
-                "updated_at": "2025-01-28T10:05:00Z"
               }
             ]
           },
@@ -9132,7 +9195,7 @@
           "state": {
             "type": "string",
             "description": "Current state of the database.",
-            "example": "restoring",
+            "example": "unknown",
             "enum": [
               "creating",
               "modifying",
@@ -9463,6 +9526,29 @@
                 "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                 "s3_region": "us-east-1",
                 "type": "s3"
+              },
+              {
+                "azure_account": "pgedge-backups",
+                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "azure_endpoint": "blob.core.usgovcloudapi.net",
+                "azure_key": "YXpLZXk=",
+                "base_path": "/backups",
+                "custom_options": {
+                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                  "storage-upload-chunk-size": "5MiB"
+                },
+                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "gcs_endpoint": "localhost",
+                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                "id": "f6b84a99-5e91-4203-be1e-131fe82e5984",
+                "retention_full": 2,
+                "retention_full_type": "count",
+                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "s3_region": "us-east-1",
+                "type": "s3"
               }
             ],
             "schedules": [
@@ -9609,7 +9695,6 @@
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
@@ -9762,6 +9847,8 @@
           },
           "cpus": "500m",
           "host_ids": [
+            "76f9b8c0-4958-11f0-a489-3bb29577c696",
+            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "500M",
@@ -10039,6 +10126,7 @@
           "cpus": "500m",
           "host_ids": [
             "76f9b8c0-4958-11f0-a489-3bb29577c696",
+            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "500M",
@@ -10162,6 +10250,7 @@
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
+              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
@@ -10314,8 +10403,6 @@
           },
           "cpus": "500m",
           "host_ids": [
-            "76f9b8c0-4958-11f0-a489-3bb29577c696",
-            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "500M",
@@ -10439,6 +10526,8 @@
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
+              "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -10590,7 +10679,6 @@
           },
           "cpus": "500m",
           "host_ids": [
-            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
@@ -10868,7 +10956,6 @@
           "cpus": "500m",
           "host_ids": [
             "76f9b8c0-4958-11f0-a489-3bb29577c696",
-            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "500M",
@@ -10992,7 +11079,6 @@
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -11145,7 +11231,6 @@
           "cpus": "500m",
           "host_ids": [
             "76f9b8c0-4958-11f0-a489-3bb29577c696",
-            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "500M",
@@ -11247,6 +11332,27 @@
           "host_ids"
         ]
       },
+      "DatabaseScripts": {
+        "type": "object",
+        "properties": {
+          "post_database_create": {
+            "$ref": "#/components/schemas/SQLScript"
+          },
+          "post_init": {
+            "$ref": "#/components/schemas/SQLScript"
+          }
+        },
+        "example": {
+          "post_database_create": [
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+            "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+          ],
+          "post_init": [
+            "CREATE ROLE accounting_admin NOLOGIN"
+          ]
+        }
+      },
       "DatabaseSpec": {
         "type": "object",
         "properties": {
@@ -11279,7 +11385,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -11292,7 +11398,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -11305,7 +11411,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -11353,270 +11459,7 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
                     },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
-                },
-                "cpus": "500m",
-                "host_ids": [
-                  "de3b1388-1f0c-42f1-a86c-59ab72f255ec"
-                ],
-                "memory": "500M",
-                "name": "n1",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ]
-                  }
-                },
-                "patroni_port": 8888,
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "f6b84a99-5e91-4203-be1e-131fe82e5984",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "02f1a7db-fca8-4521-b57a-2a375c1ced51",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
-              },
-              {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "f6b84a99-5e91-4203-be1e-131fe82e5984",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
-                },
-                "cpus": "500m",
-                "host_ids": [
-                  "de3b1388-1f0c-42f1-a86c-59ab72f255ec"
-                ],
-                "memory": "500M",
-                "name": "n1",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ]
-                  }
-                },
-                "patroni_port": 8888,
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "f6b84a99-5e91-4203-be1e-131fe82e5984",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "02f1a7db-fca8-4521-b57a-2a375c1ced51",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
-              },
-              {
-                "backup_config": {
-                  "repositories": [
                     {
                       "azure_account": "pgedge-backups",
                       "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -11797,6 +11640,9 @@
           },
           "restore_config": {
             "$ref": "#/components/schemas/RestoreConfigSpec"
+          },
+          "scripts": {
+            "$ref": "#/components/schemas/DatabaseScripts"
           },
           "services": {
             "type": "array",
@@ -11997,6 +11843,29 @@
                 "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                 "s3_region": "us-east-1",
                 "type": "s3"
+              },
+              {
+                "azure_account": "pgedge-backups",
+                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "azure_endpoint": "blob.core.usgovcloudapi.net",
+                "azure_key": "YXpLZXk=",
+                "base_path": "/backups",
+                "custom_options": {
+                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                  "storage-upload-chunk-size": "5MiB"
+                },
+                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "gcs_endpoint": "localhost",
+                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                "id": "f6b84a99-5e91-4203-be1e-131fe82e5984",
+                "retention_full": 2,
+                "retention_full_type": "count",
+                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "s3_region": "us-east-1",
+                "type": "s3"
               }
             ],
             "schedules": [
@@ -12026,7 +11895,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -12039,7 +11908,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -12052,7 +11921,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -12087,270 +11956,7 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
-                  }
-                ],
-                "schedules": [
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
                   },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  }
-                ]
-              },
-              "cpus": "500m",
-              "host_ids": [
-                "de3b1388-1f0c-42f1-a86c-59ab72f255ec"
-              ],
-              "memory": "500M",
-              "name": "n1",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ]
-                }
-              },
-              "patroni_port": 8888,
-              "port": 5432,
-              "postgres_version": "17.6",
-              "postgresql_conf": {
-                "max_connections": 1000
-              },
-              "restore_config": {
-                "repository": {
-                  "azure_account": "pgedge-backups",
-                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "azure_endpoint": "blob.core.usgovcloudapi.net",
-                  "azure_key": "YXpLZXk=",
-                  "base_path": "/backups",
-                  "custom_options": {
-                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                  },
-                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "gcs_endpoint": "localhost",
-                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                  "id": "f6b84a99-5e91-4203-be1e-131fe82e5984",
-                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                  "s3_region": "us-east-1",
-                  "type": "s3"
-                },
-                "restore_options": {
-                  "set": "20250505-153628F",
-                  "target": "123456",
-                  "type": "xid"
-                },
-                "source_database_id": "02f1a7db-fca8-4521-b57a-2a375c1ced51",
-                "source_database_name": "northwind",
-                "source_node_name": "n1"
-              },
-              "source_node": "n1"
-            },
-            {
-              "backup_config": {
-                "repositories": [
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "f6b84a99-5e91-4203-be1e-131fe82e5984",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  }
-                ],
-                "schedules": [
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  }
-                ]
-              },
-              "cpus": "500m",
-              "host_ids": [
-                "de3b1388-1f0c-42f1-a86c-59ab72f255ec"
-              ],
-              "memory": "500M",
-              "name": "n1",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ]
-                }
-              },
-              "patroni_port": 8888,
-              "port": 5432,
-              "postgres_version": "17.6",
-              "postgresql_conf": {
-                "max_connections": 1000
-              },
-              "restore_config": {
-                "repository": {
-                  "azure_account": "pgedge-backups",
-                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "azure_endpoint": "blob.core.usgovcloudapi.net",
-                  "azure_key": "YXpLZXk=",
-                  "base_path": "/backups",
-                  "custom_options": {
-                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                  },
-                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "gcs_endpoint": "localhost",
-                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                  "id": "f6b84a99-5e91-4203-be1e-131fe82e5984",
-                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                  "s3_region": "us-east-1",
-                  "type": "s3"
-                },
-                "restore_options": {
-                  "set": "20250505-153628F",
-                  "target": "123456",
-                  "type": "xid"
-                },
-                "source_database_id": "02f1a7db-fca8-4521-b57a-2a375c1ced51",
-                "source_database_name": "northwind",
-                "source_node_name": "n1"
-              },
-              "source_node": "n1"
-            },
-            {
-              "backup_config": {
-                "repositories": [
                   {
                     "azure_account": "pgedge-backups",
                     "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -12581,6 +12187,16 @@
             "source_database_id": "02f1a7db-fca8-4521-b57a-2a375c1ced51",
             "source_database_name": "northwind",
             "source_node_name": "n1"
+          },
+          "scripts": {
+            "post_database_create": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ],
+            "post_init": [
+              "CREATE ROLE accounting_admin NOLOGIN"
+            ]
           },
           "services": [
             {
@@ -13369,106 +12985,77 @@
                   "source_node_name": "n1"
                 },
                 "source_node": "n1"
-              },
+              }
+            ],
+            "minItems": 1,
+            "maxItems": 9
+          },
+          "orchestrator_opts": {
+            "$ref": "#/components/schemas/OrchestratorOpts"
+          },
+          "patroni_port": {
+            "type": "integer",
+            "description": "The port used by Patroni for this database. If the port is 0, each instance will be assigned a random port. NOTE: This field is not currently supported for Docker Swarm.",
+            "example": 8888,
+            "format": "int64",
+            "minimum": 0,
+            "maximum": 65535
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port used by the Postgres database. If the port is 0, each instance will be assigned a random port. If the port is unspecified, the database will not be exposed on any port, dependent on orchestrator support for that feature.",
+            "example": 5432,
+            "format": "int64",
+            "minimum": 0,
+            "maximum": 65535
+          },
+          "postgres_version": {
+            "type": "string",
+            "description": "The Postgres version in 'major.minor' format.",
+            "example": "17.6",
+            "pattern": "^\\d{2}\\.\\d{1,2}$"
+          },
+          "postgresql_conf": {
+            "type": "object",
+            "description": "Additional postgresql.conf settings. Will be merged with the settings provided by control-plane.",
+            "example": {
+              "max_connections": 1000
+            },
+            "maxLength": 64,
+            "additionalProperties": true
+          },
+          "restore_config": {
+            "$ref": "#/components/schemas/RestoreConfigSpec"
+          },
+          "scripts": {
+            "$ref": "#/components/schemas/DatabaseScripts"
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceSpec2"
+            },
+            "description": "Service instances to run alongside the database (e.g., MCP servers).",
+            "example": [
               {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
+                "config": {
+                  "llm_model": "gpt-4",
+                  "llm_provider": "openai",
+                  "openai_api_key": "sk-..."
                 },
                 "cpus": "500m",
+                "database_connection": {
+                  "target_nodes": [
+                    "n1",
+                    "n2"
+                  ],
+                  "target_session_attrs": "primary"
+                },
                 "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
-                "memory": "500M",
-                "name": "n1",
+                "memory": "512M",
                 "orchestrator_opts": {
                   "swarm": {
                     "extra_labels": {
@@ -13523,92 +13110,11 @@
                     ]
                   }
                 },
-                "patroni_port": 8888,
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
-              }
-            ],
-            "minItems": 1,
-            "maxItems": 9
-          },
-          "orchestrator_opts": {
-            "$ref": "#/components/schemas/OrchestratorOpts"
-          },
-          "patroni_port": {
-            "type": "integer",
-            "description": "The port used by Patroni for this database. If the port is 0, each instance will be assigned a random port. NOTE: This field is not currently supported for Docker Swarm.",
-            "example": 8888,
-            "format": "int64",
-            "minimum": 0,
-            "maximum": 65535
-          },
-          "port": {
-            "type": "integer",
-            "description": "The port used by the Postgres database. If the port is 0, each instance will be assigned a random port. If the port is unspecified, the database will not be exposed on any port, dependent on orchestrator support for that feature.",
-            "example": 5432,
-            "format": "int64",
-            "minimum": 0,
-            "maximum": 65535
-          },
-          "postgres_version": {
-            "type": "string",
-            "description": "The Postgres version in 'major.minor' format.",
-            "example": "17.6",
-            "pattern": "^\\d{2}\\.\\d{1,2}$"
-          },
-          "postgresql_conf": {
-            "type": "object",
-            "description": "Additional postgresql.conf settings. Will be merged with the settings provided by control-plane.",
-            "example": {
-              "max_connections": 1000
-            },
-            "maxLength": 64,
-            "additionalProperties": true
-          },
-          "restore_config": {
-            "$ref": "#/components/schemas/RestoreConfigSpec"
-          },
-          "services": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ServiceSpec2"
-            },
-            "description": "Service instances to run alongside the database (e.g., MCP servers).",
-            "example": [
+                "port": 0,
+                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "service_type": "rag",
+                "version": "latest"
+              },
               {
                 "config": {
                   "llm_model": "gpt-4",
@@ -14369,197 +13875,6 @@
                 "source_node_name": "n1"
               },
               "source_node": "n1"
-            },
-            {
-              "backup_config": {
-                "repositories": [
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  }
-                ],
-                "schedules": [
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  }
-                ]
-              },
-              "cpus": "500m",
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "500M",
-              "name": "n1",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ]
-                }
-              },
-              "patroni_port": 8888,
-              "port": 5432,
-              "postgres_version": "17.6",
-              "postgresql_conf": {
-                "max_connections": 1000
-              },
-              "restore_config": {
-                "repository": {
-                  "azure_account": "pgedge-backups",
-                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "azure_endpoint": "blob.core.usgovcloudapi.net",
-                  "azure_key": "YXpLZXk=",
-                  "base_path": "/backups",
-                  "custom_options": {
-                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                  },
-                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "gcs_endpoint": "localhost",
-                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                  "s3_region": "us-east-1",
-                  "type": "s3"
-                },
-                "restore_options": {
-                  "set": "20250505-153628F",
-                  "target": "123456",
-                  "type": "xid"
-                },
-                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "source_database_name": "northwind",
-                "source_node_name": "n1"
-              },
-              "source_node": "n1"
             }
           ],
           "orchestrator_opts": {
@@ -14651,6 +13966,18 @@
             "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "source_database_name": "northwind",
             "source_node_name": "n1"
+          },
+          "scripts": {
+            "post_database_create": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ],
+            "post_init": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ]
           },
           "services": [
             {
@@ -15433,196 +14760,6 @@
                   "source_node_name": "n1"
                 },
                 "source_node": "n1"
-              },
-              {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
-                },
-                "cpus": "500m",
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "500M",
-                "name": "n1",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ]
-                  }
-                },
-                "patroni_port": 8888,
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
               }
             ],
             "minItems": 1,
@@ -15664,6 +14801,9 @@
           },
           "restore_config": {
             "$ref": "#/components/schemas/RestoreConfigSpec"
+          },
+          "scripts": {
+            "$ref": "#/components/schemas/DatabaseScripts"
           },
           "services": {
             "type": "array",
@@ -16712,85 +15852,19 @@
             "source_database_name": "northwind",
             "source_node_name": "n1"
           },
+          "scripts": {
+            "post_database_create": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ],
+            "post_init": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ]
+          },
           "services": [
-            {
-              "config": {
-                "llm_model": "gpt-4",
-                "llm_provider": "openai",
-                "openai_api_key": "sk-..."
-              },
-              "cpus": "500m",
-              "database_connection": {
-                "target_nodes": [
-                  "n1",
-                  "n2"
-                ],
-                "target_session_attrs": "primary"
-              },
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "512M",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ]
-                }
-              },
-              "port": 0,
-              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "service_type": "rag",
-              "version": "latest"
-            },
             {
               "config": {
                 "llm_model": "gpt-4",
@@ -17493,196 +16567,6 @@
                   "source_node_name": "n1"
                 },
                 "source_node": "n1"
-              },
-              {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
-                },
-                "cpus": "500m",
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "500M",
-                "name": "n1",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ]
-                  }
-                },
-                "patroni_port": 8888,
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
               }
             ],
             "minItems": 1,
@@ -17724,6 +16608,9 @@
           },
           "restore_config": {
             "$ref": "#/components/schemas/RestoreConfigSpec"
+          },
+          "scripts": {
+            "$ref": "#/components/schemas/DatabaseScripts"
           },
           "services": {
             "type": "array",
@@ -18568,196 +17455,6 @@
                 "source_node_name": "n1"
               },
               "source_node": "n1"
-            },
-            {
-              "backup_config": {
-                "repositories": [
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  }
-                ],
-                "schedules": [
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  }
-                ]
-              },
-              "cpus": "500m",
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "500M",
-              "name": "n1",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ]
-                }
-              },
-              "patroni_port": 8888,
-              "port": 5432,
-              "postgres_version": "17.6",
-              "postgresql_conf": {
-                "max_connections": 1000
-              },
-              "restore_config": {
-                "repository": {
-                  "azure_account": "pgedge-backups",
-                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "azure_endpoint": "blob.core.usgovcloudapi.net",
-                  "azure_key": "YXpLZXk=",
-                  "base_path": "/backups",
-                  "custom_options": {
-                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                  },
-                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "gcs_endpoint": "localhost",
-                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                  "s3_region": "us-east-1",
-                  "type": "s3"
-                },
-                "restore_options": {
-                  "set": "20250505-153628F",
-                  "target": "123456",
-                  "type": "xid"
-                },
-                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "source_database_name": "northwind",
-                "source_node_name": "n1"
-              },
-              "source_node": "n1"
             }
           ],
           "orchestrator_opts": {
@@ -18849,6 +17546,18 @@
             "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "source_database_name": "northwind",
             "source_node_name": "n1"
+          },
+          "scripts": {
+            "post_database_create": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ],
+            "post_init": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ]
           },
           "services": [
             {
@@ -19441,105 +18150,76 @@
                   "source_node_name": "n1"
                 },
                 "source_node": "n1"
-              },
+              }
+            ],
+            "minItems": 1,
+            "maxItems": 9
+          },
+          "orchestrator_opts": {
+            "$ref": "#/components/schemas/OrchestratorOpts"
+          },
+          "patroni_port": {
+            "type": "integer",
+            "description": "The port used by Patroni for this database. If the port is 0, each instance will be assigned a random port. NOTE: This field is not currently supported for Docker Swarm.",
+            "example": 8888,
+            "format": "int64",
+            "minimum": 0,
+            "maximum": 65535
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port used by the Postgres database. If the port is 0, each instance will be assigned a random port. If the port is unspecified, the database will not be exposed on any port, dependent on orchestrator support for that feature.",
+            "example": 5432,
+            "format": "int64",
+            "minimum": 0,
+            "maximum": 65535
+          },
+          "postgres_version": {
+            "type": "string",
+            "description": "The Postgres version in 'major.minor' format.",
+            "example": "17.6",
+            "pattern": "^\\d{2}\\.\\d{1,2}$"
+          },
+          "postgresql_conf": {
+            "type": "object",
+            "description": "Additional postgresql.conf settings. Will be merged with the settings provided by control-plane.",
+            "example": {
+              "max_connections": 1000
+            },
+            "maxLength": 64,
+            "additionalProperties": true
+          },
+          "restore_config": {
+            "$ref": "#/components/schemas/RestoreConfigSpec"
+          },
+          "scripts": {
+            "$ref": "#/components/schemas/DatabaseScripts"
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceSpec5"
+            },
+            "description": "Service instances to run alongside the database (e.g., MCP servers).",
+            "example": [
               {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
+                "config": {
+                  "llm_model": "gpt-4",
+                  "llm_provider": "openai",
+                  "openai_api_key": "sk-..."
                 },
                 "cpus": "500m",
+                "database_connection": {
+                  "target_nodes": [
+                    "n1",
+                    "n2"
+                  ],
+                  "target_session_attrs": "primary"
+                },
                 "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
-                "memory": "500M",
-                "name": "n1",
+                "memory": "512M",
                 "orchestrator_opts": {
                   "swarm": {
                     "extra_labels": {
@@ -19594,92 +18274,11 @@
                     ]
                   }
                 },
-                "patroni_port": 8888,
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
-              }
-            ],
-            "minItems": 1,
-            "maxItems": 9
-          },
-          "orchestrator_opts": {
-            "$ref": "#/components/schemas/OrchestratorOpts"
-          },
-          "patroni_port": {
-            "type": "integer",
-            "description": "The port used by Patroni for this database. If the port is 0, each instance will be assigned a random port. NOTE: This field is not currently supported for Docker Swarm.",
-            "example": 8888,
-            "format": "int64",
-            "minimum": 0,
-            "maximum": 65535
-          },
-          "port": {
-            "type": "integer",
-            "description": "The port used by the Postgres database. If the port is 0, each instance will be assigned a random port. If the port is unspecified, the database will not be exposed on any port, dependent on orchestrator support for that feature.",
-            "example": 5432,
-            "format": "int64",
-            "minimum": 0,
-            "maximum": 65535
-          },
-          "postgres_version": {
-            "type": "string",
-            "description": "The Postgres version in 'major.minor' format.",
-            "example": "17.6",
-            "pattern": "^\\d{2}\\.\\d{1,2}$"
-          },
-          "postgresql_conf": {
-            "type": "object",
-            "description": "Additional postgresql.conf settings. Will be merged with the settings provided by control-plane.",
-            "example": {
-              "max_connections": 1000
-            },
-            "maxLength": 64,
-            "additionalProperties": true
-          },
-          "restore_config": {
-            "$ref": "#/components/schemas/RestoreConfigSpec"
-          },
-          "services": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ServiceSpec5"
-            },
-            "description": "Service instances to run alongside the database (e.g., MCP servers).",
-            "example": [
+                "port": 0,
+                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "service_type": "rag",
+                "version": "latest"
+              },
               {
                 "config": {
                   "llm_model": "gpt-4",
@@ -20168,196 +18767,6 @@
                 "source_node_name": "n1"
               },
               "source_node": "n1"
-            },
-            {
-              "backup_config": {
-                "repositories": [
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  }
-                ],
-                "schedules": [
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  }
-                ]
-              },
-              "cpus": "500m",
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "500M",
-              "name": "n1",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ]
-                }
-              },
-              "patroni_port": 8888,
-              "port": 5432,
-              "postgres_version": "17.6",
-              "postgresql_conf": {
-                "max_connections": 1000
-              },
-              "restore_config": {
-                "repository": {
-                  "azure_account": "pgedge-backups",
-                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "azure_endpoint": "blob.core.usgovcloudapi.net",
-                  "azure_key": "YXpLZXk=",
-                  "base_path": "/backups",
-                  "custom_options": {
-                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                  },
-                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "gcs_endpoint": "localhost",
-                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                  "s3_region": "us-east-1",
-                  "type": "s3"
-                },
-                "restore_options": {
-                  "set": "20250505-153628F",
-                  "target": "123456",
-                  "type": "xid"
-                },
-                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "source_database_name": "northwind",
-                "source_node_name": "n1"
-              },
-              "source_node": "n1"
             }
           ],
           "orchestrator_opts": {
@@ -20450,84 +18859,19 @@
             "source_database_name": "northwind",
             "source_node_name": "n1"
           },
+          "scripts": {
+            "post_database_create": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ],
+            "post_init": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ]
+          },
           "services": [
-            {
-              "config": {
-                "llm_model": "gpt-4",
-                "llm_provider": "openai",
-                "openai_api_key": "sk-..."
-              },
-              "cpus": "500m",
-              "database_connection": {
-                "target_nodes": [
-                  "n1",
-                  "n2"
-                ],
-                "target_session_attrs": "primary"
-              },
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "512M",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ]
-                }
-              },
-              "port": 0,
-              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "service_type": "rag",
-              "version": "latest"
-            },
             {
               "config": {
                 "llm_model": "gpt-4",
@@ -21037,386 +19381,6 @@
                   "source_node_name": "n1"
                 },
                 "source_node": "n1"
-              },
-              {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
-                },
-                "cpus": "500m",
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "500M",
-                "name": "n1",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ]
-                  }
-                },
-                "patroni_port": 8888,
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
-              },
-              {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
-                },
-                "cpus": "500m",
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "500M",
-                "name": "n1",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ]
-                  }
-                },
-                "patroni_port": 8888,
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
               }
             ],
             "minItems": 1,
@@ -21459,6 +19423,9 @@
           "restore_config": {
             "$ref": "#/components/schemas/RestoreConfigSpec"
           },
+          "scripts": {
+            "$ref": "#/components/schemas/DatabaseScripts"
+          },
           "services": {
             "type": "array",
             "items": {
@@ -21466,162 +19433,6 @@
             },
             "description": "Service instances to run alongside the database (e.g., MCP servers).",
             "example": [
-              {
-                "config": {
-                  "llm_model": "gpt-4",
-                  "llm_provider": "openai",
-                  "openai_api_key": "sk-..."
-                },
-                "cpus": "500m",
-                "database_connection": {
-                  "target_nodes": [
-                    "n1",
-                    "n2"
-                  ],
-                  "target_session_attrs": "primary"
-                },
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "512M",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ]
-                  }
-                },
-                "port": 0,
-                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "service_type": "rag",
-                "version": "latest"
-              },
-              {
-                "config": {
-                  "llm_model": "gpt-4",
-                  "llm_provider": "openai",
-                  "openai_api_key": "sk-..."
-                },
-                "cpus": "500m",
-                "database_connection": {
-                  "target_nodes": [
-                    "n1",
-                    "n2"
-                  ],
-                  "target_session_attrs": "primary"
-                },
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "512M",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ]
-                  }
-                },
-                "port": 0,
-                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "service_type": "rag",
-                "version": "latest"
-              },
               {
                 "config": {
                   "llm_model": "gpt-4",
@@ -22112,196 +19923,6 @@
                 "source_node_name": "n1"
               },
               "source_node": "n1"
-            },
-            {
-              "backup_config": {
-                "repositories": [
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  }
-                ],
-                "schedules": [
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  }
-                ]
-              },
-              "cpus": "500m",
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "500M",
-              "name": "n1",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ]
-                }
-              },
-              "patroni_port": 8888,
-              "port": 5432,
-              "postgres_version": "17.6",
-              "postgresql_conf": {
-                "max_connections": 1000
-              },
-              "restore_config": {
-                "repository": {
-                  "azure_account": "pgedge-backups",
-                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "azure_endpoint": "blob.core.usgovcloudapi.net",
-                  "azure_key": "YXpLZXk=",
-                  "base_path": "/backups",
-                  "custom_options": {
-                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                  },
-                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "gcs_endpoint": "localhost",
-                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                  "s3_region": "us-east-1",
-                  "type": "s3"
-                },
-                "restore_options": {
-                  "set": "20250505-153628F",
-                  "target": "123456",
-                  "type": "xid"
-                },
-                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "source_database_name": "northwind",
-                "source_node_name": "n1"
-              },
-              "source_node": "n1"
             }
           ],
           "orchestrator_opts": {
@@ -22394,7 +20015,97 @@
             "source_database_name": "northwind",
             "source_node_name": "n1"
           },
+          "scripts": {
+            "post_database_create": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ],
+            "post_init": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ]
+          },
           "services": [
+            {
+              "config": {
+                "llm_model": "gpt-4",
+                "llm_provider": "openai",
+                "openai_api_key": "sk-..."
+              },
+              "cpus": "500m",
+              "database_connection": {
+                "target_nodes": [
+                  "n1",
+                  "n2"
+                ],
+                "target_session_attrs": "primary"
+              },
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "512M",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ]
+                }
+              },
+              "port": 0,
+              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "service_type": "rag",
+              "version": "latest"
+            },
             {
               "config": {
                 "llm_model": "gpt-4",
@@ -23097,196 +20808,6 @@
                   "source_node_name": "n1"
                 },
                 "source_node": "n1"
-              },
-              {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
-                },
-                "cpus": "500m",
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "500M",
-                "name": "n1",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ]
-                  }
-                },
-                "patroni_port": 8888,
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
               }
             ],
             "minItems": 1,
@@ -23328,6 +20849,9 @@
           },
           "restore_config": {
             "$ref": "#/components/schemas/RestoreConfigSpec"
+          },
+          "scripts": {
+            "$ref": "#/components/schemas/DatabaseScripts"
           },
           "services": {
             "type": "array",
@@ -23826,386 +21350,6 @@
                 "source_node_name": "n1"
               },
               "source_node": "n1"
-            },
-            {
-              "backup_config": {
-                "repositories": [
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  }
-                ],
-                "schedules": [
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  }
-                ]
-              },
-              "cpus": "500m",
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "500M",
-              "name": "n1",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ]
-                }
-              },
-              "patroni_port": 8888,
-              "port": 5432,
-              "postgres_version": "17.6",
-              "postgresql_conf": {
-                "max_connections": 1000
-              },
-              "restore_config": {
-                "repository": {
-                  "azure_account": "pgedge-backups",
-                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "azure_endpoint": "blob.core.usgovcloudapi.net",
-                  "azure_key": "YXpLZXk=",
-                  "base_path": "/backups",
-                  "custom_options": {
-                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                  },
-                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "gcs_endpoint": "localhost",
-                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                  "s3_region": "us-east-1",
-                  "type": "s3"
-                },
-                "restore_options": {
-                  "set": "20250505-153628F",
-                  "target": "123456",
-                  "type": "xid"
-                },
-                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "source_database_name": "northwind",
-                "source_node_name": "n1"
-              },
-              "source_node": "n1"
-            },
-            {
-              "backup_config": {
-                "repositories": [
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  }
-                ],
-                "schedules": [
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  },
-                  {
-                    "cron_expression": "0 6 * * ?",
-                    "id": "daily-full-backup",
-                    "type": "full"
-                  }
-                ]
-              },
-              "cpus": "500m",
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "500M",
-              "name": "n1",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ]
-                }
-              },
-              "patroni_port": 8888,
-              "port": 5432,
-              "postgres_version": "17.6",
-              "postgresql_conf": {
-                "max_connections": 1000
-              },
-              "restore_config": {
-                "repository": {
-                  "azure_account": "pgedge-backups",
-                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "azure_endpoint": "blob.core.usgovcloudapi.net",
-                  "azure_key": "YXpLZXk=",
-                  "base_path": "/backups",
-                  "custom_options": {
-                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                  },
-                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "gcs_endpoint": "localhost",
-                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                  "s3_region": "us-east-1",
-                  "type": "s3"
-                },
-                "restore_options": {
-                  "set": "20250505-153628F",
-                  "target": "123456",
-                  "type": "xid"
-                },
-                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "source_database_name": "northwind",
-                "source_node_name": "n1"
-              },
-              "source_node": "n1"
             }
           ],
           "orchestrator_opts": {
@@ -24298,7 +21442,175 @@
             "source_database_name": "northwind",
             "source_node_name": "n1"
           },
+          "scripts": {
+            "post_database_create": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ],
+            "post_init": [
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+              "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+            ]
+          },
           "services": [
+            {
+              "config": {
+                "llm_model": "gpt-4",
+                "llm_provider": "openai",
+                "openai_api_key": "sk-..."
+              },
+              "cpus": "500m",
+              "database_connection": {
+                "target_nodes": [
+                  "n1",
+                  "n2"
+                ],
+                "target_session_attrs": "primary"
+              },
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "512M",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ]
+                }
+              },
+              "port": 0,
+              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "service_type": "rag",
+              "version": "latest"
+            },
+            {
+              "config": {
+                "llm_model": "gpt-4",
+                "llm_provider": "openai",
+                "openai_api_key": "sk-..."
+              },
+              "cpus": "500m",
+              "database_connection": {
+                "target_nodes": [
+                  "n1",
+                  "n2"
+                ],
+                "target_session_attrs": "primary"
+              },
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "512M",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ]
+                }
+              },
+              "port": 0,
+              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "service_type": "rag",
+              "version": "latest"
+            },
             {
               "config": {
                 "llm_model": "gpt-4",
@@ -24494,13 +21806,13 @@
                   ],
                   "port": 5432
                 },
-                "created_at": "1971-07-18T16:52:12Z",
+                "created_at": "1970-12-24T01:48:39Z",
                 "error": "failed to get patroni status: connection refused",
                 "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                 "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                 "node_name": "n1",
                 "postgres": {
-                  "patroni_paused": false,
+                  "patroni_paused": true,
                   "patroni_state": "unknown",
                   "pending_restart": true,
                   "role": "primary",
@@ -24518,18 +21830,13 @@
                       "name": "sub_n1n2",
                       "provider_node": "n2",
                       "status": "down"
-                    },
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
                     }
                   ],
                   "version": "4.10.0"
                 },
-                "state": "deleting",
-                "status_updated_at": "1999-09-23T18:53:48Z",
-                "updated_at": "2013-04-06T16:38:09Z"
+                "state": "unknown",
+                "status_updated_at": "1978-12-17T01:14:06Z",
+                "updated_at": "2010-08-13T18:38:44Z"
               },
               {
                 "connection_info": {
@@ -24539,13 +21846,13 @@
                   ],
                   "port": 5432
                 },
-                "created_at": "1971-07-18T16:52:12Z",
+                "created_at": "1970-12-24T01:48:39Z",
                 "error": "failed to get patroni status: connection refused",
                 "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                 "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                 "node_name": "n1",
                 "postgres": {
-                  "patroni_paused": false,
+                  "patroni_paused": true,
                   "patroni_state": "unknown",
                   "pending_restart": true,
                   "role": "primary",
@@ -24563,18 +21870,13 @@
                       "name": "sub_n1n2",
                       "provider_node": "n2",
                       "status": "down"
-                    },
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
                     }
                   ],
                   "version": "4.10.0"
                 },
-                "state": "deleting",
-                "status_updated_at": "1999-09-23T18:53:48Z",
-                "updated_at": "2013-04-06T16:38:09Z"
+                "state": "unknown",
+                "status_updated_at": "1978-12-17T01:14:06Z",
+                "updated_at": "2010-08-13T18:38:44Z"
               },
               {
                 "connection_info": {
@@ -24584,13 +21886,13 @@
                   ],
                   "port": 5432
                 },
-                "created_at": "1971-07-18T16:52:12Z",
+                "created_at": "1970-12-24T01:48:39Z",
                 "error": "failed to get patroni status: connection refused",
                 "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                 "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                 "node_name": "n1",
                 "postgres": {
-                  "patroni_paused": false,
+                  "patroni_paused": true,
                   "patroni_state": "unknown",
                   "pending_restart": true,
                   "role": "primary",
@@ -24608,70 +21910,20 @@
                       "name": "sub_n1n2",
                       "provider_node": "n2",
                       "status": "down"
-                    },
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
                     }
                   ],
                   "version": "4.10.0"
                 },
-                "state": "deleting",
-                "status_updated_at": "1999-09-23T18:53:48Z",
-                "updated_at": "2013-04-06T16:38:09Z"
-              },
-              {
-                "connection_info": {
-                  "addresses": [
-                    "10.24.34.2",
-                    "i-0123456789abcdef.ec2.internal"
-                  ],
-                  "port": 5432
-                },
-                "created_at": "1971-07-18T16:52:12Z",
-                "error": "failed to get patroni status: connection refused",
-                "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-                "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-                "node_name": "n1",
-                "postgres": {
-                  "patroni_paused": false,
-                  "patroni_state": "unknown",
-                  "pending_restart": true,
-                  "role": "primary",
-                  "version": "18.1"
-                },
-                "spock": {
-                  "read_only": "off",
-                  "subscriptions": [
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
-                    },
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
-                    },
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
-                    }
-                  ],
-                  "version": "4.10.0"
-                },
-                "state": "deleting",
-                "status_updated_at": "1999-09-23T18:53:48Z",
-                "updated_at": "2013-04-06T16:38:09Z"
+                "state": "unknown",
+                "status_updated_at": "1978-12-17T01:14:06Z",
+                "updated_at": "2010-08-13T18:38:44Z"
               }
             ]
           },
           "state": {
             "type": "string",
             "description": "Current state of the database.",
-            "example": "failed",
+            "example": "backing_up",
             "enum": [
               "creating",
               "modifying",
@@ -24710,13 +21962,13 @@
                 ],
                 "port": 5432
               },
-              "created_at": "1971-07-18T16:52:12Z",
+              "created_at": "1970-12-24T01:48:39Z",
               "error": "failed to get patroni status: connection refused",
               "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
               "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
               "node_name": "n1",
               "postgres": {
-                "patroni_paused": false,
+                "patroni_paused": true,
                 "patroni_state": "unknown",
                 "pending_restart": true,
                 "role": "primary",
@@ -24734,18 +21986,13 @@
                     "name": "sub_n1n2",
                     "provider_node": "n2",
                     "status": "down"
-                  },
-                  {
-                    "name": "sub_n1n2",
-                    "provider_node": "n2",
-                    "status": "down"
                   }
                 ],
                 "version": "4.10.0"
               },
-              "state": "deleting",
-              "status_updated_at": "1999-09-23T18:53:48Z",
-              "updated_at": "2013-04-06T16:38:09Z"
+              "state": "unknown",
+              "status_updated_at": "1978-12-17T01:14:06Z",
+              "updated_at": "2010-08-13T18:38:44Z"
             },
             {
               "connection_info": {
@@ -24755,13 +22002,13 @@
                 ],
                 "port": 5432
               },
-              "created_at": "1971-07-18T16:52:12Z",
+              "created_at": "1970-12-24T01:48:39Z",
               "error": "failed to get patroni status: connection refused",
               "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
               "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
               "node_name": "n1",
               "postgres": {
-                "patroni_paused": false,
+                "patroni_paused": true,
                 "patroni_state": "unknown",
                 "pending_restart": true,
                 "role": "primary",
@@ -24779,6 +22026,41 @@
                     "name": "sub_n1n2",
                     "provider_node": "n2",
                     "status": "down"
+                  }
+                ],
+                "version": "4.10.0"
+              },
+              "state": "unknown",
+              "status_updated_at": "1978-12-17T01:14:06Z",
+              "updated_at": "2010-08-13T18:38:44Z"
+            },
+            {
+              "connection_info": {
+                "addresses": [
+                  "10.24.34.2",
+                  "i-0123456789abcdef.ec2.internal"
+                ],
+                "port": 5432
+              },
+              "created_at": "1970-12-24T01:48:39Z",
+              "error": "failed to get patroni status: connection refused",
+              "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+              "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
+              "node_name": "n1",
+              "postgres": {
+                "patroni_paused": true,
+                "patroni_state": "unknown",
+                "pending_restart": true,
+                "role": "primary",
+                "version": "18.1"
+              },
+              "spock": {
+                "read_only": "off",
+                "subscriptions": [
+                  {
+                    "name": "sub_n1n2",
+                    "provider_node": "n2",
+                    "status": "down"
                   },
                   {
                     "name": "sub_n1n2",
@@ -24788,12 +22070,52 @@
                 ],
                 "version": "4.10.0"
               },
-              "state": "deleting",
-              "status_updated_at": "1999-09-23T18:53:48Z",
-              "updated_at": "2013-04-06T16:38:09Z"
+              "state": "unknown",
+              "status_updated_at": "1978-12-17T01:14:06Z",
+              "updated_at": "2010-08-13T18:38:44Z"
+            },
+            {
+              "connection_info": {
+                "addresses": [
+                  "10.24.34.2",
+                  "i-0123456789abcdef.ec2.internal"
+                ],
+                "port": 5432
+              },
+              "created_at": "1970-12-24T01:48:39Z",
+              "error": "failed to get patroni status: connection refused",
+              "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+              "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
+              "node_name": "n1",
+              "postgres": {
+                "patroni_paused": true,
+                "patroni_state": "unknown",
+                "pending_restart": true,
+                "role": "primary",
+                "version": "18.1"
+              },
+              "spock": {
+                "read_only": "off",
+                "subscriptions": [
+                  {
+                    "name": "sub_n1n2",
+                    "provider_node": "n2",
+                    "status": "down"
+                  },
+                  {
+                    "name": "sub_n1n2",
+                    "provider_node": "n2",
+                    "status": "down"
+                  }
+                ],
+                "version": "4.10.0"
+              },
+              "state": "unknown",
+              "status_updated_at": "1978-12-17T01:14:06Z",
+              "updated_at": "2010-08-13T18:38:44Z"
             }
           ],
-          "state": "degraded",
+          "state": "failed",
           "tenant_id": "8210ec10-2dca-406c-ac4a-0661d2189954",
           "updated_at": "2025-01-01T02:30:00Z"
         },
@@ -24941,7 +22263,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Illo dolore."
+              "example": "Totam accusamus alias."
             },
             "description": "Optional network-scoped aliases for the container.",
             "example": [
@@ -24958,7 +22280,7 @@
             },
             "additionalProperties": {
               "type": "string",
-              "example": "Accusamus alias ipsa qui."
+              "example": "Qui ut et."
             }
           },
           "id": {
@@ -25064,7 +22386,7 @@
         },
         "example": {
           "candidate_instance_id": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi",
-          "skip_validation": false
+          "skip_validation": true
         }
       },
       "FailoverDatabaseNodeResponse": {
@@ -25130,7 +22452,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Quas nostrum eos reprehenderit harum sapiente qui."
+              "example": "Animi recusandae."
             },
             "description": "The addresses that this host advertises to client applications.",
             "example": [
@@ -25185,7 +22507,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Quo recusandae quibusdam fuga molestiae."
+              "example": "Qui quam sint iure eum ducimus quia."
             },
             "description": "The addresses that this host advertises to other hosts.",
             "example": [
@@ -25203,6 +22525,14 @@
             },
             "description": "The PgEdge versions supported by this host.",
             "example": [
+              {
+                "postgres_version": "17.6",
+                "spock_version": "5"
+              },
+              {
+                "postgres_version": "17.6",
+                "spock_version": "5"
+              },
               {
                 "postgres_version": "17.6",
                 "spock_version": "5"
@@ -25270,6 +22600,14 @@
             {
               "postgres_version": "17.6",
               "spock_version": "5"
+            },
+            {
+              "postgres_version": "17.6",
+              "spock_version": "5"
+            },
+            {
+              "postgres_version": "17.6",
+              "spock_version": "5"
             }
           ]
         },
@@ -25319,7 +22657,25 @@
             "type": "object",
             "description": "The status of each component of the host.",
             "example": {
-              "Possimus error eligendi recusandae.": {
+              "At esse ut possimus error eligendi.": {
+                "details": {
+                  "alarms": [
+                    "3: NOSPACE"
+                  ]
+                },
+                "error": "failed to connect to etcd",
+                "healthy": false
+              },
+              "Atque facilis non modi explicabo illum.": {
+                "details": {
+                  "alarms": [
+                    "3: NOSPACE"
+                  ]
+                },
+                "error": "failed to connect to etcd",
+                "healthy": false
+              },
+              "Similique sed neque eos rerum quia.": {
                 "details": {
                   "alarms": [
                     "3: NOSPACE"
@@ -25352,7 +22708,7 @@
         },
         "example": {
           "components": {
-            "Atque facilis non modi explicabo illum.": {
+            "Et eius reiciendis accusamus veritatis quo recusandae.": {
               "details": {
                 "alarms": [
                   "3: NOSPACE"
@@ -25361,7 +22717,7 @@
               "error": "failed to connect to etcd",
               "healthy": false
             },
-            "Neque eos rerum quia.": {
+            "Fuga molestiae.": {
               "details": {
                 "alarms": [
                   "3: NOSPACE"
@@ -25370,7 +22726,7 @@
               "error": "failed to connect to etcd",
               "healthy": false
             },
-            "Qui et eius reiciendis accusamus.": {
+            "Quas nostrum eos reprehenderit harum sapiente qui.": {
               "details": {
                 "alarms": [
                   "3: NOSPACE"
@@ -25414,7 +22770,7 @@
           "created_at": {
             "type": "string",
             "description": "The time that the instance was created.",
-            "example": "1977-01-28T10:07:37Z",
+            "example": "1993-02-25T18:38:10Z",
             "format": "date-time"
           },
           "error": {
@@ -25461,13 +22817,13 @@
           "status_updated_at": {
             "type": "string",
             "description": "The time that the instance status information was last updated.",
-            "example": "1999-11-24T20:30:24Z",
+            "example": "1983-10-23T08:18:23Z",
             "format": "date-time"
           },
           "updated_at": {
             "type": "string",
             "description": "The time that the instance was last modified.",
-            "example": "2012-07-13T20:43:05Z",
+            "example": "1971-02-20T15:20:44Z",
             "format": "date-time"
           }
         },
@@ -25480,13 +22836,13 @@
             ],
             "port": 5432
           },
-          "created_at": "2003-06-28T19:25:47Z",
+          "created_at": "1994-07-03T05:16:56Z",
           "error": "failed to get patroni status: connection refused",
           "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
           "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
           "node_name": "n1",
           "postgres": {
-            "patroni_paused": false,
+            "patroni_paused": true,
             "patroni_state": "unknown",
             "pending_restart": true,
             "role": "primary",
@@ -25504,18 +22860,13 @@
                 "name": "sub_n1n2",
                 "provider_node": "n2",
                 "status": "down"
-              },
-              {
-                "name": "sub_n1n2",
-                "provider_node": "n2",
-                "status": "down"
               }
             ],
             "version": "4.10.0"
           },
           "state": "modifying",
-          "status_updated_at": "1992-10-18T20:01:09Z",
-          "updated_at": "1982-02-16T16:16:42Z"
+          "status_updated_at": "1994-09-09T06:25:01Z",
+          "updated_at": "2014-04-20T04:34:11Z"
         },
         "required": [
           "id",
@@ -25533,7 +22884,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Eum ducimus."
+              "example": "Ea omnis ut dolor dolorem impedit laudantium."
             },
             "description": "The addresses of the host that's running this instance.",
             "example": [
@@ -25588,7 +22939,7 @@
         "example": {
           "patroni_paused": false,
           "patroni_state": "unknown",
-          "pending_restart": true,
+          "pending_restart": false,
           "role": "primary",
           "version": "18.1"
         }
@@ -25622,11 +22973,6 @@
                 "name": "sub_n1n2",
                 "provider_node": "n2",
                 "status": "down"
-              },
-              {
-                "name": "sub_n1n2",
-                "provider_node": "n2",
-                "status": "down"
               }
             ]
           },
@@ -25640,11 +22986,6 @@
         "example": {
           "read_only": "off",
           "subscriptions": [
-            {
-              "name": "sub_n1n2",
-              "provider_node": "n2",
-              "status": "down"
-            },
             {
               "name": "sub_n1n2",
               "provider_node": "n2",
@@ -25706,6 +23047,16 @@
             },
             "description": "The tasks for the given database.",
             "example": [
+              {
+                "completed_at": "2025-06-18T16:52:35Z",
+                "created_at": "2025-06-18T16:52:05Z",
+                "database_id": "storefront",
+                "entity_id": "storefront",
+                "scope": "database",
+                "status": "completed",
+                "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
+                "type": "create"
+              },
               {
                 "completed_at": "2025-06-18T16:52:35Z",
                 "created_at": "2025-06-18T16:52:05Z",
@@ -25810,13 +23161,13 @@
                       ],
                       "port": 5432
                     },
-                    "created_at": "1971-07-18T16:52:12Z",
+                    "created_at": "1970-12-24T01:48:39Z",
                     "error": "failed to get patroni status: connection refused",
                     "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                     "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                     "node_name": "n1",
                     "postgres": {
-                      "patroni_paused": false,
+                      "patroni_paused": true,
                       "patroni_state": "unknown",
                       "pending_restart": true,
                       "role": "primary",
@@ -25834,18 +23185,13 @@
                           "name": "sub_n1n2",
                           "provider_node": "n2",
                           "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
                         }
                       ],
                       "version": "4.10.0"
                     },
-                    "state": "deleting",
-                    "status_updated_at": "1999-09-23T18:53:48Z",
-                    "updated_at": "2013-04-06T16:38:09Z"
+                    "state": "unknown",
+                    "status_updated_at": "1978-12-17T01:14:06Z",
+                    "updated_at": "2010-08-13T18:38:44Z"
                   },
                   {
                     "connection_info": {
@@ -25855,13 +23201,13 @@
                       ],
                       "port": 5432
                     },
-                    "created_at": "1971-07-18T16:52:12Z",
+                    "created_at": "1970-12-24T01:48:39Z",
                     "error": "failed to get patroni status: connection refused",
                     "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                     "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                     "node_name": "n1",
                     "postgres": {
-                      "patroni_paused": false,
+                      "patroni_paused": true,
                       "patroni_state": "unknown",
                       "pending_restart": true,
                       "role": "primary",
@@ -25879,6 +23225,41 @@
                           "name": "sub_n1n2",
                           "provider_node": "n2",
                           "status": "down"
+                        }
+                      ],
+                      "version": "4.10.0"
+                    },
+                    "state": "unknown",
+                    "status_updated_at": "1978-12-17T01:14:06Z",
+                    "updated_at": "2010-08-13T18:38:44Z"
+                  },
+                  {
+                    "connection_info": {
+                      "addresses": [
+                        "10.24.34.2",
+                        "i-0123456789abcdef.ec2.internal"
+                      ],
+                      "port": 5432
+                    },
+                    "created_at": "1970-12-24T01:48:39Z",
+                    "error": "failed to get patroni status: connection refused",
+                    "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+                    "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
+                    "node_name": "n1",
+                    "postgres": {
+                      "patroni_paused": true,
+                      "patroni_state": "unknown",
+                      "pending_restart": true,
+                      "role": "primary",
+                      "version": "18.1"
+                    },
+                    "spock": {
+                      "read_only": "off",
+                      "subscriptions": [
+                        {
+                          "name": "sub_n1n2",
+                          "provider_node": "n2",
+                          "status": "down"
                         },
                         {
                           "name": "sub_n1n2",
@@ -25888,9 +23269,9 @@
                       ],
                       "version": "4.10.0"
                     },
-                    "state": "deleting",
-                    "status_updated_at": "1999-09-23T18:53:48Z",
-                    "updated_at": "2013-04-06T16:38:09Z"
+                    "state": "unknown",
+                    "status_updated_at": "1978-12-17T01:14:06Z",
+                    "updated_at": "2010-08-13T18:38:44Z"
                   }
                 ],
                 "state": "failed",
@@ -25909,13 +23290,13 @@
                       ],
                       "port": 5432
                     },
-                    "created_at": "1971-07-18T16:52:12Z",
+                    "created_at": "1970-12-24T01:48:39Z",
                     "error": "failed to get patroni status: connection refused",
                     "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                     "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                     "node_name": "n1",
                     "postgres": {
-                      "patroni_paused": false,
+                      "patroni_paused": true,
                       "patroni_state": "unknown",
                       "pending_restart": true,
                       "role": "primary",
@@ -25933,18 +23314,13 @@
                           "name": "sub_n1n2",
                           "provider_node": "n2",
                           "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
                         }
                       ],
                       "version": "4.10.0"
                     },
-                    "state": "deleting",
-                    "status_updated_at": "1999-09-23T18:53:48Z",
-                    "updated_at": "2013-04-06T16:38:09Z"
+                    "state": "unknown",
+                    "status_updated_at": "1978-12-17T01:14:06Z",
+                    "updated_at": "2010-08-13T18:38:44Z"
                   },
                   {
                     "connection_info": {
@@ -25954,13 +23330,13 @@
                       ],
                       "port": 5432
                     },
-                    "created_at": "1971-07-18T16:52:12Z",
+                    "created_at": "1970-12-24T01:48:39Z",
                     "error": "failed to get patroni status: connection refused",
                     "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                     "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                     "node_name": "n1",
                     "postgres": {
-                      "patroni_paused": false,
+                      "patroni_paused": true,
                       "patroni_state": "unknown",
                       "pending_restart": true,
                       "role": "primary",
@@ -25978,6 +23354,41 @@
                           "name": "sub_n1n2",
                           "provider_node": "n2",
                           "status": "down"
+                        }
+                      ],
+                      "version": "4.10.0"
+                    },
+                    "state": "unknown",
+                    "status_updated_at": "1978-12-17T01:14:06Z",
+                    "updated_at": "2010-08-13T18:38:44Z"
+                  },
+                  {
+                    "connection_info": {
+                      "addresses": [
+                        "10.24.34.2",
+                        "i-0123456789abcdef.ec2.internal"
+                      ],
+                      "port": 5432
+                    },
+                    "created_at": "1970-12-24T01:48:39Z",
+                    "error": "failed to get patroni status: connection refused",
+                    "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+                    "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
+                    "node_name": "n1",
+                    "postgres": {
+                      "patroni_paused": true,
+                      "patroni_state": "unknown",
+                      "pending_restart": true,
+                      "role": "primary",
+                      "version": "18.1"
+                    },
+                    "spock": {
+                      "read_only": "off",
+                      "subscriptions": [
+                        {
+                          "name": "sub_n1n2",
+                          "provider_node": "n2",
+                          "status": "down"
                         },
                         {
                           "name": "sub_n1n2",
@@ -25987,9 +23398,9 @@
                       ],
                       "version": "4.10.0"
                     },
-                    "state": "deleting",
-                    "status_updated_at": "1999-09-23T18:53:48Z",
-                    "updated_at": "2013-04-06T16:38:09Z"
+                    "state": "unknown",
+                    "status_updated_at": "1978-12-17T01:14:06Z",
+                    "updated_at": "2010-08-13T18:38:44Z"
                   }
                 ],
                 "state": "failed",
@@ -26008,13 +23419,13 @@
                       ],
                       "port": 5432
                     },
-                    "created_at": "1971-07-18T16:52:12Z",
+                    "created_at": "1970-12-24T01:48:39Z",
                     "error": "failed to get patroni status: connection refused",
                     "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                     "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                     "node_name": "n1",
                     "postgres": {
-                      "patroni_paused": false,
+                      "patroni_paused": true,
                       "patroni_state": "unknown",
                       "pending_restart": true,
                       "role": "primary",
@@ -26032,18 +23443,13 @@
                           "name": "sub_n1n2",
                           "provider_node": "n2",
                           "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
                         }
                       ],
                       "version": "4.10.0"
                     },
-                    "state": "deleting",
-                    "status_updated_at": "1999-09-23T18:53:48Z",
-                    "updated_at": "2013-04-06T16:38:09Z"
+                    "state": "unknown",
+                    "status_updated_at": "1978-12-17T01:14:06Z",
+                    "updated_at": "2010-08-13T18:38:44Z"
                   },
                   {
                     "connection_info": {
@@ -26053,13 +23459,13 @@
                       ],
                       "port": 5432
                     },
-                    "created_at": "1971-07-18T16:52:12Z",
+                    "created_at": "1970-12-24T01:48:39Z",
                     "error": "failed to get patroni status: connection refused",
                     "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
                     "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
                     "node_name": "n1",
                     "postgres": {
-                      "patroni_paused": false,
+                      "patroni_paused": true,
                       "patroni_state": "unknown",
                       "pending_restart": true,
                       "role": "primary",
@@ -26077,6 +23483,41 @@
                           "name": "sub_n1n2",
                           "provider_node": "n2",
                           "status": "down"
+                        }
+                      ],
+                      "version": "4.10.0"
+                    },
+                    "state": "unknown",
+                    "status_updated_at": "1978-12-17T01:14:06Z",
+                    "updated_at": "2010-08-13T18:38:44Z"
+                  },
+                  {
+                    "connection_info": {
+                      "addresses": [
+                        "10.24.34.2",
+                        "i-0123456789abcdef.ec2.internal"
+                      ],
+                      "port": 5432
+                    },
+                    "created_at": "1970-12-24T01:48:39Z",
+                    "error": "failed to get patroni status: connection refused",
+                    "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+                    "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
+                    "node_name": "n1",
+                    "postgres": {
+                      "patroni_paused": true,
+                      "patroni_state": "unknown",
+                      "pending_restart": true,
+                      "role": "primary",
+                      "version": "18.1"
+                    },
+                    "spock": {
+                      "read_only": "off",
+                      "subscriptions": [
+                        {
+                          "name": "sub_n1n2",
+                          "provider_node": "n2",
+                          "status": "down"
                         },
                         {
                           "name": "sub_n1n2",
@@ -26086,9 +23527,9 @@
                       ],
                       "version": "4.10.0"
                     },
-                    "state": "deleting",
-                    "status_updated_at": "1999-09-23T18:53:48Z",
-                    "updated_at": "2013-04-06T16:38:09Z"
+                    "state": "unknown",
+                    "status_updated_at": "1978-12-17T01:14:06Z",
+                    "updated_at": "2010-08-13T18:38:44Z"
                   }
                 ],
                 "state": "failed",
@@ -26682,6 +24123,69 @@
                   "spock_version": "5"
                 }
               ]
+            },
+            {
+              "client_addresses": [
+                "10.24.34.2",
+                "i-0123456789abcdef.ec2.internal"
+              ],
+              "cohort": {
+                "control_available": true,
+                "member_id": "lah4bsznw6kc0hp7biylmmmll",
+                "type": "swarm"
+              },
+              "cpus": 4,
+              "data_dir": "/data",
+              "default_pgedge_version": {
+                "postgres_version": "17.6",
+                "spock_version": "5"
+              },
+              "etcd_mode": "server",
+              "id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+              "memory": "16GiB",
+              "orchestrator": "swarm",
+              "peer_addresses": [
+                "10.24.34.2",
+                "i-0123456789abcdef.ec2.internal"
+              ],
+              "status": {
+                "components": {
+                  "Enim et voluptatum ex ea dolore.": {
+                    "details": {
+                      "alarms": [
+                        "3: NOSPACE"
+                      ]
+                    },
+                    "error": "failed to connect to etcd",
+                    "healthy": false
+                  },
+                  "Tenetur nostrum repellendus sint qui.": {
+                    "details": {
+                      "alarms": [
+                        "3: NOSPACE"
+                      ]
+                    },
+                    "error": "failed to connect to etcd",
+                    "healthy": false
+                  }
+                },
+                "state": "available",
+                "updated_at": "2021-07-01T12:34:56Z"
+              },
+              "supported_pgedge_versions": [
+                {
+                  "postgres_version": "17.6",
+                  "spock_version": "5"
+                },
+                {
+                  "postgres_version": "17.6",
+                  "spock_version": "5"
+                },
+                {
+                  "postgres_version": "17.6",
+                  "spock_version": "5"
+                }
+              ]
             }
           ]
         },
@@ -26979,16 +24483,6 @@
               "status": "completed",
               "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
               "type": "create"
-            },
-            {
-              "completed_at": "2025-06-18T16:52:35Z",
-              "created_at": "2025-06-18T16:52:05Z",
-              "database_id": "storefront",
-              "entity_id": "storefront",
-              "scope": "database",
-              "status": "completed",
-              "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
-              "type": "create"
             }
           ]
         },
@@ -27109,7 +24603,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "At praesentium ut dolorem sapiente."
+              "example": "Sapiente placeat illo."
             },
             "description": "The nodes to restore. Defaults to all nodes if empty or unspecified.",
             "example": [
@@ -27149,16 +24643,6 @@
             },
             "description": "The tasks that will restore each database node.",
             "example": [
-              {
-                "completed_at": "2025-06-18T16:52:35Z",
-                "created_at": "2025-06-18T16:52:05Z",
-                "database_id": "storefront",
-                "entity_id": "storefront",
-                "scope": "database",
-                "status": "completed",
-                "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
-                "type": "create"
-              },
               {
                 "completed_at": "2025-06-18T16:52:35Z",
                 "created_at": "2025-06-18T16:52:05Z",
@@ -27407,6 +24891,16 @@
             },
             "description": "The tasks that will restore each database node.",
             "example": [
+              {
+                "completed_at": "2025-06-18T16:52:35Z",
+                "created_at": "2025-06-18T16:52:05Z",
+                "database_id": "storefront",
+                "entity_id": "storefront",
+                "scope": "database",
+                "status": "completed",
+                "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
+                "type": "create"
+              },
               {
                 "completed_at": "2025-06-18T16:52:35Z",
                 "created_at": "2025-06-18T16:52:05Z",
@@ -27786,6 +25280,23 @@
           "type"
         ]
       },
+      "SQLScript": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "example": "i3l",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "description": "Each element of this array is an individual SQL statement.",
+        "example": [
+          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+          "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app"
+        ],
+        "minItems": 0,
+        "maxItems": 256
+      },
       "ServiceInstance": {
         "type": "object",
         "properties": {
@@ -27875,6 +25386,11 @@
                 "container_port": 8080,
                 "host_port": 8080,
                 "name": "web-client"
+              },
+              {
+                "container_port": 8080,
+                "host_port": 8080,
+                "name": "web-client"
               }
             ],
             "service_ready": true
@@ -27898,7 +25414,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Necessitatibus labore ipsa id modi et et."
+              "example": "Eos et error vel nihil."
             },
             "description": "The addresses of the host that's running this service instance.",
             "example": [
@@ -27932,11 +25448,6 @@
             },
             "description": "Port mappings for this service instance.",
             "example": [
-              {
-                "container_port": 8080,
-                "host_port": 8080,
-                "name": "web-client"
-              },
               {
                 "container_port": 8080,
                 "host_port": 8080,
@@ -28032,6 +25543,7 @@
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
+              "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
               "de3b1388-1f0c-42f1-a86c-59ab72f255ec"
             ],
             "minItems": 1
@@ -28193,7 +25705,6 @@
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -28254,7 +25765,6 @@
             "target_session_attrs": "primary"
           },
           "host_ids": [
-            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
@@ -28357,8 +25867,6 @@
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -28419,6 +25927,7 @@
             "target_session_attrs": "primary"
           },
           "host_ids": [
+            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
@@ -28748,6 +26257,7 @@
           },
           "host_ids": [
             "76f9b8c0-4958-11f0-a489-3bb29577c696",
+            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "512M",
@@ -29014,7 +26524,6 @@
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -29204,7 +26713,7 @@
             },
             "additionalProperties": {
               "type": "string",
-              "example": "Aut doloribus rem culpa ullam minus dolore."
+              "example": "Rem culpa."
             }
           },
           "extra_networks": {

--- a/api/apiv1/gen/http/openapi3.yaml
+++ b/api/apiv1/gen/http/openapi3.yaml
@@ -551,43 +551,6 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateDatabaseRequest2'
             examples:
-              Built-in roles:
-                summary: Built-in roles
-                description: The Control Plane can create multiple users on your behalf, and it includes some built-in roles that make it easy to assign limited permissions.
-                value:
-                  id: storefront
-                  spec:
-                    database_name: storefront
-                    database_users:
-                      - attributes:
-                          - LOGIN
-                          - SUPERUSER
-                        db_owner: true
-                        password: password
-                        username: admin
-                      - attributes:
-                          - LOGIN
-                        password: password
-                        roles:
-                          - pgedge_application
-                        username: storefront_app
-                      - attributes:
-                          - LOGIN
-                        password: password
-                        roles:
-                          - pgedge_application_read_only
-                        username: business_intelligence_app
-                    nodes:
-                      - host_ids:
-                          - us-east-1
-                        name: n1
-                      - host_ids:
-                          - ap-south-1
-                        name: n2
-                      - host_ids:
-                          - eu-central-1
-                        name: n3
-                    port: 5432
               Creating from an existing backup:
                 summary: Creating from an existing backup
                 description: A configuration that creates a database from an existing backup in S3.
@@ -672,6 +635,46 @@ paths:
                           - eu-central-1
                         name: n3
                     port: 5432
+              User-defined SQL scripts:
+                summary: User-defined SQL scripts
+                description: The Control Plane can run custom SQL scripts at different points in the database creation process.
+                value:
+                  id: storefront
+                  spec:
+                    database_name: storefront
+                    database_users:
+                      - attributes:
+                          - LOGIN
+                          - SUPERUSER
+                        db_owner: true
+                        password: password
+                        username: admin
+                      - password: password
+                        roles:
+                          - read_write
+                        username: storefront
+                      - password: password
+                        roles:
+                          - read_write
+                        username: accounting
+                    nodes:
+                      - host_ids:
+                          - us-east-1
+                        name: n1
+                      - host_ids:
+                          - ap-south-1
+                        name: n2
+                      - host_ids:
+                          - eu-central-1
+                        name: n3
+                    port: 5432
+                    scripts:
+                      post_database_create:
+                        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO read_write
+                        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO read_write
+                        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO read_write
+                      post_init:
+                        - CREATE ROLE read_write NOLOGIN
               With cloud backups:
                 summary: With cloud backups
                 description: A configuration that includes backups to S3 from all nodes. Note that the S3 access key and secret can be excluded if EC2 instance profiles are configured for each host.
@@ -1139,14 +1142,17 @@ paths:
             type: array
             items:
               type: string
-              example: Cupiditate molestiae.
+              example: Doloribus consequatur voluptatibus sed et nisi.
             description: Host IDs to treat as removed during this update. Events targeting these hosts will be skipped.
             example:
-              - Accusamus quia dolores.
-              - Laboriosam placeat distinctio atque dolor autem.
+              - Perspiciatis et veniam blanditiis et.
+              - Repellat fuga occaecati optio accusantium.
+              - Voluptatibus sunt deserunt sapiente doloribus est.
           example:
-            - Excepturi sapiente neque doloribus consequatur voluptatibus.
-            - Et nisi nihil corporis.
+            - Officiis sint.
+            - Ad aut velit distinctio sed.
+            - Rem voluptas qui.
+            - Voluptatem nesciunt dignissimos voluptas vel earum.
         - name: database_id
           in: path
           description: ID of the database to update.
@@ -4686,13 +4692,13 @@ components:
                   - 10.24.34.2
                   - i-0123456789abcdef.ec2.internal
                 port: 5432
-              created_at: "1971-07-18T16:52:12Z"
+              created_at: "1970-12-24T01:48:39Z"
               error: 'failed to get patroni status: connection refused'
               host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
               id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
               node_name: n1
               postgres:
-                patroni_paused: false
+                patroni_paused: true
                 patroni_state: unknown
                 pending_restart: true
                 role: primary
@@ -4706,25 +4712,22 @@ components:
                   - name: sub_n1n2
                     provider_node: n2
                     status: down
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
                 version: 4.10.0
-              state: deleting
-              status_updated_at: "1999-09-23T18:53:48Z"
-              updated_at: "2013-04-06T16:38:09Z"
+              state: unknown
+              status_updated_at: "1978-12-17T01:14:06Z"
+              updated_at: "2010-08-13T18:38:44Z"
             - connection_info:
                 addresses:
                   - 10.24.34.2
                   - i-0123456789abcdef.ec2.internal
                 port: 5432
-              created_at: "1971-07-18T16:52:12Z"
+              created_at: "1970-12-24T01:48:39Z"
               error: 'failed to get patroni status: connection refused'
               host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
               id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
               node_name: n1
               postgres:
-                patroni_paused: false
+                patroni_paused: true
                 patroni_state: unknown
                 pending_restart: true
                 role: primary
@@ -4738,13 +4741,39 @@ components:
                   - name: sub_n1n2
                     provider_node: n2
                     status: down
+                version: 4.10.0
+              state: unknown
+              status_updated_at: "1978-12-17T01:14:06Z"
+              updated_at: "2010-08-13T18:38:44Z"
+            - connection_info:
+                addresses:
+                  - 10.24.34.2
+                  - i-0123456789abcdef.ec2.internal
+                port: 5432
+              created_at: "1970-12-24T01:48:39Z"
+              error: 'failed to get patroni status: connection refused'
+              host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+              id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
+              node_name: n1
+              postgres:
+                patroni_paused: true
+                patroni_state: unknown
+                pending_restart: true
+                role: primary
+                version: "18.1"
+              spock:
+                read_only: "off"
+                subscriptions:
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
                   - name: sub_n1n2
                     provider_node: n2
                     status: down
                 version: 4.10.0
-              state: deleting
-              status_updated_at: "1999-09-23T18:53:48Z"
-              updated_at: "2013-04-06T16:38:09Z"
+              state: unknown
+              status_updated_at: "1978-12-17T01:14:06Z"
+              updated_at: "2010-08-13T18:38:44Z"
         service_instances:
           type: array
           items:
@@ -4776,30 +4805,6 @@ components:
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
-                service_ready: true
-              updated_at: "2025-01-28T10:05:00Z"
-            - created_at: "2025-01-28T10:00:00Z"
-              database_id: production
-              error: 'failed to start container: image not found'
-              host_id: host-1
-              service_id: mcp-server
-              service_instance_id: mcp-server-host-1
-              state: running
-              status:
-                addresses:
-                  - 10.24.34.2
-                  - i-0123456789abcdef.ec2.internal
-                container_id: a1b2c3d4e5f6
-                health_check:
-                  checked_at: "2025-01-28T10:00:00Z"
-                  message: Connection refused
-                  status: healthy
-                image_version: 1.0.0
-                last_health_at: "2025-01-28T10:00:00Z"
-                ports:
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
@@ -4827,30 +4832,6 @@ components:
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                service_ready: true
-              updated_at: "2025-01-28T10:05:00Z"
-            - created_at: "2025-01-28T10:00:00Z"
-              database_id: production
-              error: 'failed to start container: image not found'
-              host_id: host-1
-              service_id: mcp-server
-              service_instance_id: mcp-server-host-1
-              state: running
-              status:
-                addresses:
-                  - 10.24.34.2
-                  - i-0123456789abcdef.ec2.internal
-                container_id: a1b2c3d4e5f6
-                health_check:
-                  checked_at: "2025-01-28T10:00:00Z"
-                  message: Connection refused
-                  status: healthy
-                image_version: 1.0.0
-                last_health_at: "2025-01-28T10:00:00Z"
-                ports:
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
@@ -4864,7 +4845,7 @@ components:
         state:
           type: string
           description: Current state of the database.
-          example: modifying
+          example: available
           enum:
             - creating
             - modifying
@@ -5079,12 +5060,77 @@ components:
               state: available
               status_updated_at: "1993-04-25T23:06:28Z"
               updated_at: "1981-08-22T23:20:01Z"
+            - connection_info:
+                addresses:
+                  - 10.24.34.2
+                  - i-0123456789abcdef.ec2.internal
+                port: 5432
+              created_at: "2011-03-15T17:48:48Z"
+              error: 'failed to get patroni status: connection refused'
+              host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+              id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
+              node_name: n1
+              postgres:
+                patroni_paused: false
+                patroni_state: unknown
+                pending_restart: true
+                role: primary
+                version: "18.1"
+              spock:
+                read_only: "off"
+                subscriptions:
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                version: 4.10.0
+              state: available
+              status_updated_at: "1993-04-25T23:06:28Z"
+              updated_at: "1981-08-22T23:20:01Z"
         service_instances:
           type: array
           items:
             $ref: '#/components/schemas/ServiceInstance'
           description: Service instances running alongside this database.
           example:
+            - created_at: "2025-01-28T10:00:00Z"
+              database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              error: 'failed to start container: image not found'
+              host_id: host-1
+              service_id: mcp-server
+              service_instance_id: mcp-server-host-1
+              state: running
+              status:
+                addresses:
+                  - 10.24.34.2
+                  - i-0123456789abcdef.ec2.internal
+                container_id: a1b2c3d4e5f6
+                health_check:
+                  checked_at: "2025-01-28T10:00:00Z"
+                  message: Connection refused
+                  status: healthy
+                image_version: 1.0.0
+                last_health_at: "2025-01-28T10:00:00Z"
+                ports:
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                service_ready: true
+              updated_at: "2025-01-28T10:05:00Z"
             - created_at: "2025-01-28T10:00:00Z"
               database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               error: 'failed to start container: image not found'
@@ -5508,78 +5554,12 @@ components:
                     name: web-client
                 service_ready: true
               updated_at: "2025-01-28T10:05:00Z"
-            - created_at: "2025-01-28T10:00:00Z"
-              database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              error: 'failed to start container: image not found'
-              host_id: host-1
-              service_id: mcp-server
-              service_instance_id: mcp-server-host-1
-              state: running
-              status:
-                addresses:
-                  - 10.24.34.2
-                  - i-0123456789abcdef.ec2.internal
-                container_id: a1b2c3d4e5f6
-                health_check:
-                  checked_at: "2025-01-28T10:00:00Z"
-                  message: Connection refused
-                  status: healthy
-                image_version: 1.0.0
-                last_health_at: "2025-01-28T10:00:00Z"
-                ports:
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                service_ready: true
-              updated_at: "2025-01-28T10:05:00Z"
-            - created_at: "2025-01-28T10:00:00Z"
-              database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              error: 'failed to start container: image not found'
-              host_id: host-1
-              service_id: mcp-server
-              service_instance_id: mcp-server-host-1
-              state: running
-              status:
-                addresses:
-                  - 10.24.34.2
-                  - i-0123456789abcdef.ec2.internal
-                container_id: a1b2c3d4e5f6
-                health_check:
-                  checked_at: "2025-01-28T10:00:00Z"
-                  message: Connection refused
-                  status: healthy
-                image_version: 1.0.0
-                last_health_at: "2025-01-28T10:00:00Z"
-                ports:
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                service_ready: true
-              updated_at: "2025-01-28T10:05:00Z"
         spec:
           $ref: '#/components/schemas/DatabaseSpec4'
         state:
           type: string
           description: Current state of the database.
-          example: unknown
+          example: degraded
           enum:
             - creating
             - modifying
@@ -5826,6 +5806,38 @@ components:
               state: available
               status_updated_at: "1993-04-25T23:06:28Z"
               updated_at: "1981-08-22T23:20:01Z"
+            - connection_info:
+                addresses:
+                  - 10.24.34.2
+                  - i-0123456789abcdef.ec2.internal
+                port: 5432
+              created_at: "2011-03-15T17:48:48Z"
+              error: 'failed to get patroni status: connection refused'
+              host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+              id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
+              node_name: n1
+              postgres:
+                patroni_paused: false
+                patroni_state: unknown
+                pending_restart: true
+                role: primary
+                version: "18.1"
+              spock:
+                read_only: "off"
+                subscriptions:
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                version: 4.10.0
+              state: available
+              status_updated_at: "1993-04-25T23:06:28Z"
+              updated_at: "1981-08-22T23:20:01Z"
         service_instances:
           type: array
           items:
@@ -5898,12 +5910,78 @@ components:
                     name: web-client
                 service_ready: true
               updated_at: "2025-01-28T10:05:00Z"
+            - created_at: "2025-01-28T10:00:00Z"
+              database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              error: 'failed to start container: image not found'
+              host_id: host-1
+              service_id: mcp-server
+              service_instance_id: mcp-server-host-1
+              state: running
+              status:
+                addresses:
+                  - 10.24.34.2
+                  - i-0123456789abcdef.ec2.internal
+                container_id: a1b2c3d4e5f6
+                health_check:
+                  checked_at: "2025-01-28T10:00:00Z"
+                  message: Connection refused
+                  status: healthy
+                image_version: 1.0.0
+                last_health_at: "2025-01-28T10:00:00Z"
+                ports:
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                service_ready: true
+              updated_at: "2025-01-28T10:05:00Z"
+            - created_at: "2025-01-28T10:00:00Z"
+              database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              error: 'failed to start container: image not found'
+              host_id: host-1
+              service_id: mcp-server
+              service_instance_id: mcp-server-host-1
+              state: running
+              status:
+                addresses:
+                  - 10.24.34.2
+                  - i-0123456789abcdef.ec2.internal
+                container_id: a1b2c3d4e5f6
+                health_check:
+                  checked_at: "2025-01-28T10:00:00Z"
+                  message: Connection refused
+                  status: healthy
+                image_version: 1.0.0
+                last_health_at: "2025-01-28T10:00:00Z"
+                ports:
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                service_ready: true
+              updated_at: "2025-01-28T10:05:00Z"
         spec:
           $ref: '#/components/schemas/DatabaseSpec6'
         state:
           type: string
           description: Current state of the database.
-          example: unknown
+          example: modifying
           enum:
             - creating
             - modifying
@@ -6254,45 +6332,12 @@ components:
                     name: web-client
                 service_ready: true
               updated_at: "2025-01-28T10:05:00Z"
-            - created_at: "2025-01-28T10:00:00Z"
-              database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              error: 'failed to start container: image not found'
-              host_id: host-1
-              service_id: mcp-server
-              service_instance_id: mcp-server-host-1
-              state: running
-              status:
-                addresses:
-                  - 10.24.34.2
-                  - i-0123456789abcdef.ec2.internal
-                container_id: a1b2c3d4e5f6
-                health_check:
-                  checked_at: "2025-01-28T10:00:00Z"
-                  message: Connection refused
-                  status: healthy
-                image_version: 1.0.0
-                last_health_at: "2025-01-28T10:00:00Z"
-                ports:
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
-                service_ready: true
-              updated_at: "2025-01-28T10:05:00Z"
         spec:
           $ref: '#/components/schemas/DatabaseSpec7'
         state:
           type: string
           description: Current state of the database.
-          example: restoring
+          example: unknown
           enum:
             - creating
             - modifying
@@ -6539,6 +6584,26 @@ components:
               s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
               s3_region: us-east-1
               type: s3
+            - azure_account: pgedge-backups
+              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              azure_endpoint: blob.core.usgovcloudapi.net
+              azure_key: YXpLZXk=
+              base_path: /backups
+              custom_options:
+                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                storage-upload-chunk-size: 5MiB
+              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              gcs_endpoint: localhost
+              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+              id: f6b84a99-5e91-4203-be1e-131fe82e5984
+              retention_full: 2
+              retention_full_type: count
+              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              s3_endpoint: s3.us-east-1.amazonaws.com
+              s3_key: AKIAIOSFODNN7EXAMPLE
+              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              s3_region: us-east-1
+              type: s3
           schedules:
             - cron_expression: 0 6 * * ?
               id: daily-full-backup
@@ -6640,7 +6705,6 @@ components:
             maxLength: 63
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
@@ -6762,6 +6826,8 @@ components:
               type: full
         cpus: 500m
         host_ids:
+          - 76f9b8c0-4958-11f0-a489-3bb29577c696
+          - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 500M
         name: n1
@@ -6974,6 +7040,7 @@ components:
         host_ids:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
+          - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 500M
         name: n1
         orchestrator_opts:
@@ -7063,215 +7130,6 @@ components:
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
-          minItems: 1
-        memory:
-          type: string
-          description: The amount of memory in SI or IEC notation to allocate for the database on this node and to use for tuning Postgres. Defaults to the total available memory on the host. Whether this limit is enforced depends on the orchestrator.
-          example: 500M
-          maxLength: 16
-        name:
-          type: string
-          description: The name of the database node.
-          example: n1
-          pattern: n[0-9]+
-        orchestrator_opts:
-          $ref: '#/components/schemas/OrchestratorOpts'
-        patroni_port:
-          type: integer
-          description: 'The port used by Patroni for this node. Overrides the Patroni port set in the DatabaseSpec. NOTE: This field is not currently supported for Docker Swarm.'
-          example: 8888
-          format: int64
-          minimum: 0
-          maximum: 65535
-        port:
-          type: integer
-          description: The port used by the Postgres database for this node. Overrides the Postgres port set in the DatabaseSpec.
-          example: 5432
-          format: int64
-          minimum: 0
-          maximum: 65535
-        postgres_version:
-          type: string
-          description: The Postgres version for this node in 'major.minor' format. Overrides the Postgres version set in the DatabaseSpec.
-          example: "17.6"
-          pattern: ^\d{2}\.\d{1,2}$
-        postgresql_conf:
-          type: object
-          description: Additional postgresql.conf settings for this particular node. Will be merged with the settings provided by control-plane.
-          example:
-            max_connections: 1000
-          additionalProperties: true
-        restore_config:
-          $ref: '#/components/schemas/RestoreConfigSpec'
-        source_node:
-          type: string
-          description: The name of the source node to use for sync. This is typically the node (like 'n1') from which the data will be copied to initialize this new node.
-          example: n1
-      example:
-        backup_config:
-          repositories:
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
-          schedules:
-            - cron_expression: 0 6 * * ?
-              id: daily-full-backup
-              type: full
-            - cron_expression: 0 6 * * ?
-              id: daily-full-backup
-              type: full
-            - cron_expression: 0 6 * * ?
-              id: daily-full-backup
-              type: full
-        cpus: 500m
-        host_ids:
-          - 76f9b8c0-4958-11f0-a489-3bb29577c696
-          - 76f9b8c0-4958-11f0-a489-3bb29577c696
-          - 76f9b8c0-4958-11f0-a489-3bb29577c696
-        memory: 500M
-        name: n1
-        orchestrator_opts:
-          swarm:
-            extra_labels:
-              traefik.enable: "true"
-              traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-            extra_networks:
-              - aliases:
-                  - pg-db
-                  - db-alias
-                driver_opts:
-                  com.docker.network.endpoint.expose: "true"
-                id: traefik-public
-              - aliases:
-                  - pg-db
-                  - db-alias
-                driver_opts:
-                  com.docker.network.endpoint.expose: "true"
-                id: traefik-public
-              - aliases:
-                  - pg-db
-                  - db-alias
-                driver_opts:
-                  com.docker.network.endpoint.expose: "true"
-                id: traefik-public
-            extra_volumes:
-              - destination_path: /backups/container
-                host_path: /Users/user/backups/host
-              - destination_path: /backups/container
-                host_path: /Users/user/backups/host
-              - destination_path: /backups/container
-                host_path: /Users/user/backups/host
-        patroni_port: 8888
-        port: 5432
-        postgres_version: "17.6"
-        postgresql_conf:
-          max_connections: 1000
-        restore_config:
-          repository:
-            azure_account: pgedge-backups
-            azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-            azure_endpoint: blob.core.usgovcloudapi.net
-            azure_key: YXpLZXk=
-            base_path: /backups
-            custom_options:
-              s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-            gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-            gcs_endpoint: localhost
-            gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-            id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-            s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-            s3_endpoint: s3.us-east-1.amazonaws.com
-            s3_key: AKIAIOSFODNN7EXAMPLE
-            s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-            s3_region: us-east-1
-            type: s3
-          restore_options:
-            set: 20250505-153628F
-            target: "123456"
-            type: xid
-          source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-          source_database_name: northwind
-          source_node_name: n1
-        source_node: n1
-      required:
-        - name
-        - host_ids
-    DatabaseNodeSpec5:
-      type: object
-      properties:
-        backup_config:
-          $ref: '#/components/schemas/BackupConfigSpec'
-        cpus:
-          type: string
-          description: The number of CPUs to allocate for the database on this node and to use for tuning Postgres. It can include the SI suffix 'm', e.g. '500m' for 500 millicpus. Cannot allocate units smaller than 1m. Defaults to the number of available CPUs on the host if 0 or unspecified. Cannot allocate more CPUs than are available on the host. Whether this limit is enforced depends on the orchestrator.
-          example: 500m
-          pattern: ^[0-9]+(\.[0-9]{1,3}|m)?$
-        host_ids:
-          type: array
-          items:
-            type: string
-            example: 76f9b8c0-4958-11f0-a489-3bb29577c696
-            minLength: 1
-            maxLength: 63
-          description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
-          example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
@@ -7393,6 +7251,215 @@ components:
         cpus: 500m
         host_ids:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
+        memory: 500M
+        name: n1
+        orchestrator_opts:
+          swarm:
+            extra_labels:
+              traefik.enable: "true"
+              traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+            extra_networks:
+              - aliases:
+                  - pg-db
+                  - db-alias
+                driver_opts:
+                  com.docker.network.endpoint.expose: "true"
+                id: traefik-public
+              - aliases:
+                  - pg-db
+                  - db-alias
+                driver_opts:
+                  com.docker.network.endpoint.expose: "true"
+                id: traefik-public
+              - aliases:
+                  - pg-db
+                  - db-alias
+                driver_opts:
+                  com.docker.network.endpoint.expose: "true"
+                id: traefik-public
+            extra_volumes:
+              - destination_path: /backups/container
+                host_path: /Users/user/backups/host
+              - destination_path: /backups/container
+                host_path: /Users/user/backups/host
+              - destination_path: /backups/container
+                host_path: /Users/user/backups/host
+        patroni_port: 8888
+        port: 5432
+        postgres_version: "17.6"
+        postgresql_conf:
+          max_connections: 1000
+        restore_config:
+          repository:
+            azure_account: pgedge-backups
+            azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+            azure_endpoint: blob.core.usgovcloudapi.net
+            azure_key: YXpLZXk=
+            base_path: /backups
+            custom_options:
+              s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+            gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+            gcs_endpoint: localhost
+            gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+            id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+            s3_endpoint: s3.us-east-1.amazonaws.com
+            s3_key: AKIAIOSFODNN7EXAMPLE
+            s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+            s3_region: us-east-1
+            type: s3
+          restore_options:
+            set: 20250505-153628F
+            target: "123456"
+            type: xid
+          source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+          source_database_name: northwind
+          source_node_name: n1
+        source_node: n1
+      required:
+        - name
+        - host_ids
+    DatabaseNodeSpec5:
+      type: object
+      properties:
+        backup_config:
+          $ref: '#/components/schemas/BackupConfigSpec'
+        cpus:
+          type: string
+          description: The number of CPUs to allocate for the database on this node and to use for tuning Postgres. It can include the SI suffix 'm', e.g. '500m' for 500 millicpus. Cannot allocate units smaller than 1m. Defaults to the number of available CPUs on the host if 0 or unspecified. Cannot allocate more CPUs than are available on the host. Whether this limit is enforced depends on the orchestrator.
+          example: 500m
+          pattern: ^[0-9]+(\.[0-9]{1,3}|m)?$
+        host_ids:
+          type: array
+          items:
+            type: string
+            example: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            minLength: 1
+            maxLength: 63
+          description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
+          example:
+            - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            - 76f9b8c0-4958-11f0-a489-3bb29577c696
+          minItems: 1
+        memory:
+          type: string
+          description: The amount of memory in SI or IEC notation to allocate for the database on this node and to use for tuning Postgres. Defaults to the total available memory on the host. Whether this limit is enforced depends on the orchestrator.
+          example: 500M
+          maxLength: 16
+        name:
+          type: string
+          description: The name of the database node.
+          example: n1
+          pattern: n[0-9]+
+        orchestrator_opts:
+          $ref: '#/components/schemas/OrchestratorOpts'
+        patroni_port:
+          type: integer
+          description: 'The port used by Patroni for this node. Overrides the Patroni port set in the DatabaseSpec. NOTE: This field is not currently supported for Docker Swarm.'
+          example: 8888
+          format: int64
+          minimum: 0
+          maximum: 65535
+        port:
+          type: integer
+          description: The port used by the Postgres database for this node. Overrides the Postgres port set in the DatabaseSpec.
+          example: 5432
+          format: int64
+          minimum: 0
+          maximum: 65535
+        postgres_version:
+          type: string
+          description: The Postgres version for this node in 'major.minor' format. Overrides the Postgres version set in the DatabaseSpec.
+          example: "17.6"
+          pattern: ^\d{2}\.\d{1,2}$
+        postgresql_conf:
+          type: object
+          description: Additional postgresql.conf settings for this particular node. Will be merged with the settings provided by control-plane.
+          example:
+            max_connections: 1000
+          additionalProperties: true
+        restore_config:
+          $ref: '#/components/schemas/RestoreConfigSpec'
+        source_node:
+          type: string
+          description: The name of the source node to use for sync. This is typically the node (like 'n1') from which the data will be copied to initialize this new node.
+          example: n1
+      example:
+        backup_config:
+          repositories:
+            - azure_account: pgedge-backups
+              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              azure_endpoint: blob.core.usgovcloudapi.net
+              azure_key: YXpLZXk=
+              base_path: /backups
+              custom_options:
+                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                storage-upload-chunk-size: 5MiB
+              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              gcs_endpoint: localhost
+              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              retention_full: 2
+              retention_full_type: count
+              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              s3_endpoint: s3.us-east-1.amazonaws.com
+              s3_key: AKIAIOSFODNN7EXAMPLE
+              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              s3_region: us-east-1
+              type: s3
+            - azure_account: pgedge-backups
+              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              azure_endpoint: blob.core.usgovcloudapi.net
+              azure_key: YXpLZXk=
+              base_path: /backups
+              custom_options:
+                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                storage-upload-chunk-size: 5MiB
+              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              gcs_endpoint: localhost
+              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              retention_full: 2
+              retention_full_type: count
+              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              s3_endpoint: s3.us-east-1.amazonaws.com
+              s3_key: AKIAIOSFODNN7EXAMPLE
+              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              s3_region: us-east-1
+              type: s3
+            - azure_account: pgedge-backups
+              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              azure_endpoint: blob.core.usgovcloudapi.net
+              azure_key: YXpLZXk=
+              base_path: /backups
+              custom_options:
+                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                storage-upload-chunk-size: 5MiB
+              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              gcs_endpoint: localhost
+              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              retention_full: 2
+              retention_full_type: count
+              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              s3_endpoint: s3.us-east-1.amazonaws.com
+              s3_key: AKIAIOSFODNN7EXAMPLE
+              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              s3_region: us-east-1
+              type: s3
+          schedules:
+            - cron_expression: 0 6 * * ?
+              id: daily-full-backup
+              type: full
+            - cron_expression: 0 6 * * ?
+              id: daily-full-backup
+              type: full
+            - cron_expression: 0 6 * * ?
+              id: daily-full-backup
+              type: full
+        cpus: 500m
+        host_ids:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 500M
@@ -7605,7 +7672,6 @@ components:
         host_ids:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
-          - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 500M
         name: n1
         orchestrator_opts:
@@ -7693,7 +7759,6 @@ components:
             maxLength: 63
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
@@ -7816,7 +7881,6 @@ components:
         host_ids:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
-          - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 500M
         name: n1
         orchestrator_opts:
@@ -7885,6 +7949,20 @@ components:
       required:
         - name
         - host_ids
+    DatabaseScripts:
+      type: object
+      properties:
+        post_database_create:
+          $ref: '#/components/schemas/SQLScript'
+        post_init:
+          $ref: '#/components/schemas/SQLScript'
+      example:
+        post_database_create:
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+          - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+        post_init:
+          - CREATE ROLE accounting_admin NOLOGIN
     DatabaseSpec:
       type: object
       properties:
@@ -7911,7 +7989,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -7920,7 +7998,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -7929,7 +8007,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -7968,186 +8046,6 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - de3b1388-1f0c-42f1-a86c-59ab72f255ec
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              patroni_port: 8888
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: f6b84a99-5e91-4203-be1e-131fe82e5984
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 02f1a7db-fca8-4521-b57a-2a375c1ced51
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: f6b84a99-5e91-4203-be1e-131fe82e5984
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - de3b1388-1f0c-42f1-a86c-59ab72f255ec
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              patroni_port: 8888
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: f6b84a99-5e91-4203-be1e-131fe82e5984
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 02f1a7db-fca8-4521-b57a-2a375c1ced51
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
-            - backup_config:
-                repositories:
                   - azure_account: pgedge-backups
                     azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
                     azure_endpoint: blob.core.usgovcloudapi.net
@@ -8278,6 +8176,8 @@ components:
           additionalProperties: true
         restore_config:
           $ref: '#/components/schemas/RestoreConfigSpec'
+        scripts:
+          $ref: '#/components/schemas/DatabaseScripts'
         services:
           type: array
           items:
@@ -8412,6 +8312,26 @@ components:
               s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
               s3_region: us-east-1
               type: s3
+            - azure_account: pgedge-backups
+              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              azure_endpoint: blob.core.usgovcloudapi.net
+              azure_key: YXpLZXk=
+              base_path: /backups
+              custom_options:
+                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                storage-upload-chunk-size: 5MiB
+              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              gcs_endpoint: localhost
+              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+              id: f6b84a99-5e91-4203-be1e-131fe82e5984
+              retention_full: 2
+              retention_full_type: count
+              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              s3_endpoint: s3.us-east-1.amazonaws.com
+              s3_key: AKIAIOSFODNN7EXAMPLE
+              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              s3_region: us-east-1
+              type: s3
           schedules:
             - cron_expression: 0 6 * * ?
               id: daily-full-backup
@@ -8429,7 +8349,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -8438,7 +8358,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -8447,7 +8367,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -8476,186 +8396,6 @@ components:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
-              schedules:
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-            cpus: 500m
-            host_ids:
-              - de3b1388-1f0c-42f1-a86c-59ab72f255ec
-            memory: 500M
-            name: n1
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-            patroni_port: 8888
-            port: 5432
-            postgres_version: "17.6"
-            postgresql_conf:
-              max_connections: 1000
-            restore_config:
-              repository:
-                azure_account: pgedge-backups
-                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                azure_endpoint: blob.core.usgovcloudapi.net
-                azure_key: YXpLZXk=
-                base_path: /backups
-                custom_options:
-                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                gcs_endpoint: localhost
-                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                id: f6b84a99-5e91-4203-be1e-131fe82e5984
-                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                s3_endpoint: s3.us-east-1.amazonaws.com
-                s3_key: AKIAIOSFODNN7EXAMPLE
-                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                s3_region: us-east-1
-                type: s3
-              restore_options:
-                set: 20250505-153628F
-                target: "123456"
-                type: xid
-              source_database_id: 02f1a7db-fca8-4521-b57a-2a375c1ced51
-              source_database_name: northwind
-              source_node_name: n1
-            source_node: n1
-          - backup_config:
-              repositories:
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: f6b84a99-5e91-4203-be1e-131fe82e5984
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-              schedules:
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-            cpus: 500m
-            host_ids:
-              - de3b1388-1f0c-42f1-a86c-59ab72f255ec
-            memory: 500M
-            name: n1
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-            patroni_port: 8888
-            port: 5432
-            postgres_version: "17.6"
-            postgresql_conf:
-              max_connections: 1000
-            restore_config:
-              repository:
-                azure_account: pgedge-backups
-                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                azure_endpoint: blob.core.usgovcloudapi.net
-                azure_key: YXpLZXk=
-                base_path: /backups
-                custom_options:
-                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                gcs_endpoint: localhost
-                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                id: f6b84a99-5e91-4203-be1e-131fe82e5984
-                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                s3_endpoint: s3.us-east-1.amazonaws.com
-                s3_key: AKIAIOSFODNN7EXAMPLE
-                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                s3_region: us-east-1
-                type: s3
-              restore_options:
-                set: 20250505-153628F
-                target: "123456"
-                type: xid
-              source_database_id: 02f1a7db-fca8-4521-b57a-2a375c1ced51
-              source_database_name: northwind
-              source_node_name: n1
-            source_node: n1
-          - backup_config:
-              repositories:
                 - azure_account: pgedge-backups
                   azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
                   azure_endpoint: blob.core.usgovcloudapi.net
@@ -8816,6 +8556,13 @@ components:
           source_database_id: 02f1a7db-fca8-4521-b57a-2a375c1ced51
           source_database_name: northwind
           source_node_name: n1
+        scripts:
+          post_database_create:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+          post_init:
+            - CREATE ROLE accounting_admin NOLOGIN
         services:
           - config:
               llm_model: gpt-4
@@ -9366,148 +9113,6 @@ components:
                 source_database_name: northwind
                 source_node_name: n1
               source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              patroni_port: 8888
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
           minItems: 1
           maxItems: 9
         orchestrator_opts:
@@ -9540,12 +9145,63 @@ components:
           additionalProperties: true
         restore_config:
           $ref: '#/components/schemas/RestoreConfigSpec'
+        scripts:
+          $ref: '#/components/schemas/DatabaseScripts'
         services:
           type: array
           items:
             $ref: '#/components/schemas/ServiceSpec2'
           description: Service instances to run alongside the database (e.g., MCP servers).
           example:
+            - config:
+                llm_model: gpt-4
+                llm_provider: openai
+                openai_api_key: sk-...
+              cpus: 500m
+              database_connection:
+                target_nodes:
+                  - n1
+                  - n2
+                target_session_attrs: primary
+              host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              memory: 512M
+              orchestrator_opts:
+                swarm:
+                  extra_labels:
+                    traefik.enable: "true"
+                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                  extra_networks:
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                  extra_volumes:
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+              port: 0
+              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              service_type: rag
+              version: latest
             - config:
                 llm_model: gpt-4
                 llm_provider: openai
@@ -10087,148 +9743,6 @@ components:
               source_database_name: northwind
               source_node_name: n1
             source_node: n1
-          - backup_config:
-              repositories:
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-              schedules:
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-            cpus: 500m
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 500M
-            name: n1
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-            patroni_port: 8888
-            port: 5432
-            postgres_version: "17.6"
-            postgresql_conf:
-              max_connections: 1000
-            restore_config:
-              repository:
-                azure_account: pgedge-backups
-                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                azure_endpoint: blob.core.usgovcloudapi.net
-                azure_key: YXpLZXk=
-                base_path: /backups
-                custom_options:
-                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                gcs_endpoint: localhost
-                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                s3_endpoint: s3.us-east-1.amazonaws.com
-                s3_key: AKIAIOSFODNN7EXAMPLE
-                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                s3_region: us-east-1
-                type: s3
-              restore_options:
-                set: 20250505-153628F
-                target: "123456"
-                type: xid
-              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              source_database_name: northwind
-              source_node_name: n1
-            source_node: n1
         orchestrator_opts:
           swarm:
             extra_labels:
@@ -10291,6 +9805,15 @@ components:
           source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
           source_database_name: northwind
           source_node_name: n1
+        scripts:
+          post_database_create:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+          post_init:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
         services:
           - config:
               llm_model: gpt-4
@@ -10835,147 +10358,6 @@ components:
                 source_database_name: northwind
                 source_node_name: n1
               source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              patroni_port: 8888
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
           minItems: 1
           maxItems: 9
         orchestrator_opts:
@@ -11008,6 +10390,8 @@ components:
           additionalProperties: true
         restore_config:
           $ref: '#/components/schemas/RestoreConfigSpec'
+        scripts:
+          $ref: '#/components/schemas/DatabaseScripts'
         services:
           type: array
           items:
@@ -11756,56 +11140,16 @@ components:
           source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
           source_database_name: northwind
           source_node_name: n1
+        scripts:
+          post_database_create:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+          post_init:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
         services:
-          - config:
-              llm_model: gpt-4
-              llm_provider: openai
-              openai_api_key: sk-...
-            cpus: 500m
-            database_connection:
-              target_nodes:
-                - n1
-                - n2
-              target_session_attrs: primary
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 512M
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-            port: 0
-            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-            service_type: rag
-            version: latest
           - config:
               llm_model: gpt-4
               llm_provider: openai
@@ -12300,147 +11644,6 @@ components:
                 source_database_name: northwind
                 source_node_name: n1
               source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              patroni_port: 8888
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
           minItems: 1
           maxItems: 9
         orchestrator_opts:
@@ -12473,6 +11676,8 @@ components:
           additionalProperties: true
         restore_config:
           $ref: '#/components/schemas/RestoreConfigSpec'
+        scripts:
+          $ref: '#/components/schemas/DatabaseScripts'
         services:
           type: array
           items:
@@ -13067,147 +12272,6 @@ components:
               source_database_name: northwind
               source_node_name: n1
             source_node: n1
-          - backup_config:
-              repositories:
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-              schedules:
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-            cpus: 500m
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 500M
-            name: n1
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-            patroni_port: 8888
-            port: 5432
-            postgres_version: "17.6"
-            postgresql_conf:
-              max_connections: 1000
-            restore_config:
-              repository:
-                azure_account: pgedge-backups
-                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                azure_endpoint: blob.core.usgovcloudapi.net
-                azure_key: YXpLZXk=
-                base_path: /backups
-                custom_options:
-                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                gcs_endpoint: localhost
-                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                s3_endpoint: s3.us-east-1.amazonaws.com
-                s3_key: AKIAIOSFODNN7EXAMPLE
-                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                s3_region: us-east-1
-                type: s3
-              restore_options:
-                set: 20250505-153628F
-                target: "123456"
-                type: xid
-              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              source_database_name: northwind
-              source_node_name: n1
-            source_node: n1
         orchestrator_opts:
           swarm:
             extra_labels:
@@ -13270,6 +12334,15 @@ components:
           source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
           source_database_name: northwind
           source_node_name: n1
+        scripts:
+          post_database_create:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+          post_init:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
         services:
           - config:
               llm_model: gpt-4
@@ -13673,147 +12746,6 @@ components:
                 source_database_name: northwind
                 source_node_name: n1
               source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              patroni_port: 8888
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
           minItems: 1
           maxItems: 9
         orchestrator_opts:
@@ -13846,12 +12778,62 @@ components:
           additionalProperties: true
         restore_config:
           $ref: '#/components/schemas/RestoreConfigSpec'
+        scripts:
+          $ref: '#/components/schemas/DatabaseScripts'
         services:
           type: array
           items:
             $ref: '#/components/schemas/ServiceSpec5'
           description: Service instances to run alongside the database (e.g., MCP servers).
           example:
+            - config:
+                llm_model: gpt-4
+                llm_provider: openai
+                openai_api_key: sk-...
+              cpus: 500m
+              database_connection:
+                target_nodes:
+                  - n1
+                  - n2
+                target_session_attrs: primary
+              host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              memory: 512M
+              orchestrator_opts:
+                swarm:
+                  extra_labels:
+                    traefik.enable: "true"
+                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                  extra_networks:
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                  extra_volumes:
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+              port: 0
+              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              service_type: rag
+              version: latest
             - config:
                 llm_model: gpt-4
                 llm_provider: openai
@@ -14199,147 +13181,6 @@ components:
               source_database_name: northwind
               source_node_name: n1
             source_node: n1
-          - backup_config:
-              repositories:
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-              schedules:
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-            cpus: 500m
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 500M
-            name: n1
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-            patroni_port: 8888
-            port: 5432
-            postgres_version: "17.6"
-            postgresql_conf:
-              max_connections: 1000
-            restore_config:
-              repository:
-                azure_account: pgedge-backups
-                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                azure_endpoint: blob.core.usgovcloudapi.net
-                azure_key: YXpLZXk=
-                base_path: /backups
-                custom_options:
-                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                gcs_endpoint: localhost
-                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                s3_endpoint: s3.us-east-1.amazonaws.com
-                s3_key: AKIAIOSFODNN7EXAMPLE
-                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                s3_region: us-east-1
-                type: s3
-              restore_options:
-                set: 20250505-153628F
-                target: "123456"
-                type: xid
-              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              source_database_name: northwind
-              source_node_name: n1
-            source_node: n1
         orchestrator_opts:
           swarm:
             extra_labels:
@@ -14402,55 +13243,16 @@ components:
           source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
           source_database_name: northwind
           source_node_name: n1
+        scripts:
+          post_database_create:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+          post_init:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
         services:
-          - config:
-              llm_model: gpt-4
-              llm_provider: openai
-              openai_api_key: sk-...
-            cpus: 500m
-            database_connection:
-              target_nodes:
-                - n1
-                - n2
-              target_session_attrs: primary
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 512M
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-            port: 0
-            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-            service_type: rag
-            version: latest
           - config:
               llm_model: gpt-4
               llm_provider: openai
@@ -14801,288 +13603,6 @@ components:
                 source_database_name: northwind
                 source_node_name: n1
               source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              patroni_port: 8888
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              patroni_port: 8888
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
           minItems: 1
           maxItems: 9
         orchestrator_opts:
@@ -15115,110 +13635,14 @@ components:
           additionalProperties: true
         restore_config:
           $ref: '#/components/schemas/RestoreConfigSpec'
+        scripts:
+          $ref: '#/components/schemas/DatabaseScripts'
         services:
           type: array
           items:
             $ref: '#/components/schemas/ServiceSpec6'
           description: Service instances to run alongside the database (e.g., MCP servers).
           example:
-            - config:
-                llm_model: gpt-4
-                llm_provider: openai
-                openai_api_key: sk-...
-              cpus: 500m
-              database_connection:
-                target_nodes:
-                  - n1
-                  - n2
-                target_session_attrs: primary
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 512M
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              port: 0
-              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              service_type: rag
-              version: latest
-            - config:
-                llm_model: gpt-4
-                llm_provider: openai
-                openai_api_key: sk-...
-              cpus: 500m
-              database_connection:
-                target_nodes:
-                  - n1
-                  - n2
-                target_session_attrs: primary
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 512M
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              port: 0
-              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              service_type: rag
-              version: latest
             - config:
                 llm_model: gpt-4
                 llm_provider: openai
@@ -15568,147 +13992,6 @@ components:
               source_database_name: northwind
               source_node_name: n1
             source_node: n1
-          - backup_config:
-              repositories:
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-              schedules:
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-            cpus: 500m
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 500M
-            name: n1
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-            patroni_port: 8888
-            port: 5432
-            postgres_version: "17.6"
-            postgresql_conf:
-              max_connections: 1000
-            restore_config:
-              repository:
-                azure_account: pgedge-backups
-                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                azure_endpoint: blob.core.usgovcloudapi.net
-                azure_key: YXpLZXk=
-                base_path: /backups
-                custom_options:
-                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                gcs_endpoint: localhost
-                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                s3_endpoint: s3.us-east-1.amazonaws.com
-                s3_key: AKIAIOSFODNN7EXAMPLE
-                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                s3_region: us-east-1
-                type: s3
-              restore_options:
-                set: 20250505-153628F
-                target: "123456"
-                type: xid
-              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              source_database_name: northwind
-              source_node_name: n1
-            source_node: n1
         orchestrator_opts:
           swarm:
             extra_labels:
@@ -15771,7 +14054,65 @@ components:
           source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
           source_database_name: northwind
           source_node_name: n1
+        scripts:
+          post_database_create:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+          post_init:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
         services:
+          - config:
+              llm_model: gpt-4
+              llm_provider: openai
+              openai_api_key: sk-...
+            cpus: 500m
+            database_connection:
+              target_nodes:
+                - n1
+                - n2
+              target_session_attrs: primary
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 512M
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+            port: 0
+            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            service_type: rag
+            version: latest
           - config:
               llm_model: gpt-4
               llm_provider: openai
@@ -16266,147 +14607,6 @@ components:
                 source_database_name: northwind
                 source_node_name: n1
               source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-              patroni_port: 8888
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
           minItems: 1
           maxItems: 9
         orchestrator_opts:
@@ -16439,6 +14639,8 @@ components:
           additionalProperties: true
         restore_config:
           $ref: '#/components/schemas/RestoreConfigSpec'
+        scripts:
+          $ref: '#/components/schemas/DatabaseScripts'
         services:
           type: array
           items:
@@ -16794,288 +14996,6 @@ components:
               source_database_name: northwind
               source_node_name: n1
             source_node: n1
-          - backup_config:
-              repositories:
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-              schedules:
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-            cpus: 500m
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 500M
-            name: n1
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-            patroni_port: 8888
-            port: 5432
-            postgres_version: "17.6"
-            postgresql_conf:
-              max_connections: 1000
-            restore_config:
-              repository:
-                azure_account: pgedge-backups
-                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                azure_endpoint: blob.core.usgovcloudapi.net
-                azure_key: YXpLZXk=
-                base_path: /backups
-                custom_options:
-                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                gcs_endpoint: localhost
-                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                s3_endpoint: s3.us-east-1.amazonaws.com
-                s3_key: AKIAIOSFODNN7EXAMPLE
-                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                s3_region: us-east-1
-                type: s3
-              restore_options:
-                set: 20250505-153628F
-                target: "123456"
-                type: xid
-              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              source_database_name: northwind
-              source_node_name: n1
-            source_node: n1
-          - backup_config:
-              repositories:
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-              schedules:
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-                - cron_expression: 0 6 * * ?
-                  id: daily-full-backup
-                  type: full
-            cpus: 500m
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 500M
-            name: n1
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-            patroni_port: 8888
-            port: 5432
-            postgres_version: "17.6"
-            postgresql_conf:
-              max_connections: 1000
-            restore_config:
-              repository:
-                azure_account: pgedge-backups
-                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                azure_endpoint: blob.core.usgovcloudapi.net
-                azure_key: YXpLZXk=
-                base_path: /backups
-                custom_options:
-                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                gcs_endpoint: localhost
-                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                s3_endpoint: s3.us-east-1.amazonaws.com
-                s3_key: AKIAIOSFODNN7EXAMPLE
-                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                s3_region: us-east-1
-                type: s3
-              restore_options:
-                set: 20250505-153628F
-                target: "123456"
-                type: xid
-              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              source_database_name: northwind
-              source_node_name: n1
-            source_node: n1
         orchestrator_opts:
           swarm:
             extra_labels:
@@ -17138,7 +15058,114 @@ components:
           source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
           source_database_name: northwind
           source_node_name: n1
+        scripts:
+          post_database_create:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+          post_init:
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+            - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
         services:
+          - config:
+              llm_model: gpt-4
+              llm_provider: openai
+              openai_api_key: sk-...
+            cpus: 500m
+            database_connection:
+              target_nodes:
+                - n1
+                - n2
+              target_session_attrs: primary
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 512M
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+            port: 0
+            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            service_type: rag
+            version: latest
+          - config:
+              llm_model: gpt-4
+              llm_provider: openai
+              openai_api_key: sk-...
+            cpus: 500m
+            database_connection:
+              target_nodes:
+                - n1
+                - n2
+              target_session_attrs: primary
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 512M
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+            port: 0
+            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            service_type: rag
+            version: latest
           - config:
               llm_model: gpt-4
               llm_provider: openai
@@ -17266,13 +15293,13 @@ components:
                   - 10.24.34.2
                   - i-0123456789abcdef.ec2.internal
                 port: 5432
-              created_at: "1971-07-18T16:52:12Z"
+              created_at: "1970-12-24T01:48:39Z"
               error: 'failed to get patroni status: connection refused'
               host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
               id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
               node_name: n1
               postgres:
-                patroni_paused: false
+                patroni_paused: true
                 patroni_state: unknown
                 pending_restart: true
                 role: primary
@@ -17286,25 +15313,22 @@ components:
                   - name: sub_n1n2
                     provider_node: n2
                     status: down
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
                 version: 4.10.0
-              state: deleting
-              status_updated_at: "1999-09-23T18:53:48Z"
-              updated_at: "2013-04-06T16:38:09Z"
+              state: unknown
+              status_updated_at: "1978-12-17T01:14:06Z"
+              updated_at: "2010-08-13T18:38:44Z"
             - connection_info:
                 addresses:
                   - 10.24.34.2
                   - i-0123456789abcdef.ec2.internal
                 port: 5432
-              created_at: "1971-07-18T16:52:12Z"
+              created_at: "1970-12-24T01:48:39Z"
               error: 'failed to get patroni status: connection refused'
               host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
               id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
               node_name: n1
               postgres:
-                patroni_paused: false
+                patroni_paused: true
                 patroni_state: unknown
                 pending_restart: true
                 role: primary
@@ -17318,25 +15342,22 @@ components:
                   - name: sub_n1n2
                     provider_node: n2
                     status: down
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
                 version: 4.10.0
-              state: deleting
-              status_updated_at: "1999-09-23T18:53:48Z"
-              updated_at: "2013-04-06T16:38:09Z"
+              state: unknown
+              status_updated_at: "1978-12-17T01:14:06Z"
+              updated_at: "2010-08-13T18:38:44Z"
             - connection_info:
                 addresses:
                   - 10.24.34.2
                   - i-0123456789abcdef.ec2.internal
                 port: 5432
-              created_at: "1971-07-18T16:52:12Z"
+              created_at: "1970-12-24T01:48:39Z"
               error: 'failed to get patroni status: connection refused'
               host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
               id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
               node_name: n1
               postgres:
-                patroni_paused: false
+                patroni_paused: true
                 patroni_state: unknown
                 pending_restart: true
                 role: primary
@@ -17350,49 +15371,14 @@ components:
                   - name: sub_n1n2
                     provider_node: n2
                     status: down
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
                 version: 4.10.0
-              state: deleting
-              status_updated_at: "1999-09-23T18:53:48Z"
-              updated_at: "2013-04-06T16:38:09Z"
-            - connection_info:
-                addresses:
-                  - 10.24.34.2
-                  - i-0123456789abcdef.ec2.internal
-                port: 5432
-              created_at: "1971-07-18T16:52:12Z"
-              error: 'failed to get patroni status: connection refused'
-              host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-              id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-              node_name: n1
-              postgres:
-                patroni_paused: false
-                patroni_state: unknown
-                pending_restart: true
-                role: primary
-                version: "18.1"
-              spock:
-                read_only: "off"
-                subscriptions:
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
-                version: 4.10.0
-              state: deleting
-              status_updated_at: "1999-09-23T18:53:48Z"
-              updated_at: "2013-04-06T16:38:09Z"
+              state: unknown
+              status_updated_at: "1978-12-17T01:14:06Z"
+              updated_at: "2010-08-13T18:38:44Z"
         state:
           type: string
           description: Current state of the database.
-          example: failed
+          example: backing_up
           enum:
             - creating
             - modifying
@@ -17423,13 +15409,13 @@ components:
                 - 10.24.34.2
                 - i-0123456789abcdef.ec2.internal
               port: 5432
-            created_at: "1971-07-18T16:52:12Z"
+            created_at: "1970-12-24T01:48:39Z"
             error: 'failed to get patroni status: connection refused'
             host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
             id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
             node_name: n1
             postgres:
-              patroni_paused: false
+              patroni_paused: true
               patroni_state: unknown
               pending_restart: true
               role: primary
@@ -17443,25 +15429,22 @@ components:
                 - name: sub_n1n2
                   provider_node: n2
                   status: down
-                - name: sub_n1n2
-                  provider_node: n2
-                  status: down
               version: 4.10.0
-            state: deleting
-            status_updated_at: "1999-09-23T18:53:48Z"
-            updated_at: "2013-04-06T16:38:09Z"
+            state: unknown
+            status_updated_at: "1978-12-17T01:14:06Z"
+            updated_at: "2010-08-13T18:38:44Z"
           - connection_info:
               addresses:
                 - 10.24.34.2
                 - i-0123456789abcdef.ec2.internal
               port: 5432
-            created_at: "1971-07-18T16:52:12Z"
+            created_at: "1970-12-24T01:48:39Z"
             error: 'failed to get patroni status: connection refused'
             host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
             id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
             node_name: n1
             postgres:
-              patroni_paused: false
+              patroni_paused: true
               patroni_state: unknown
               pending_restart: true
               role: primary
@@ -17475,14 +15458,69 @@ components:
                 - name: sub_n1n2
                   provider_node: n2
                   status: down
+              version: 4.10.0
+            state: unknown
+            status_updated_at: "1978-12-17T01:14:06Z"
+            updated_at: "2010-08-13T18:38:44Z"
+          - connection_info:
+              addresses:
+                - 10.24.34.2
+                - i-0123456789abcdef.ec2.internal
+              port: 5432
+            created_at: "1970-12-24T01:48:39Z"
+            error: 'failed to get patroni status: connection refused'
+            host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+            id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
+            node_name: n1
+            postgres:
+              patroni_paused: true
+              patroni_state: unknown
+              pending_restart: true
+              role: primary
+              version: "18.1"
+            spock:
+              read_only: "off"
+              subscriptions:
+                - name: sub_n1n2
+                  provider_node: n2
+                  status: down
                 - name: sub_n1n2
                   provider_node: n2
                   status: down
               version: 4.10.0
-            state: deleting
-            status_updated_at: "1999-09-23T18:53:48Z"
-            updated_at: "2013-04-06T16:38:09Z"
-        state: degraded
+            state: unknown
+            status_updated_at: "1978-12-17T01:14:06Z"
+            updated_at: "2010-08-13T18:38:44Z"
+          - connection_info:
+              addresses:
+                - 10.24.34.2
+                - i-0123456789abcdef.ec2.internal
+              port: 5432
+            created_at: "1970-12-24T01:48:39Z"
+            error: 'failed to get patroni status: connection refused'
+            host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+            id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
+            node_name: n1
+            postgres:
+              patroni_paused: true
+              patroni_state: unknown
+              pending_restart: true
+              role: primary
+              version: "18.1"
+            spock:
+              read_only: "off"
+              subscriptions:
+                - name: sub_n1n2
+                  provider_node: n2
+                  status: down
+                - name: sub_n1n2
+                  provider_node: n2
+                  status: down
+              version: 4.10.0
+            state: unknown
+            status_updated_at: "1978-12-17T01:14:06Z"
+            updated_at: "2010-08-13T18:38:44Z"
+        state: failed
         tenant_id: 8210ec10-2dca-406c-ac4a-0661d2189954
         updated_at: "2025-01-01T02:30:00Z"
       required:
@@ -17593,7 +15631,7 @@ components:
           type: array
           items:
             type: string
-            example: Illo dolore.
+            example: Totam accusamus alias.
           description: Optional network-scoped aliases for the container.
           example:
             - pg-db
@@ -17606,7 +15644,7 @@ components:
             com.docker.network.endpoint.expose: "true"
           additionalProperties:
             type: string
-            example: Accusamus alias ipsa qui.
+            example: Qui ut et.
         id:
           type: string
           description: The name or ID of the network to connect to.
@@ -17686,7 +15724,7 @@ components:
           example: false
       example:
         candidate_instance_id: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
-        skip_validation: false
+        skip_validation: true
     FailoverDatabaseNodeResponse:
       type: object
       properties:
@@ -17736,7 +15774,7 @@ components:
           type: array
           items:
             type: string
-            example: Quas nostrum eos reprehenderit harum sapiente qui.
+            example: Animi recusandae.
           description: The addresses that this host advertises to client applications.
           example:
             - 10.24.34.2
@@ -17779,7 +15817,7 @@ components:
           type: array
           items:
             type: string
-            example: Quo recusandae quibusdam fuga molestiae.
+            example: Qui quam sint iure eum ducimus quia.
           description: The addresses that this host advertises to other hosts.
           example:
             - 10.24.34.2
@@ -17792,6 +15830,10 @@ components:
             $ref: '#/components/schemas/PgEdgeVersion'
           description: The PgEdge versions supported by this host.
           example:
+            - postgres_version: "17.6"
+              spock_version: "5"
+            - postgres_version: "17.6"
+              spock_version: "5"
             - postgres_version: "17.6"
               spock_version: "5"
             - postgres_version: "17.6"
@@ -17837,6 +15879,10 @@ components:
             spock_version: "5"
           - postgres_version: "17.6"
             spock_version: "5"
+          - postgres_version: "17.6"
+            spock_version: "5"
+          - postgres_version: "17.6"
+            spock_version: "5"
       required:
         - id
         - orchestrator
@@ -17874,7 +15920,19 @@ components:
           type: object
           description: The status of each component of the host.
           example:
-            Possimus error eligendi recusandae.:
+            At esse ut possimus error eligendi.:
+              details:
+                alarms:
+                  - '3: NOSPACE'
+              error: failed to connect to etcd
+              healthy: false
+            Atque facilis non modi explicabo illum.:
+              details:
+                alarms:
+                  - '3: NOSPACE'
+              error: failed to connect to etcd
+              healthy: false
+            Similique sed neque eos rerum quia.:
               details:
                 alarms:
                   - '3: NOSPACE'
@@ -17897,19 +15955,19 @@ components:
           format: date-time
       example:
         components:
-          Atque facilis non modi explicabo illum.:
+          Et eius reiciendis accusamus veritatis quo recusandae.:
             details:
               alarms:
                 - '3: NOSPACE'
             error: failed to connect to etcd
             healthy: false
-          Neque eos rerum quia.:
+          Fuga molestiae.:
             details:
               alarms:
                 - '3: NOSPACE'
             error: failed to connect to etcd
             healthy: false
-          Qui et eius reiciendis accusamus.:
+          Quas nostrum eos reprehenderit harum sapiente qui.:
             details:
               alarms:
                 - '3: NOSPACE'
@@ -17941,7 +15999,7 @@ components:
         created_at:
           type: string
           description: The time that the instance was created.
-          example: "1977-01-28T10:07:37Z"
+          example: "1993-02-25T18:38:10Z"
           format: date-time
         error:
           type: string
@@ -17979,12 +16037,12 @@ components:
         status_updated_at:
           type: string
           description: The time that the instance status information was last updated.
-          example: "1999-11-24T20:30:24Z"
+          example: "1983-10-23T08:18:23Z"
           format: date-time
         updated_at:
           type: string
           description: The time that the instance was last modified.
-          example: "2012-07-13T20:43:05Z"
+          example: "1971-02-20T15:20:44Z"
           format: date-time
       description: An instance of pgEdge Postgres running on a host.
       example:
@@ -17993,13 +16051,13 @@ components:
             - 10.24.34.2
             - i-0123456789abcdef.ec2.internal
           port: 5432
-        created_at: "2003-06-28T19:25:47Z"
+        created_at: "1994-07-03T05:16:56Z"
         error: 'failed to get patroni status: connection refused'
         host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
         id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
         node_name: n1
         postgres:
-          patroni_paused: false
+          patroni_paused: true
           patroni_state: unknown
           pending_restart: true
           role: primary
@@ -18013,13 +16071,10 @@ components:
             - name: sub_n1n2
               provider_node: n2
               status: down
-            - name: sub_n1n2
-              provider_node: n2
-              status: down
           version: 4.10.0
         state: modifying
-        status_updated_at: "1992-10-18T20:01:09Z"
-        updated_at: "1982-02-16T16:16:42Z"
+        status_updated_at: "1994-09-09T06:25:01Z"
+        updated_at: "2014-04-20T04:34:11Z"
       required:
         - id
         - host_id
@@ -18034,7 +16089,7 @@ components:
           type: array
           items:
             type: string
-            example: Eum ducimus.
+            example: Ea omnis ut dolor dolorem impedit laudantium.
           description: The addresses of the host that's running this instance.
           example:
             - 10.24.34.2
@@ -18075,7 +16130,7 @@ components:
       example:
         patroni_paused: false
         patroni_state: unknown
-        pending_restart: true
+        pending_restart: false
         role: primary
         version: "18.1"
     InstanceSpockStatus:
@@ -18100,9 +16155,6 @@ components:
             - name: sub_n1n2
               provider_node: n2
               status: down
-            - name: sub_n1n2
-              provider_node: n2
-              status: down
         version:
           type: string
           description: The version of Spock for this instance.
@@ -18111,9 +16163,6 @@ components:
       example:
         read_only: "off"
         subscriptions:
-          - name: sub_n1n2
-            provider_node: n2
-            status: down
           - name: sub_n1n2
             provider_node: n2
             status: down
@@ -18158,6 +16207,14 @@ components:
             $ref: '#/components/schemas/Task'
           description: The tasks for the given database.
           example:
+            - completed_at: "2025-06-18T16:52:35Z"
+              created_at: "2025-06-18T16:52:05Z"
+              database_id: storefront
+              entity_id: storefront
+              scope: database
+              status: completed
+              task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
+              type: create
             - completed_at: "2025-06-18T16:52:35Z"
               created_at: "2025-06-18T16:52:05Z"
               database_id: storefront
@@ -18236,13 +16293,13 @@ components:
                       - 10.24.34.2
                       - i-0123456789abcdef.ec2.internal
                     port: 5432
-                  created_at: "1971-07-18T16:52:12Z"
+                  created_at: "1970-12-24T01:48:39Z"
                   error: 'failed to get patroni status: connection refused'
                   host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
                   id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
                   node_name: n1
                   postgres:
-                    patroni_paused: false
+                    patroni_paused: true
                     patroni_state: unknown
                     pending_restart: true
                     role: primary
@@ -18256,25 +16313,22 @@ components:
                       - name: sub_n1n2
                         provider_node: n2
                         status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
                     version: 4.10.0
-                  state: deleting
-                  status_updated_at: "1999-09-23T18:53:48Z"
-                  updated_at: "2013-04-06T16:38:09Z"
+                  state: unknown
+                  status_updated_at: "1978-12-17T01:14:06Z"
+                  updated_at: "2010-08-13T18:38:44Z"
                 - connection_info:
                     addresses:
                       - 10.24.34.2
                       - i-0123456789abcdef.ec2.internal
                     port: 5432
-                  created_at: "1971-07-18T16:52:12Z"
+                  created_at: "1970-12-24T01:48:39Z"
                   error: 'failed to get patroni status: connection refused'
                   host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
                   id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
                   node_name: n1
                   postgres:
-                    patroni_paused: false
+                    patroni_paused: true
                     patroni_state: unknown
                     pending_restart: true
                     role: primary
@@ -18288,13 +16342,39 @@ components:
                       - name: sub_n1n2
                         provider_node: n2
                         status: down
+                    version: 4.10.0
+                  state: unknown
+                  status_updated_at: "1978-12-17T01:14:06Z"
+                  updated_at: "2010-08-13T18:38:44Z"
+                - connection_info:
+                    addresses:
+                      - 10.24.34.2
+                      - i-0123456789abcdef.ec2.internal
+                    port: 5432
+                  created_at: "1970-12-24T01:48:39Z"
+                  error: 'failed to get patroni status: connection refused'
+                  host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+                  id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
+                  node_name: n1
+                  postgres:
+                    patroni_paused: true
+                    patroni_state: unknown
+                    pending_restart: true
+                    role: primary
+                    version: "18.1"
+                  spock:
+                    read_only: "off"
+                    subscriptions:
+                      - name: sub_n1n2
+                        provider_node: n2
+                        status: down
                       - name: sub_n1n2
                         provider_node: n2
                         status: down
                     version: 4.10.0
-                  state: deleting
-                  status_updated_at: "1999-09-23T18:53:48Z"
-                  updated_at: "2013-04-06T16:38:09Z"
+                  state: unknown
+                  status_updated_at: "1978-12-17T01:14:06Z"
+                  updated_at: "2010-08-13T18:38:44Z"
               state: failed
               tenant_id: 8210ec10-2dca-406c-ac4a-0661d2189954
               updated_at: "2025-01-01T02:30:00Z"
@@ -18306,13 +16386,13 @@ components:
                       - 10.24.34.2
                       - i-0123456789abcdef.ec2.internal
                     port: 5432
-                  created_at: "1971-07-18T16:52:12Z"
+                  created_at: "1970-12-24T01:48:39Z"
                   error: 'failed to get patroni status: connection refused'
                   host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
                   id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
                   node_name: n1
                   postgres:
-                    patroni_paused: false
+                    patroni_paused: true
                     patroni_state: unknown
                     pending_restart: true
                     role: primary
@@ -18326,25 +16406,22 @@ components:
                       - name: sub_n1n2
                         provider_node: n2
                         status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
                     version: 4.10.0
-                  state: deleting
-                  status_updated_at: "1999-09-23T18:53:48Z"
-                  updated_at: "2013-04-06T16:38:09Z"
+                  state: unknown
+                  status_updated_at: "1978-12-17T01:14:06Z"
+                  updated_at: "2010-08-13T18:38:44Z"
                 - connection_info:
                     addresses:
                       - 10.24.34.2
                       - i-0123456789abcdef.ec2.internal
                     port: 5432
-                  created_at: "1971-07-18T16:52:12Z"
+                  created_at: "1970-12-24T01:48:39Z"
                   error: 'failed to get patroni status: connection refused'
                   host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
                   id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
                   node_name: n1
                   postgres:
-                    patroni_paused: false
+                    patroni_paused: true
                     patroni_state: unknown
                     pending_restart: true
                     role: primary
@@ -18358,13 +16435,39 @@ components:
                       - name: sub_n1n2
                         provider_node: n2
                         status: down
+                    version: 4.10.0
+                  state: unknown
+                  status_updated_at: "1978-12-17T01:14:06Z"
+                  updated_at: "2010-08-13T18:38:44Z"
+                - connection_info:
+                    addresses:
+                      - 10.24.34.2
+                      - i-0123456789abcdef.ec2.internal
+                    port: 5432
+                  created_at: "1970-12-24T01:48:39Z"
+                  error: 'failed to get patroni status: connection refused'
+                  host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+                  id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
+                  node_name: n1
+                  postgres:
+                    patroni_paused: true
+                    patroni_state: unknown
+                    pending_restart: true
+                    role: primary
+                    version: "18.1"
+                  spock:
+                    read_only: "off"
+                    subscriptions:
+                      - name: sub_n1n2
+                        provider_node: n2
+                        status: down
                       - name: sub_n1n2
                         provider_node: n2
                         status: down
                     version: 4.10.0
-                  state: deleting
-                  status_updated_at: "1999-09-23T18:53:48Z"
-                  updated_at: "2013-04-06T16:38:09Z"
+                  state: unknown
+                  status_updated_at: "1978-12-17T01:14:06Z"
+                  updated_at: "2010-08-13T18:38:44Z"
               state: failed
               tenant_id: 8210ec10-2dca-406c-ac4a-0661d2189954
               updated_at: "2025-01-01T02:30:00Z"
@@ -18376,13 +16479,13 @@ components:
                       - 10.24.34.2
                       - i-0123456789abcdef.ec2.internal
                     port: 5432
-                  created_at: "1971-07-18T16:52:12Z"
+                  created_at: "1970-12-24T01:48:39Z"
                   error: 'failed to get patroni status: connection refused'
                   host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
                   id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
                   node_name: n1
                   postgres:
-                    patroni_paused: false
+                    patroni_paused: true
                     patroni_state: unknown
                     pending_restart: true
                     role: primary
@@ -18396,25 +16499,22 @@ components:
                       - name: sub_n1n2
                         provider_node: n2
                         status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
                     version: 4.10.0
-                  state: deleting
-                  status_updated_at: "1999-09-23T18:53:48Z"
-                  updated_at: "2013-04-06T16:38:09Z"
+                  state: unknown
+                  status_updated_at: "1978-12-17T01:14:06Z"
+                  updated_at: "2010-08-13T18:38:44Z"
                 - connection_info:
                     addresses:
                       - 10.24.34.2
                       - i-0123456789abcdef.ec2.internal
                     port: 5432
-                  created_at: "1971-07-18T16:52:12Z"
+                  created_at: "1970-12-24T01:48:39Z"
                   error: 'failed to get patroni status: connection refused'
                   host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
                   id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
                   node_name: n1
                   postgres:
-                    patroni_paused: false
+                    patroni_paused: true
                     patroni_state: unknown
                     pending_restart: true
                     role: primary
@@ -18428,13 +16528,39 @@ components:
                       - name: sub_n1n2
                         provider_node: n2
                         status: down
+                    version: 4.10.0
+                  state: unknown
+                  status_updated_at: "1978-12-17T01:14:06Z"
+                  updated_at: "2010-08-13T18:38:44Z"
+                - connection_info:
+                    addresses:
+                      - 10.24.34.2
+                      - i-0123456789abcdef.ec2.internal
+                    port: 5432
+                  created_at: "1970-12-24T01:48:39Z"
+                  error: 'failed to get patroni status: connection refused'
+                  host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+                  id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
+                  node_name: n1
+                  postgres:
+                    patroni_paused: true
+                    patroni_state: unknown
+                    pending_restart: true
+                    role: primary
+                    version: "18.1"
+                  spock:
+                    read_only: "off"
+                    subscriptions:
+                      - name: sub_n1n2
+                        provider_node: n2
+                        status: down
                       - name: sub_n1n2
                         provider_node: n2
                         status: down
                     version: 4.10.0
-                  state: deleting
-                  status_updated_at: "1999-09-23T18:53:48Z"
-                  updated_at: "2013-04-06T16:38:09Z"
+                  state: unknown
+                  status_updated_at: "1978-12-17T01:14:06Z"
+                  updated_at: "2010-08-13T18:38:44Z"
               state: failed
               tenant_id: 8210ec10-2dca-406c-ac4a-0661d2189954
               updated_at: "2025-01-01T02:30:00Z"
@@ -18841,6 +16967,48 @@ components:
                 spock_version: "5"
               - postgres_version: "17.6"
                 spock_version: "5"
+          - client_addresses:
+              - 10.24.34.2
+              - i-0123456789abcdef.ec2.internal
+            cohort:
+              control_available: true
+              member_id: lah4bsznw6kc0hp7biylmmmll
+              type: swarm
+            cpus: 4
+            data_dir: /data
+            default_pgedge_version:
+              postgres_version: "17.6"
+              spock_version: "5"
+            etcd_mode: server
+            id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+            memory: 16GiB
+            orchestrator: swarm
+            peer_addresses:
+              - 10.24.34.2
+              - i-0123456789abcdef.ec2.internal
+            status:
+              components:
+                Enim et voluptatum ex ea dolore.:
+                  details:
+                    alarms:
+                      - '3: NOSPACE'
+                  error: failed to connect to etcd
+                  healthy: false
+                Tenetur nostrum repellendus sint qui.:
+                  details:
+                    alarms:
+                      - '3: NOSPACE'
+                  error: failed to connect to etcd
+                  healthy: false
+              state: available
+              updated_at: "2021-07-01T12:34:56Z"
+            supported_pgedge_versions:
+              - postgres_version: "17.6"
+                spock_version: "5"
+              - postgres_version: "17.6"
+                spock_version: "5"
+              - postgres_version: "17.6"
+                spock_version: "5"
       required:
         - hosts
     ListTasksResponse:
@@ -19057,14 +17225,6 @@ components:
             status: completed
             task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
             type: create
-          - completed_at: "2025-06-18T16:52:35Z"
-            created_at: "2025-06-18T16:52:05Z"
-            database_id: storefront
-            entity_id: storefront
-            scope: database
-            status: completed
-            task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
-            type: create
       required:
         - task
         - update_database_tasks
@@ -19159,7 +17319,7 @@ components:
           type: array
           items:
             type: string
-            example: At praesentium ut dolorem sapiente.
+            example: Sapiente placeat illo.
           description: The nodes to restore. Defaults to all nodes if empty or unspecified.
           example:
             - n1
@@ -19187,14 +17347,6 @@ components:
             $ref: '#/components/schemas/Task'
           description: The tasks that will restore each database node.
           example:
-            - completed_at: "2025-06-18T16:52:35Z"
-              created_at: "2025-06-18T16:52:05Z"
-              database_id: storefront
-              entity_id: storefront
-              scope: database
-              status: completed
-              task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
-              type: create
             - completed_at: "2025-06-18T16:52:35Z"
               created_at: "2025-06-18T16:52:05Z"
               database_id: storefront
@@ -19370,6 +17522,14 @@ components:
             $ref: '#/components/schemas/Task'
           description: The tasks that will restore each database node.
           example:
+            - completed_at: "2025-06-18T16:52:35Z"
+              created_at: "2025-06-18T16:52:05Z"
+              database_id: storefront
+              entity_id: storefront
+              scope: database
+              status: completed
+              task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
+              type: create
             - completed_at: "2025-06-18T16:52:35Z"
               created_at: "2025-06-18T16:52:05Z"
               database_id: storefront
@@ -19654,6 +17814,20 @@ components:
         type: s3
       required:
         - type
+    SQLScript:
+      type: array
+      items:
+        type: string
+        example: i3l
+        minLength: 1
+        maxLength: 1024
+      description: Each element of this array is an individual SQL statement.
+      example:
+        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app
+        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app
+        - ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app
+      minItems: 0
+      maxItems: 256
     ServiceInstance:
       type: object
       properties:
@@ -19727,6 +17901,9 @@ components:
             - container_port: 8080
               host_port: 8080
               name: web-client
+            - container_port: 8080
+              host_port: 8080
+              name: web-client
           service_ready: true
         updated_at: "2025-01-28T10:05:00Z"
       required:
@@ -19744,7 +17921,7 @@ components:
           type: array
           items:
             type: string
-            example: Necessitatibus labore ipsa id modi et et.
+            example: Eos et error vel nihil.
           description: The addresses of the host that's running this service instance.
           example:
             - 10.24.34.2
@@ -19770,9 +17947,6 @@ components:
             $ref: '#/components/schemas/PortMapping'
           description: Port mappings for this service instance.
           example:
-            - container_port: 8080
-              host_port: 8080
-              name: web-client
             - container_port: 8080
               host_port: 8080
               name: web-client
@@ -19840,6 +18014,7 @@ components:
             maxLength: 63
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
+            - de3b1388-1f0c-42f1-a86c-59ab72f255ec
             - de3b1388-1f0c-42f1-a86c-59ab72f255ec
           minItems: 1
         memory:
@@ -19957,7 +18132,6 @@ components:
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
           type: string
@@ -20004,7 +18178,6 @@ components:
             - n2
           target_session_attrs: primary
         host_ids:
-          - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 512M
@@ -20076,8 +18249,6 @@ components:
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
           type: string
@@ -20124,6 +18295,7 @@ components:
             - n2
           target_session_attrs: primary
         host_ids:
+          - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 512M
@@ -20364,6 +18536,7 @@ components:
         host_ids:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
+          - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 512M
         orchestrator_opts:
           swarm:
@@ -20553,7 +18726,6 @@ components:
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
           type: string
@@ -20689,7 +18861,7 @@ components:
             traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
           additionalProperties:
             type: string
-            example: Aut doloribus rem culpa ullam minus dolore.
+            example: Rem culpa.
         extra_networks:
           type: array
           items:

--- a/changes/unreleased/Added-20260412-202528.yaml
+++ b/changes/unreleased/Added-20260412-202528.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added the ability to run user-defined SQL scripts during database creation via the `scripts` field on the database spec.
+time: 2026-04-12T20:25:28.998139-04:00

--- a/docs/using/create-db.md
+++ b/docs/using/create-db.md
@@ -163,3 +163,64 @@ After creating the database, you can enable extensions in your database using `C
 !!! note
 
     Always include `spock` in `shared_preload_libraries`, as it is required for core functionality provided by the Control Plane. The Control Plane will call `CREATE EXTENSION` for spock when initializing each instance.
+
+## User-Defined Scripts
+
+The `scripts` field allows you to run SQL statements at specific points during the database creation process. The scripts are executed by the `pgedge` superuser. This is useful for setting up roles, default privileges, schema objects, and other one-time initialization that must happen before the database is ready for use.
+
+Two script types are supported:
+
+- `post_init` - Runs on each primary instance after the instance is created, but before database users are created. Statements execute in the `postgres` database within a transaction. Use this to create roles that database users can be assigned to via their `roles` field.
+- `post_database_create` - Runs on each primary instance after the application database is created and Spock is initialized, but before subscriptions are set up. Statements execute in the application database within a transaction. Use this to set default privileges, create tables, or perform other schema initialization.
+
+!!! warning
+
+    Scripts only execute during the initial creation of a database. Once a database has been successfully created, any changes to the `scripts` field will have no effect.
+
+!!! warning
+
+    Script statements execute within a transaction. Operations that cannot run inside a transaction - such as `CREATE DATABASE`, `VACUUM`, or `CREATE INDEX CONCURRENTLY` - are not supported.
+
+The following example creates a database with a `read_write` role that is assigned to an application user. The `post_init` script creates the role before users are provisioned, and `post_database_create` configures default privileges so that objects created by the `admin` user are automatically accessible to the role:
+
+=== "curl"
+
+    ```sh
+    curl -X POST http://host-3:3000/v1/databases \
+        -H 'Content-Type:application/json' \
+        --data '{
+            "id": "example",
+            "spec": {
+                "database_name": "example",
+                "database_users": [
+                    {
+                        "username": "admin",
+                        "password": "password",
+                        "db_owner": true,
+                        "attributes": ["LOGIN", "SUPERUSER"]
+                    },
+                    {
+                        "username": "app",
+                        "password": "password",
+                        "roles": ["read_write"]
+                    }
+                ],
+                "port": 5432,
+                "nodes": [
+                    { "name": "n1", "host_ids": ["host-1"] },
+                    { "name": "n2", "host_ids": ["host-2"] },
+                    { "name": "n3", "host_ids": ["host-3"] }
+                ],
+                "scripts": {
+                    "post_init": [
+                        "CREATE ROLE read_write NOLOGIN"
+                    ],
+                    "post_database_create": [
+                        "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO read_write",
+                        "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO read_write",
+                        "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO read_write"
+                    ]
+                }
+            }
+        }'
+    ```

--- a/e2e/scripts_test.go
+++ b/e2e/scripts_test.go
@@ -1,0 +1,146 @@
+//go:build e2e_test
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	api "github.com/pgEdge/control-plane/api/apiv1/gen/control_plane"
+)
+
+func TestScripts(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+	host2 := fixture.HostIDs()[1]
+
+	username := "admin"
+	password := "password"
+
+	tLog(t, "creating database")
+
+	ctx := t.Context()
+	db := fixture.NewDatabaseFixture(ctx, t, &api.CreateDatabaseRequest{
+		Spec: &api.DatabaseSpec{
+			DatabaseName: "test_scripts",
+			DatabaseUsers: []*api.DatabaseUserSpec{
+				{
+					Username:   username,
+					Password:   pointerTo(password),
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+				{
+					Username: "app",
+					// This role assignment will fail if the post-init script
+					// does not run before the users are created.
+					Roles: []string{"test_role"},
+				},
+			},
+			Port:        pointerTo(0),
+			PatroniPort: pointerTo(0),
+			Nodes: []*api.DatabaseNodeSpec{
+				{Name: "n1", HostIds: []api.Identifier{api.Identifier(host1)}},
+			},
+			Scripts: &api.DatabaseScripts{
+				PostInit: api.SQLScript{
+					"CREATE ROLE test_role NOLOGIN",
+				},
+				PostDatabaseCreate: api.SQLScript{
+					"CREATE TABLE foo (id int primary key, val text)",
+					"INSERT INTO foo (id, val) VALUES (1, 'foo')",
+				},
+			},
+		},
+	})
+
+	tLog(t, "validating that scripts ran")
+
+	opts := ConnectionOptions{
+		Username: username,
+		Password: password,
+	}
+	db.WithConnection(ctx, opts, t, func(conn *pgx.Conn) {
+		const roleExistsQuery = "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'test_role')"
+		const valQuery = "SELECT val FROM foo WHERE id = 1"
+
+		var roleExists bool
+		require.NoError(t, conn.QueryRow(ctx, roleExistsQuery).Scan(&roleExists))
+		require.True(t, roleExists)
+
+		var val string
+		require.NoError(t, conn.QueryRow(ctx, valQuery).Scan(&val))
+		require.Equal(t, "foo", val)
+	})
+
+	tLog(t, "updating database scripts and adding a node")
+
+	db.Update(ctx, UpdateOptions{
+		Spec: &api.DatabaseSpec{
+			DatabaseName: "test_scripts",
+			DatabaseUsers: []*api.DatabaseUserSpec{
+				{
+					Username:   username,
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+				// TODO(PLAT-544): This will work after the 'populate nodes'
+				//        enhancement to propagate roles from the source node.
+				// {
+				// 	Username: "app",
+				// 	Roles:    []string{"test_role"},
+				// },
+			},
+			Port:        pointerTo(0),
+			PatroniPort: pointerTo(0),
+			Nodes: []*api.DatabaseNodeSpec{
+				{Name: "n1", HostIds: []api.Identifier{api.Identifier(host1)}},
+				{Name: "n2", HostIds: []api.Identifier{api.Identifier(host2)}},
+			},
+			Scripts: &api.DatabaseScripts{
+				PostInit: api.SQLScript{
+					"CREATE ROLE test_role_2 NOLOGIN",
+				},
+				PostDatabaseCreate: api.SQLScript{
+					"CREATE TABLE bar (id int primary key, val text)",
+					"INSERT INTO bar (id, val) VALUES (1, 'foo')",
+				},
+			},
+		},
+	})
+
+	tLog(t, "validating that the scripts did not run")
+
+	opts = ConnectionOptions{
+		Username: username,
+		Password: password,
+		Matcher:  WithNode("n2"),
+	}
+	db.WithConnection(ctx, opts, t, func(conn *pgx.Conn) {
+		// const roleExistsQuery = "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'test_role')"
+		const roleNotExistsQuery = "SELECT NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'test_role_2')"
+		const valQuery = "SELECT val FROM foo WHERE id = 1"
+		const tableNotExistsQuery = "SELECT NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'bar');"
+
+		// TODO(PLAT-544): This will work after the 'populate nodes' enhancement
+		//       to propagate roles from the source node.
+		// var roleExists bool
+		// assert.NoError(t, conn.QueryRow(ctx, roleExistsQuery).Scan(&roleExists))
+		// assert.True(t, roleExists)
+
+		var roleNotExists bool
+		require.NoError(t, conn.QueryRow(ctx, roleNotExistsQuery).Scan(&roleNotExists))
+		require.True(t, roleNotExists)
+
+		var val string
+		require.NoError(t, conn.QueryRow(ctx, valQuery).Scan(&val))
+		require.Equal(t, "foo", val)
+
+		var tableNotExists bool
+		require.NoError(t, conn.QueryRow(ctx, tableNotExistsQuery).Scan(&tableNotExists))
+		require.True(t, tableNotExists)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pgEdge/control-plane
 
-go 1.25.0
+go 1.25.6
 
 toolchain go1.25.8
 
@@ -35,6 +35,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.34.0
+	github.com/valkdb/postgresparser v1.1.9
 	github.com/wI2L/jsondiff v0.6.1
 	go.etcd.io/etcd/api/v3 v3.6.5
 	go.etcd.io/etcd/client/pkg/v3 v3.6.5
@@ -46,6 +47,11 @@ require (
 	goa.design/goa/v3 v3.23.4
 	gonum.org/v1/gonum v0.16.0
 	gopkg.in/ini.v1 v1.67.0
+)
+
+require (
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
 github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -424,6 +426,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
+github.com/valkdb/postgresparser v1.1.9 h1:nk95NhZyTiT/zOx678/GBSVlppYhsFSdFjhUlk8kogQ=
+github.com/valkdb/postgresparser v1.1.9/go.mod h1:ZLdOJbyhChgvx3QpbYKR8VPpUMVG3pHNv+2pS8T2uXQ=
 github.com/wI2L/jsondiff v0.6.1 h1:ISZb9oNWbP64LHnu4AUhsMF5W0FIj5Ok3Krip9Shqpw=
 github.com/wI2L/jsondiff v0.6.1/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
@@ -511,6 +515,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/server/internal/api/apiv1/convert.go
+++ b/server/internal/api/apiv1/convert.go
@@ -288,6 +288,16 @@ func serviceSpecsToAPI(services []*database.ServiceSpec) []*api.ServiceSpec {
 	return apiServices
 }
 
+func scriptsToAPI(scripts *database.ScriptStatements) *api.DatabaseScripts {
+	if scripts == nil {
+		return nil
+	}
+	return &api.DatabaseScripts{
+		PostInit:           scripts.PostInit,
+		PostDatabaseCreate: scripts.PostDatabaseCreate,
+	}
+}
+
 func databaseSpecToAPI(d *database.Spec) *api.DatabaseSpec {
 	return &api.DatabaseSpec{
 		DatabaseName:     d.DatabaseName,
@@ -304,6 +314,7 @@ func databaseSpecToAPI(d *database.Spec) *api.DatabaseSpec {
 		RestoreConfig:    restoreConfigToAPI(d.RestoreConfig),
 		PostgresqlConf:   d.PostgreSQLConf,
 		OrchestratorOpts: orchestratorOptsToAPI(d.OrchestratorOpts),
+		Scripts:          scriptsToAPI(d.Scripts),
 	}
 }
 
@@ -719,6 +730,16 @@ func apiToServiceSpecs(apiServices []*api.ServiceSpec) ([]*database.ServiceSpec,
 	return services, nil
 }
 
+func apiToScripts(scripts *api.DatabaseScripts) *database.ScriptStatements {
+	if scripts == nil {
+		return nil
+	}
+	return &database.ScriptStatements{
+		PostInit:           scripts.PostInit,
+		PostDatabaseCreate: scripts.PostDatabaseCreate,
+	}
+}
+
 func apiToDatabaseSpec(
 	orchestrator config.Orchestrator,
 	id, tID *api.Identifier,
@@ -798,6 +819,7 @@ func apiToDatabaseSpec(
 		PostgreSQLConf:   apiSpec.PostgresqlConf,
 		RestoreConfig:    restoreConfig,
 		OrchestratorOpts: orchestratorOptsToDatabase(apiSpec.OrchestratorOpts),
+		Scripts:          apiToScripts(apiSpec.Scripts),
 	}, nil
 }
 

--- a/server/internal/api/apiv1/post_init_handlers.go
+++ b/server/internal/api/apiv1/post_init_handlers.go
@@ -327,7 +327,7 @@ func (s *PostInitHandlers) CreateDatabase(ctx context.Context, req *api.CreateDa
 		return nil, apiErr(err)
 	}
 
-	t, err := s.workflowSvc.CreateDatabase(ctx, spec)
+	t, err := s.workflowSvc.CreateDatabase(ctx, db)
 	if err != nil {
 		return nil, apiErr(err)
 	}
@@ -396,7 +396,7 @@ func (s *PostInitHandlers) UpdateDatabase(ctx context.Context, req *api.UpdateDa
 	}
 
 	prevState := db.State
-	t, err := s.workflowSvc.UpdateDatabase(ctx, spec, req.ForceUpdate, req.RemoveHost...)
+	t, err := s.workflowSvc.UpdateDatabase(ctx, db, req.ForceUpdate, req.RemoveHost...)
 	if err != nil {
 		restorationErr := s.dbSvc.UpdateDatabaseState(ctx, db.DatabaseID, db.State, prevState)
 		if restorationErr != nil {
@@ -431,7 +431,7 @@ func (s *PostInitHandlers) DeleteDatabase(ctx context.Context, req *api.DeleteDa
 		return nil, apiErr(err)
 	}
 
-	t, err := s.workflowSvc.DeleteDatabase(ctx, databaseID)
+	t, err := s.workflowSvc.DeleteDatabase(ctx, db)
 
 	if err != nil {
 		restorationErr := s.dbSvc.UpdateDatabaseState(ctx, db.DatabaseID, database.DatabaseStateDeleting, prevState)
@@ -817,7 +817,7 @@ func (s *PostInitHandlers) RestoreDatabase(ctx context.Context, req *api.Restore
 		return apiErr(cause)
 	}
 
-	t, nodeTasks, err := s.workflowSvc.PgBackRestRestore(ctx, db.Spec, targetNodes, restoreConfig)
+	t, nodeTasks, err := s.workflowSvc.PgBackRestRestore(ctx, db, targetNodes, restoreConfig)
 	if err != nil {
 		return nil, handleError(err)
 	}

--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/valkdb/postgresparser"
+
 	api "github.com/pgEdge/control-plane/api/apiv1/gen/control_plane"
 	"github.com/pgEdge/control-plane/server/internal/config"
 	"github.com/pgEdge/control-plane/server/internal/database"
@@ -69,6 +71,7 @@ func validateDatabaseSpec(orchestrator config.Orchestrator, spec *api.DatabaseSp
 	errs = append(errs, validateMemory(spec.Memory, []string{"memory"})...)
 	errs = append(errs, validatePorts(spec.Port, spec.PatroniPort, []string{"port"}))
 	errs = append(errs, validateUsers(spec.DatabaseUsers, []string{"database_users"})...)
+	errs = append(errs, validateScripts(spec.Scripts, []string{"scripts"})...)
 
 	// Track node-name uniqueness and prepare set for cross-node checks.
 	seenNodeNames := make(ds.Set[string], len(spec.Nodes))
@@ -820,4 +823,34 @@ func validateHostIDUniqueness(ctx context.Context, hostSvc *host.Service, hostID
 		// Other errors (connection failures, permission errors, etc.) should be propagated
 		return fmt.Errorf("failed to check for existing host: %w", err)
 	}
+}
+
+func validateScripts(scripts *api.DatabaseScripts, path []string) []error {
+	if scripts == nil {
+		return nil
+	}
+	return slices.Concat(
+		validateScript(scripts.PostInit, appendPath(path, "post_init")),
+		validateScript(scripts.PostDatabaseCreate, appendPath(path, "post_database_create")),
+	)
+}
+
+func validateScript(statements []string, path []string) []error {
+	var errs []error
+	for i, statement := range statements {
+		statementPath := appendPath(path, arrayIndexPath(i))
+		if err := validateSQLStatement(statement, statementPath); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func validateSQLStatement(statement string, path []string) error {
+	_, err := postgresparser.ParseSQLStrict(statement)
+	if err != nil {
+		err = fmt.Errorf("failed to parse SQL statement: %w", err)
+		return newValidationError(err, path)
+	}
+	return nil
 }

--- a/server/internal/api/apiv1/validate_test.go
+++ b/server/internal/api/apiv1/validate_test.go
@@ -1174,6 +1174,60 @@ func TestValidateDatabaseSpec(t *testing.T) {
 				"database_users[3]: cannot have multiple users with db_owner = true",
 			},
 		},
+		{
+			name: "valid scripts",
+			spec: &api.DatabaseSpec{
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name: "n1",
+						HostIds: []api.Identifier{
+							api.Identifier("host-1"),
+						},
+					},
+				},
+				Scripts: &api.DatabaseScripts{
+					PostInit: api.SQLScript{
+						"CREATE ROLE pgedge_superuser NOLOGIN",
+					},
+					PostDatabaseCreate: api.SQLScript{
+						"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+						"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+						"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app;",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid scripts",
+			spec: &api.DatabaseSpec{
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name: "n1",
+						HostIds: []api.Identifier{
+							api.Identifier("host-1"),
+						},
+					},
+				},
+				Scripts: &api.DatabaseScripts{
+					PostInit: api.SQLScript{
+						"CREATE ROLE",
+					},
+					PostDatabaseCreate: api.SQLScript{
+						"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO app",
+						// This line has a typo in the word 'PRIVILEGES'
+						"ALTER DEFAULT PRIVILEGS FOR ROLE admin GRANT ALL PRIVILEGES ON TABLES TO app",
+						"ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT ALL PRIVILEGES ON SEQUENCES TO app",
+						// This line contains multiple statements
+						"ALTER DEFAULT PRIVILEGES FOR ROLE app GRANT USAGE ON SCHEMAS TO app_read_only; ALTER DEFAULT PRIVILEGES FOR ROLE app GRANT USAGE ON TYPES TO app_read_only;",
+					},
+				},
+			},
+			expected: []string{
+				"scripts.post_init[0]: failed to parse SQL statement",
+				"scripts.post_database_create[1]: failed to parse SQL statement",
+				"scripts.post_database_create[3]: failed to parse SQL statement",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := validateDatabaseSpec(config.OrchestratorSwarm, tc.spec)

--- a/server/internal/database/database.go
+++ b/server/internal/database/database.go
@@ -48,6 +48,7 @@ type Database struct {
 	Spec             *Spec
 	Instances        []*Instance
 	ServiceInstances []*ServiceInstance
+	NotCreated       bool
 }
 
 func databaseToStored(d *Database) *StoredDatabase {
@@ -57,6 +58,7 @@ func databaseToStored(d *Database) *StoredDatabase {
 		CreatedAt:  d.CreatedAt,
 		UpdatedAt:  d.UpdatedAt,
 		State:      d.State,
+		NotCreated: d.NotCreated,
 	}
 }
 
@@ -70,6 +72,7 @@ func storedToDatabase(d *StoredDatabase, storedSpec *StoredSpec, instances []*In
 		Spec:             storedSpec.Spec,
 		Instances:        instances,
 		ServiceInstances: serviceInstances,
+		NotCreated:       d.NotCreated,
 	}
 }
 

--- a/server/internal/database/database.go
+++ b/server/internal/database/database.go
@@ -4,7 +4,10 @@ import (
 	"time"
 
 	"github.com/pgEdge/control-plane/server/internal/ds"
+	"github.com/pgEdge/control-plane/server/internal/resource"
 )
+
+const VariableNameDatabaseNotCreated resource.VariableName = "database_not_created"
 
 type DatabaseState string
 
@@ -49,6 +52,12 @@ type Database struct {
 	Instances        []*Instance
 	ServiceInstances []*ServiceInstance
 	NotCreated       bool
+}
+
+func (d *Database) Variables() resource.Variables {
+	return resource.Variables{
+		VariableNameDatabaseNotCreated: d.NotCreated,
+	}
 }
 
 func databaseToStored(d *Database) *StoredDatabase {

--- a/server/internal/database/database_store.go
+++ b/server/internal/database/database_store.go
@@ -15,6 +15,7 @@ type StoredDatabase struct {
 	CreatedAt  time.Time     `json:"created_at"`
 	UpdatedAt  time.Time     `json:"updated_at"`
 	State      DatabaseState `json:"state"`
+	NotCreated bool          `json:"not_created"`
 }
 
 type DatabaseStore struct {

--- a/server/internal/database/instance_resource.go
+++ b/server/internal/database/instance_resource.go
@@ -34,6 +34,7 @@ type InstanceResource struct {
 	PrimaryInstanceID        string                `json:"primary_instance_id"`
 	OrchestratorDependencies []resource.Identifier `json:"dependencies"`
 	ConnectionInfo           *ConnectionInfo       `json:"connection_info"`
+	PostInit                 *Script               `json:"post_init"`
 }
 
 func (r *InstanceResource) ResourceVersion() string {
@@ -83,6 +84,10 @@ func (r *InstanceResource) Refresh(ctx context.Context, rc *resource.Context) er
 		return resource.ErrNotFound
 	}
 	r.PrimaryInstanceID = primaryInstanceID
+
+	if err := SetScriptNeedsToRun(ctx, rc, r.PostInit); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -175,6 +180,10 @@ func (r *InstanceResource) initializeInstance(ctx context.Context, rc *resource.
 		return err
 	}
 	defer conn.Close(ctx)
+
+	if err := ExecuteScript(ctx, rc, conn, r.PostInit); err != nil {
+		return fmt.Errorf("failed to execute post-init script: %w", err)
+	}
 
 	// Spock shouldn't exist in the 'postgres' database, but we want to err on
 	// the side of caution.

--- a/server/internal/database/operations/common.go
+++ b/server/internal/database/operations/common.go
@@ -9,6 +9,7 @@ import (
 )
 
 type NodeResources struct {
+	DatabaseID        string
 	DatabaseOwner     string
 	DatabaseName      string
 	NodeName          string
@@ -16,6 +17,7 @@ type NodeResources struct {
 	PrimaryInstanceID string
 	InstanceResources []*database.InstanceResources
 	RestoreConfig     *database.RestoreConfig
+	Scripts           database.Scripts
 }
 
 func (n *NodeResources) primaryInstance() *database.InstanceResources {
@@ -55,11 +57,13 @@ func (n *NodeResources) databaseResourceState() (*resource.State, error) {
 	}
 
 	db := &database.PostgresDatabaseResource{
-		NodeName:         n.NodeName,
-		DatabaseName:     n.DatabaseName,
-		Owner:            n.DatabaseOwner,
-		RenameFrom:       renameFrom,
-		HasRestoreConfig: hasRestoreConfig,
+		DatabaseID:         n.DatabaseID,
+		NodeName:           n.NodeName,
+		DatabaseName:       n.DatabaseName,
+		Owner:              n.DatabaseOwner,
+		RenameFrom:         renameFrom,
+		HasRestoreConfig:   hasRestoreConfig,
+		PostDatabaseCreate: n.Scripts[database.ScriptNamePostDatabaseCreate],
 	}
 
 	state := resource.NewState()

--- a/server/internal/database/operations/restore_database.go
+++ b/server/internal/database/operations/restore_database.go
@@ -11,6 +11,7 @@ import (
 // as well as the end state for both the primary instance and the replica
 // instances for the given node.
 type NodeRestoreResources struct {
+	DatabaseID       string
 	DatabaseOwner    string
 	DatabaseName     string
 	NodeName         string
@@ -25,6 +26,7 @@ func (n *NodeRestoreResources) ToNodeResources() *NodeResources {
 	all = append(all, n.ReplicaInstances...)
 
 	return &NodeResources{
+		DatabaseID:        n.DatabaseID,
 		DatabaseOwner:     n.DatabaseOwner,
 		DatabaseName:      n.DatabaseName,
 		NodeName:          n.NodeName,

--- a/server/internal/database/orchestrator.go
+++ b/server/internal/database/orchestrator.go
@@ -155,7 +155,7 @@ func (c *ConnectionInfo) AdminDSN(dbName string) *postgres.DSN {
 }
 
 type Orchestrator interface {
-	GenerateInstanceResources(spec *InstanceSpec) (*InstanceResources, error)
+	GenerateInstanceResources(spec *InstanceSpec, scripts Scripts) (*InstanceResources, error)
 	GenerateInstanceRestoreResources(spec *InstanceSpec, taskID uuid.UUID) (*InstanceResources, error)
 	GenerateServiceInstanceResources(spec *ServiceInstanceSpec) (*ServiceInstanceResources, error)
 	GetInstanceConnectionInfo(ctx context.Context,

--- a/server/internal/database/postgres_database.go
+++ b/server/internal/database/postgres_database.go
@@ -26,12 +26,14 @@ func PostgresDatabaseResourceIdentifier(nodeName, dbName string) resource.Identi
 }
 
 type PostgresDatabaseResource struct {
-	NodeName          string                `json:"node_name"`
-	DatabaseName      string                `json:"database_name"`
-	Owner             string                `json:"owner"`
-	RenameFrom        string                `json:"rename_from"`
-	HasRestoreConfig  bool                  `json:"has_restore_config"`
-	ExtraDependencies []resource.Identifier `json:"extra_dependencies"`
+	DatabaseID         string                `json:"database_id"`
+	NodeName           string                `json:"node_name"`
+	DatabaseName       string                `json:"database_name"`
+	Owner              string                `json:"owner"`
+	RenameFrom         string                `json:"rename_from"`
+	HasRestoreConfig   bool                  `json:"has_restore_config"`
+	ExtraDependencies  []resource.Identifier `json:"extra_dependencies"`
+	PostDatabaseCreate *Script               `json:"post_database_create,omitempty"`
 }
 
 func (p *PostgresDatabaseResource) ResourceVersion() string {
@@ -94,6 +96,10 @@ func (p *PostgresDatabaseResource) Refresh(ctx context.Context, rc *resource.Con
 	}
 	if needsCreate {
 		return resource.ErrNotFound
+	}
+
+	if err := SetScriptNeedsToRun(ctx, rc, p.PostDatabaseCreate); err != nil {
+		return err
 	}
 
 	return nil
@@ -214,6 +220,9 @@ func (p *PostgresDatabaseResource) create(ctx context.Context, rc *resource.Cont
 	err = postgres.InitializeSpockNode(p.NodeName, dsn).Exec(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("failed to initialize spock: %w", err)
+	}
+	if err := ExecuteScript(ctx, rc, conn, p.PostDatabaseCreate); err != nil {
+		return fmt.Errorf("failed to execute post-database-create script: %w", err)
 	}
 
 	return nil

--- a/server/internal/database/script.go
+++ b/server/internal/database/script.go
@@ -1,0 +1,192 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/pgEdge/control-plane/server/internal/resource"
+	"github.com/rs/zerolog"
+	"github.com/samber/do"
+)
+
+type ScriptName string
+
+func (s ScriptName) String() string {
+	return string(s)
+}
+
+const (
+	ScriptNamePostInit           ScriptName = "post_init"
+	ScriptNamePostDatabaseCreate ScriptName = "post_database_create"
+)
+
+type Script struct {
+	DatabaseID string     `json:"database_id"`
+	NodeName   string     `json:"node_name"`
+	Name       ScriptName `json:"name"`
+	Statements []string   `json:"statements"`
+	Succeeded  bool       `json:"succeeded"`
+	// NeedsToRun is used to trigger a resource diff. Resources should call
+	// SetScriptNeedsToRun to set it.
+	NeedsToRun bool `json:"needs_to_run"`
+}
+
+type Scripts map[ScriptName]*Script
+
+type ScriptResult struct {
+	DatabaseID  string     `json:"database_id"`
+	ScriptName  ScriptName `json:"script_name"`
+	NodeName    string     `json:"node_name"`
+	Succeeded   bool       `json:"succeeded"`
+	StartedAt   time.Time  `json:"started_at"`
+	CompletedAt time.Time  `json:"completed_at"`
+	Error       string     `json:"error"`
+}
+
+func NewScriptResult(databaseID string, scriptName ScriptName, nodeName string) *ScriptResult {
+	return &ScriptResult{
+		DatabaseID: databaseID,
+		ScriptName: scriptName,
+		NodeName:   nodeName,
+	}
+}
+
+func (s *ScriptResult) Validate() error {
+	if s == nil {
+		return errors.New("cannot be nil")
+	}
+	if s.DatabaseID == "" {
+		return errors.New("database ID cannot be empty")
+	}
+	if s.ScriptName == "" {
+		return errors.New("script name cannot be empty")
+	}
+	if s.NodeName == "" {
+		return errors.New("node name cannot be empty")
+	}
+
+	return nil
+}
+
+func ExecuteScript(ctx context.Context, rc *resource.Context, conn *pgx.Conn, script *Script) error {
+	ok, err := checkScriptPreconditions(rc, script)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	svc, err := do.Invoke[*Service](rc.Injector)
+	if err != nil {
+		return err
+	}
+	logger, err := do.Invoke[zerolog.Logger](rc.Injector)
+	if err != nil {
+		return err
+	}
+
+	logger = logger.With().
+		Str("database_id", script.DatabaseID).
+		Str("node_name", script.NodeName).
+		Stringer("script_name", script.Name).
+		Logger()
+
+	result, err := svc.GetScriptResult(ctx, script.DatabaseID, script.Name, script.NodeName)
+	if err != nil {
+		return fmt.Errorf("failed to get script result: %w", err)
+	}
+	if result.Succeeded {
+		return nil
+	}
+
+	logger.Info().Msg("executing script")
+
+	// We're intentionally not using repair mode here so that any tables created
+	// by these scripts end up in the replication set. This does not cause
+	// conflicts because we execute scripts only once, before any subscriptions
+	// are created.
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	result.StartedAt = time.Now()
+
+	var errs []error
+	for i, statement := range script.Statements {
+		_, err := tx.Exec(ctx, statement)
+		if err != nil {
+			err = fmt.Errorf("failed to execute %s[%d]: %w", script.Name, i, err)
+			result.Error = err.Error()
+			errs = append(errs, err)
+			break
+		}
+	}
+
+	if len(errs) == 0 {
+		if err := tx.Commit(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to commit transaction: %w", err))
+		}
+	}
+
+	result.CompletedAt = time.Now()
+	result.Succeeded = len(errs) == 0
+	if result.Succeeded {
+		result.Error = ""
+	}
+
+	elapsed := result.CompletedAt.Sub(result.StartedAt)
+	logger.Info().
+		Float64("duration_seconds", elapsed.Seconds()).
+		Bool("succeeded", result.Succeeded).
+		Msg("script completed")
+
+	if err := svc.UpdateScriptResult(ctx, result); err != nil {
+		errs = append(errs, fmt.Errorf("failed to store script result: %w", err))
+	}
+
+	return errors.Join(errs...)
+}
+
+func IsDatabaseNotCreated(rc *resource.Context) (bool, error) {
+	databaseNotCreated, err := resource.VariableFromContext[bool](rc, VariableNameDatabaseNotCreated)
+	if errors.Is(err, resource.ErrVariableUndefined) {
+		// Default to false when undefined
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("failed to check database not created: %w", err)
+	}
+	return databaseNotCreated, nil
+}
+
+func SetScriptNeedsToRun(ctx context.Context, rc *resource.Context, script *Script) error {
+	ok, err := checkScriptPreconditions(rc, script)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	script.NeedsToRun = true
+	return nil
+}
+
+func checkScriptPreconditions(rc *resource.Context, script *Script) (bool, error) {
+	if script == nil {
+		return false, nil
+	}
+	if script.Succeeded {
+		return false, nil
+	}
+	databaseNotCreated, err := IsDatabaseNotCreated(rc)
+	if err != nil {
+		return false, err
+	}
+	return databaseNotCreated, nil
+}

--- a/server/internal/database/script_result_store.go
+++ b/server/internal/database/script_result_store.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"github.com/pgEdge/control-plane/server/internal/storage"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+type StoredScriptResult struct {
+	storage.StoredValue
+	Result *ScriptResult `json:"script_result"`
+}
+
+type ScriptResultStore struct {
+	client *clientv3.Client
+	root   string
+}
+
+func NewScriptResultStore(client *clientv3.Client, root string) *ScriptResultStore {
+	return &ScriptResultStore{
+		client: client,
+		root:   root,
+	}
+}
+
+func (s *ScriptResultStore) Prefix() string {
+	return storage.Prefix("/", s.root, "script_results")
+}
+
+func (s *ScriptResultStore) DatabasePrefix(databaseID string) string {
+	return storage.Prefix(s.Prefix(), databaseID)
+}
+
+func (s *ScriptResultStore) ScriptNamePrefix(databaseID string, name ScriptName) string {
+	return storage.Prefix(s.DatabasePrefix(databaseID), name.String())
+}
+
+func (s *ScriptResultStore) Key(databaseID string, scriptName ScriptName, nodeName string) string {
+	return storage.Prefix(s.ScriptNamePrefix(databaseID, scriptName), nodeName)
+}
+
+func (s *ScriptResultStore) GetByKey(databaseID string, scriptName ScriptName, nodeName string) storage.GetOp[*StoredScriptResult] {
+	key := s.Key(databaseID, scriptName, nodeName)
+	return storage.NewGetOp[*StoredScriptResult](s.client, key)
+}
+
+func (s *ScriptResultStore) Update(item *StoredScriptResult) storage.PutOp[*StoredScriptResult] {
+	key := s.Key(item.Result.DatabaseID, item.Result.ScriptName, item.Result.NodeName)
+	return storage.NewUpdateOp(s.client, key, item)
+}
+
+func (s *ScriptResultStore) DeleteByDatabaseID(databaseID string) storage.DeleteOp {
+	prefix := s.DatabasePrefix(databaseID)
+	return storage.NewDeletePrefixOp(s.client, prefix)
+}

--- a/server/internal/database/service.go
+++ b/server/internal/database/service.go
@@ -173,6 +173,7 @@ func (s *Service) DeleteDatabase(ctx context.Context, databaseID string) error {
 		s.store.Instance.DeleteByDatabaseID(databaseID),
 		s.store.InstanceSpec.DeleteByDatabaseID(databaseID),
 		s.store.InstanceStatus.DeleteByDatabaseID(databaseID),
+		s.store.ScriptResult.DeleteByDatabaseID(databaseID),
 	)
 
 	if err := s.store.Txn(ops...).Commit(ctx); err != nil {
@@ -274,6 +275,47 @@ func (s *Service) UpdateDatabaseState(ctx context.Context, databaseID string, fr
 	storedDb.State = to
 	if err := s.store.Database.Update(storedDb).Exec(ctx); err != nil {
 		return fmt.Errorf("failed to update database state: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) GetScriptResult(ctx context.Context, databaseID string, scriptName ScriptName, nodeName string) (*ScriptResult, error) {
+	stored, err := s.store.ScriptResult.
+		GetByKey(databaseID, scriptName, nodeName).
+		Exec(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		return NewScriptResult(databaseID, scriptName, nodeName), nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get script result: %w", err)
+	}
+
+	return stored.Result, nil
+}
+
+func (s *Service) UpdateScriptResult(ctx context.Context, result *ScriptResult) error {
+	if err := result.Validate(); err != nil {
+		return fmt.Errorf("invalid script result: %w", err)
+	}
+
+	stored, err := s.store.ScriptResult.
+		GetByKey(result.DatabaseID, result.ScriptName, result.NodeName).
+		Exec(ctx)
+	switch {
+	case errors.Is(err, storage.ErrNotFound):
+		stored = &StoredScriptResult{Result: result}
+	case err != nil:
+		return fmt.Errorf("failed to get script result: %w", err)
+	case stored.Result.Succeeded:
+		// Avoid overwriting a successful result in the off-chance of
+		// overlapping operations.
+		return errors.New("script already marked as succeeded")
+	default:
+		stored.Result = result
+	}
+
+	if err := s.store.ScriptResult.Update(stored).Exec(ctx); err != nil {
+		return fmt.Errorf("failed to store script result: %w", err)
 	}
 
 	return nil

--- a/server/internal/database/service.go
+++ b/server/internal/database/service.go
@@ -73,6 +73,7 @@ func (s *Service) CreateDatabase(ctx context.Context, spec *Spec) (*Database, er
 		UpdatedAt:  now,
 		State:      DatabaseStateCreating,
 		Spec:       spec,
+		NotCreated: true,
 	}
 
 	if err := s.store.Txn(
@@ -263,6 +264,11 @@ func (s *Service) UpdateDatabaseState(ctx context.Context, databaseID string, fr
 	// database is in the expected state
 	if from != "" && storedDb.State != from {
 		return fmt.Errorf("database state is not in expected state %s, but %s", from, storedDb.State)
+	}
+	// creation is considered complete the first time we set the database to
+	// available.
+	if to == DatabaseStateAvailable && storedDb.NotCreated {
+		storedDb.NotCreated = false
 	}
 
 	storedDb.State = to

--- a/server/internal/database/spec.go
+++ b/server/internal/database/spec.go
@@ -298,6 +298,21 @@ func (d *SwarmOpts) Clone() *SwarmOpts {
 	}
 }
 
+type ScriptStatements struct {
+	PostInit           []string `json:"post_init"`
+	PostDatabaseCreate []string `json:"post_database_create"`
+}
+
+func (s *ScriptStatements) Clone() *ScriptStatements {
+	if s == nil {
+		return nil
+	}
+	return &ScriptStatements{
+		PostInit:           slices.Clone(s.PostInit),
+		PostDatabaseCreate: slices.Clone(s.PostDatabaseCreate),
+	}
+}
+
 type Spec struct {
 	DatabaseID       string            `json:"database_id"`
 	TenantID         *string           `json:"tenant_id,omitempty"`
@@ -315,6 +330,7 @@ type Spec struct {
 	RestoreConfig    *RestoreConfig    `json:"restore_config"`
 	PostgreSQLConf   map[string]any    `json:"postgresql_conf"`
 	OrchestratorOpts *OrchestratorOpts `json:"orchestrator_opts,omitempty"`
+	Scripts          *ScriptStatements `json:"scripts,omitempty"`
 }
 
 func (s *Spec) Node(name string) (*Node, error) {
@@ -402,6 +418,7 @@ func (s *Spec) Clone() *Spec {
 		BackupConfig:     s.BackupConfig.Clone(),
 		RestoreConfig:    s.RestoreConfig.Clone(),
 		OrchestratorOpts: s.OrchestratorOpts.Clone(),
+		Scripts:          s.Scripts.Clone(),
 	}
 }
 
@@ -581,12 +598,14 @@ func (s *InstanceSpec) Clone() *InstanceSpec {
 }
 
 type NodeInstances struct {
-	DatabaseOwner string          `json:"database_owner"`
-	DatabaseName  string          `json:"database_name"`
-	NodeName      string          `json:"node_name"`
-	SourceNode    string          `json:"source_node"`
-	Instances     []*InstanceSpec `json:"instances"`
-	RestoreConfig *RestoreConfig  `json:"restore_config"`
+	DatabaseID    string            `json:"database_id"`
+	DatabaseOwner string            `json:"database_owner"`
+	DatabaseName  string            `json:"database_name"`
+	NodeName      string            `json:"node_name"`
+	SourceNode    string            `json:"source_node"`
+	Instances     []*InstanceSpec   `json:"instances"`
+	RestoreConfig *RestoreConfig    `json:"restore_config"`
+	Scripts       *ScriptStatements `json:"scripts"`
 }
 
 func (n *NodeInstances) InstanceIDs() []string {
@@ -675,12 +694,14 @@ func (s *Spec) NodeInstances() ([]*NodeInstances, error) {
 		}
 
 		nodes[nodeIdx] = &NodeInstances{
+			DatabaseID:    s.DatabaseID,
 			DatabaseOwner: owner,
 			DatabaseName:  s.DatabaseName,
 			NodeName:      node.Name,
 			SourceNode:    node.SourceNode,
 			Instances:     instances,
 			RestoreConfig: effectiveRestore,
+			Scripts:       s.Scripts,
 		}
 	}
 	return nodes, nil

--- a/server/internal/database/store.go
+++ b/server/internal/database/store.go
@@ -13,6 +13,7 @@ type Store struct {
 	Instance              *InstanceStore
 	InstanceStatus        *InstanceStatusStore
 	InstanceSpec          *InstanceSpecStore
+	ScriptResult          *ScriptResultStore
 	ServiceInstance       *ServiceInstanceStore
 	ServiceInstanceStatus *ServiceInstanceStatusStore
 }
@@ -25,6 +26,7 @@ func NewStore(client *clientv3.Client, root string) *Store {
 		Instance:              NewInstanceStore(client, root),
 		InstanceStatus:        NewInstanceStatusStore(client, root),
 		InstanceSpec:          NewInstanceSpecStore(client, root),
+		ScriptResult:          NewScriptResultStore(client, root),
 		ServiceInstance:       NewServiceInstanceStore(client, root),
 		ServiceInstanceStatus: NewServiceInstanceStatusStore(client, root),
 	}

--- a/server/internal/orchestrator/swarm/orchestrator.go
+++ b/server/internal/orchestrator/swarm/orchestrator.go
@@ -148,8 +148,8 @@ func (o *Orchestrator) PopulateHostStatus(ctx context.Context, status *host.Host
 	return nil
 }
 
-func (o *Orchestrator) GenerateInstanceResources(spec *database.InstanceSpec) (*database.InstanceResources, error) {
-	instance, orchestratorResources, err := o.instanceResources(spec)
+func (o *Orchestrator) GenerateInstanceResources(spec *database.InstanceSpec, scripts database.Scripts) (*database.InstanceResources, error) {
+	instance, orchestratorResources, err := o.instanceResources(spec, scripts)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func ServiceInstanceName(serviceType, databaseID, serviceID, hostID string) stri
 	return fmt.Sprintf("%s-%s-%s-%s", serviceType, databaseID, serviceID, base36[:8])
 }
 
-func (o *Orchestrator) instanceResources(spec *database.InstanceSpec) (*database.InstanceResource, []resource.Resource, error) {
+func (o *Orchestrator) instanceResources(spec *database.InstanceSpec, scripts database.Scripts) (*database.InstanceResource, []resource.Resource, error) {
 	images, err := o.versions.GetImages(spec.PgEdgeVersion)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get images: %w", err)
@@ -294,6 +294,7 @@ func (o *Orchestrator) instanceResources(spec *database.InstanceSpec) (*database
 	instance := &database.InstanceResource{
 		Spec:             spec,
 		InstanceHostname: instanceHostname,
+		PostInit:         scripts[database.ScriptNamePostInit],
 		OrchestratorDependencies: []resource.Identifier{
 			service.Identifier(),
 		},
@@ -372,7 +373,7 @@ func (o *Orchestrator) GenerateInstanceRestoreResources(spec *database.InstanceS
 
 	spec.InPlaceRestore = true
 
-	instance, resources, err := o.instanceResources(spec)
+	instance, resources, err := o.instanceResources(spec, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate instance resources: %w", err)
 	}

--- a/server/internal/orchestrator/systemd/orchestrator.go
+++ b/server/internal/orchestrator/systemd/orchestrator.go
@@ -146,7 +146,7 @@ func (o *Orchestrator) PopulateHostStatus(ctx context.Context, h *host.HostStatu
 	return nil
 }
 
-func (o *Orchestrator) GenerateInstanceResources(spec *database.InstanceSpec) (*database.InstanceResources, error) {
+func (o *Orchestrator) GenerateInstanceResources(spec *database.InstanceSpec, scripts database.Scripts) (*database.InstanceResources, error) {
 	paths, err := o.instancePaths(spec.PgEdgeVersion.PostgresVersion, spec.InstanceID)
 	if err != nil {
 		return nil, err
@@ -274,6 +274,7 @@ func (o *Orchestrator) GenerateInstanceResources(spec *database.InstanceSpec) (*
 	instance := &database.InstanceResource{
 		Spec:             spec,
 		InstanceHostname: o.cfg.PeerAddress(),
+		PostInit:         scripts[database.ScriptNamePostInit],
 		OrchestratorDependencies: []resource.Identifier{
 			patroniUnit.Identifier(),
 		},
@@ -371,7 +372,7 @@ func (o *Orchestrator) GenerateInstanceRestoreResources(spec *database.InstanceS
 	restoreSpec := *spec
 	restoreSpec.InPlaceRestore = true
 
-	instance, err := o.GenerateInstanceResources(&restoreSpec)
+	instance, err := o.GenerateInstanceResources(&restoreSpec, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/resource/resource.go
+++ b/server/internal/resource/resource.go
@@ -12,6 +12,8 @@ import (
 )
 
 var ErrNotFound = errors.New("resource not found")
+var ErrVariableUndefined = errors.New("variable not defined")
+var ErrVariableTypeMismatch = errors.New("variable type mismatch")
 
 func ProvideRegistry(i *do.Injector) {
 	do.Provide(i, func(_ *do.Injector) (*Registry, error) {
@@ -85,11 +87,20 @@ func ToResource[T Resource](data *ResourceData) (T, error) {
 	return resource, nil
 }
 
+type VariableName string
+
+func (v VariableName) String() string {
+	return string(v)
+}
+
+type Variables map[VariableName]any
+
 type Context struct {
-	State    *State
-	Registry *Registry
-	Injector *do.Injector
-	HostID   string // The ID of the host that's executing this context.
+	State     *State
+	Registry  *Registry
+	Injector  *do.Injector
+	HostID    string // The ID of the host that's executing this context.
+	Variables Variables
 }
 
 type ExecutorType string
@@ -218,4 +229,19 @@ func TypedFromRegistry[T Resource](registry *Registry, data *ResourceData) (T, e
 		return zero, fmt.Errorf("unexpected resource type: %T", resource)
 	}
 	return typed, nil
+}
+
+func VariableFromContext[T any](rc *Context, name VariableName) (T, error) {
+	var zero T
+
+	v, ok := rc.Variables[name]
+	if !ok {
+		return zero, ErrVariableUndefined
+	}
+	asType, ok := v.(T)
+	if !ok {
+		return zero, fmt.Errorf("%w: expected %T, but got %T", ErrVariableTypeMismatch, zero, v)
+	}
+
+	return asType, nil
 }

--- a/server/internal/resource/resource_test.go
+++ b/server/internal/resource/resource_test.go
@@ -1,0 +1,41 @@
+package resource_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pgEdge/control-plane/server/internal/resource"
+)
+
+func TestVariables(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		rc := &resource.Context{
+			Variables: resource.Variables{
+				"foo": "bar",
+			},
+		}
+		out, err := resource.VariableFromContext[string](rc, "foo")
+		assert.NoError(t, err)
+		assert.Equal(t, "bar", out)
+	})
+
+	t.Run("undefined", func(t *testing.T) {
+		rc := &resource.Context{}
+		out, err := resource.VariableFromContext[string](rc, "foo")
+		assert.Zero(t, out)
+		assert.ErrorIs(t, err, resource.ErrVariableUndefined)
+	})
+
+	t.Run("type mismatch", func(t *testing.T) {
+		rc := &resource.Context{
+			Variables: resource.Variables{
+				"foo": "bar",
+			},
+		}
+		out, err := resource.VariableFromContext[bool](rc, "foo")
+		assert.Zero(t, out)
+		assert.ErrorIs(t, err, resource.ErrVariableTypeMismatch)
+		assert.ErrorContains(t, err, "variable type mismatch: expected bool, but got string")
+	})
+}

--- a/server/internal/workflows/activities/activities.go
+++ b/server/internal/workflows/activities/activities.go
@@ -31,6 +31,7 @@ func (a *Activities) Register(work *worker.Worker) error {
 		work.RegisterActivity(a.GetInstanceResources),
 		work.RegisterActivity(a.GetPrimaryInstance),
 		work.RegisterActivity(a.GetRestoreResources),
+		work.RegisterActivity(a.GetScriptResults),
 		work.RegisterActivity(a.LogTaskEvent),
 		work.RegisterActivity(a.PerformFailover),
 		work.RegisterActivity(a.PerformSwitchover),

--- a/server/internal/workflows/activities/apply_event.go
+++ b/server/internal/workflows/activities/apply_event.go
@@ -17,11 +17,12 @@ import (
 )
 
 type ApplyEventInput struct {
-	DatabaseID  string          `json:"database_id"`
-	TaskID      uuid.UUID       `json:"task_id"`
-	State       *resource.State `json:"state"`
-	Event       *resource.Event `json:"event"`
-	RemoveHosts []string        `json:"remove_hosts"`
+	DatabaseID  string             `json:"database_id"`
+	TaskID      uuid.UUID          `json:"task_id"`
+	State       *resource.State    `json:"state"`
+	Event       *resource.Event    `json:"event"`
+	RemoveHosts []string           `json:"remove_hosts"`
+	Variables   resource.Variables `json:"variables"`
 }
 
 type ApplyEventOutput struct {
@@ -77,10 +78,11 @@ func (a *Activities) ApplyEvent(ctx context.Context, input *ApplyEventInput) (*A
 	}
 
 	rc := &resource.Context{
-		State:    input.State,
-		Injector: a.Injector,
-		Registry: registry,
-		HostID:   a.Config.HostID,
+		State:     input.State,
+		Injector:  a.Injector,
+		Registry:  registry,
+		HostID:    a.Config.HostID,
+		Variables: input.Variables,
 	}
 
 	event := input.Event

--- a/server/internal/workflows/activities/executor.go
+++ b/server/internal/workflows/activities/executor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/cschleiden/go-workflows/core"
-	"github.com/samber/do"
 
 	"github.com/pgEdge/control-plane/server/internal/database"
 	"github.com/pgEdge/control-plane/server/internal/resource"
@@ -18,17 +17,6 @@ var (
 )
 
 func (a *Activities) ResolveExecutor(state *resource.State, executor resource.Executor) (core.Queue, error) {
-	registry, err := do.Invoke[*resource.Registry](a.Injector)
-	if err != nil {
-		return "", err
-	}
-	rc := &resource.Context{
-		State:    state,
-		Injector: a.Injector,
-		Registry: registry,
-		HostID:   a.Config.HostID,
-	}
-
 	switch executor.Type {
 	case resource.ExecutorTypeHost:
 		return utils.HostQueue(executor.ID), nil
@@ -37,7 +25,7 @@ func (a *Activities) ResolveExecutor(state *resource.State, executor resource.Ex
 	case resource.ExecutorTypeAny:
 		return utils.AnyQueue(), nil
 	case resource.ExecutorTypePrimary:
-		node, err := resource.FromContext[*database.NodeResource](rc, database.NodeResourceIdentifier(executor.ID))
+		node, err := resource.FromState[*database.NodeResource](state, database.NodeResourceIdentifier(executor.ID))
 		if errors.Is(err, resource.ErrNotFound) {
 			return "", ErrExecutorNotFound
 		} else if err != nil {
@@ -48,7 +36,7 @@ func (a *Activities) ResolveExecutor(state *resource.State, executor resource.Ex
 			// is probably missing the node in its dependencies.
 			return "", fmt.Errorf("node %s has no primary instance", node.Name)
 		}
-		instance, err := resource.FromContext[*database.InstanceResource](rc, database.InstanceResourceIdentifier(node.PrimaryInstanceID))
+		instance, err := resource.FromState[*database.InstanceResource](state, database.InstanceResourceIdentifier(node.PrimaryInstanceID))
 		if errors.Is(err, resource.ErrNotFound) {
 			return "", ErrExecutorNotFound
 		} else if err != nil {

--- a/server/internal/workflows/activities/get_instance_resources.go
+++ b/server/internal/workflows/activities/get_instance_resources.go
@@ -12,7 +12,8 @@ import (
 )
 
 type GetInstanceResourcesInput struct {
-	Spec *database.InstanceSpec
+	Spec    *database.InstanceSpec
+	Scripts database.Scripts
 }
 
 type GetInstanceResourcesOutput struct {
@@ -44,7 +45,7 @@ func (a *Activities) GetInstanceResources(ctx context.Context, input *GetInstanc
 		return nil, fmt.Errorf("failed to reconcile instance spec: %w", err)
 	}
 
-	resources, err := a.Orchestrator.GenerateInstanceResources(spec)
+	resources, err := a.Orchestrator.GenerateInstanceResources(spec, input.Scripts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate instance resources: %w", err)
 	}

--- a/server/internal/workflows/activities/get_restore_resources.go
+++ b/server/internal/workflows/activities/get_restore_resources.go
@@ -48,7 +48,7 @@ func (a *Activities) GetRestoreResources(ctx context.Context, input *GetRestoreR
 		return nil, fmt.Errorf("failed to reconcile instance spec: %w", err)
 	}
 
-	resources, err := a.Orchestrator.GenerateInstanceResources(spec)
+	resources, err := a.Orchestrator.GenerateInstanceResources(spec, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate instance resources: %w", err)
 	}

--- a/server/internal/workflows/activities/get_script_results.go
+++ b/server/internal/workflows/activities/get_script_results.go
@@ -1,0 +1,56 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cschleiden/go-workflows/activity"
+	"github.com/cschleiden/go-workflows/workflow"
+
+	"github.com/pgEdge/control-plane/server/internal/database"
+	"github.com/pgEdge/control-plane/server/internal/utils"
+)
+
+type GetScriptResultsInput struct {
+	DatabaseID  string                `json:"database_id"`
+	NodeName    string                `json:"node_name"`
+	ScriptNames []database.ScriptName `json:"script_names"`
+}
+
+type GetScriptResultsOutput struct {
+	Succeeded map[database.ScriptName]bool `json:"succeeded"`
+}
+
+func (a *Activities) ExecuteGetScriptResults(
+	ctx workflow.Context,
+	input *GetScriptResultsInput,
+) workflow.Future[*GetScriptResultsOutput] {
+	options := workflow.ActivityOptions{
+		Queue: utils.AnyQueue(),
+		RetryOptions: workflow.RetryOptions{
+			MaxAttempts: 1,
+		},
+	}
+	return workflow.ExecuteActivity[*GetScriptResultsOutput](ctx, options, a.GetScriptResults, input)
+}
+
+func (a *Activities) GetScriptResults(ctx context.Context, input *GetScriptResultsInput) (*GetScriptResultsOutput, error) {
+	logger := activity.Logger(ctx).With(
+		"database_id", input.DatabaseID,
+		"node_name", input.NodeName,
+	)
+	logger.Debug("getting script results")
+
+	succeeded := make(map[database.ScriptName]bool, len(input.ScriptNames))
+	for _, scriptName := range input.ScriptNames {
+		result, err := a.DatabaseService.GetScriptResult(ctx, input.DatabaseID, scriptName, input.NodeName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get script result: %w", err)
+		}
+		succeeded[scriptName] = result.Succeeded
+	}
+
+	return &GetScriptResultsOutput{
+		Succeeded: succeeded,
+	}, nil
+}

--- a/server/internal/workflows/common.go
+++ b/server/internal/workflows/common.go
@@ -20,6 +20,7 @@ func (w *Workflows) applyEvents(
 	databaseID string,
 	taskID uuid.UUID,
 	state *resource.State,
+	variables resource.Variables,
 	plan resource.Plan,
 	removeHosts ...string,
 ) error {
@@ -32,6 +33,7 @@ func (w *Workflows) applyEvents(
 				State:       state,
 				Event:       event,
 				RemoveHosts: removeHosts,
+				Variables:   variables,
 			}
 			future, err := w.Activities.ExecuteApplyEvent(ctx, in)
 			switch {
@@ -132,6 +134,7 @@ func (w *Workflows) applyPlans(
 	databaseID string,
 	taskID uuid.UUID,
 	state *resource.State,
+	variables resource.Variables,
 	plans []resource.Plan,
 	removeHosts ...string,
 ) error {
@@ -154,7 +157,7 @@ func (w *Workflows) applyPlans(
 		if err != nil {
 			return err
 		}
-		err = w.applyEvents(ctx, databaseID, taskID, state, plan, removeHosts...)
+		err = w.applyEvents(ctx, databaseID, taskID, state, variables, plan, removeHosts...)
 		if err != nil {
 			return fmt.Errorf("error in plan %d: %w", i, err)
 		}

--- a/server/internal/workflows/common.go
+++ b/server/internal/workflows/common.go
@@ -250,11 +250,17 @@ func (w *Workflows) getNodeResources(
 	ctx workflow.Context,
 	node *database.NodeInstances,
 ) (*operations.NodeResources, error) {
+	scripts, err := w.getScripts(ctx, node)
+	if err != nil {
+		return nil, err
+	}
+
 	resources := make([]*database.InstanceResources, len(node.Instances))
 
 	for i, instance := range node.Instances {
 		in := &activities.GetInstanceResourcesInput{
-			Spec: instance,
+			Spec:    instance,
+			Scripts: scripts,
 		}
 		out, err := w.Activities.
 			ExecuteGetInstanceResources(ctx, in).
@@ -267,11 +273,58 @@ func (w *Workflows) getNodeResources(
 	}
 
 	return &operations.NodeResources{
+		DatabaseID:        node.DatabaseID,
 		DatabaseOwner:     node.DatabaseOwner,
 		DatabaseName:      node.DatabaseName,
 		NodeName:          node.NodeName,
 		SourceNode:        node.SourceNode,
 		InstanceResources: resources,
 		RestoreConfig:     node.RestoreConfig,
+		Scripts:           scripts,
 	}, nil
+}
+
+func (w *Workflows) getScripts(
+	ctx workflow.Context,
+	node *database.NodeInstances,
+) (database.Scripts, error) {
+	if node.Scripts == nil {
+		return nil, nil
+	}
+	var scriptNames []database.ScriptName
+	scripts := database.Scripts{}
+	if len(node.Scripts.PostInit) != 0 {
+		scripts[database.ScriptNamePostInit] = &database.Script{
+			DatabaseID: node.DatabaseID,
+			NodeName:   node.NodeName,
+			Name:       database.ScriptNamePostInit,
+			Statements: node.Scripts.PostInit,
+		}
+		scriptNames = append(scriptNames, database.ScriptNamePostInit)
+	}
+	if len(node.Scripts.PostDatabaseCreate) != 0 {
+		scripts[database.ScriptNamePostDatabaseCreate] = &database.Script{
+			DatabaseID: node.DatabaseID,
+			NodeName:   node.NodeName,
+			Name:       database.ScriptNamePostDatabaseCreate,
+			Statements: node.Scripts.PostDatabaseCreate,
+		}
+		scriptNames = append(scriptNames, database.ScriptNamePostDatabaseCreate)
+	}
+	in := &activities.GetScriptResultsInput{
+		DatabaseID:  node.DatabaseID,
+		NodeName:    node.NodeName,
+		ScriptNames: scriptNames,
+	}
+	out, err := w.Activities.
+		ExecuteGetScriptResults(ctx, in).
+		Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get script results: %w", err)
+	}
+	for name, succeeded := range out.Succeeded {
+		scripts[name].Succeeded = succeeded
+	}
+
+	return scripts, nil
 }

--- a/server/internal/workflows/delete_database.go
+++ b/server/internal/workflows/delete_database.go
@@ -9,13 +9,15 @@ import (
 
 	"github.com/pgEdge/control-plane/server/internal/database"
 	"github.com/pgEdge/control-plane/server/internal/database/operations"
+	"github.com/pgEdge/control-plane/server/internal/resource"
 	"github.com/pgEdge/control-plane/server/internal/task"
 	"github.com/pgEdge/control-plane/server/internal/workflows/activities"
 )
 
 type DeleteDatabaseInput struct {
-	DatabaseID string    `json:"database_id"`
-	TaskID     uuid.UUID `json:"task_id"`
+	DatabaseID string             `json:"database_id"`
+	TaskID     uuid.UUID          `json:"task_id"`
+	Variables  resource.Variables `json:"variables"`
 }
 
 type DeleteDatabaseOutput struct{}
@@ -81,6 +83,7 @@ func (w *Workflows) DeleteDatabase(ctx workflow.Context, input *DeleteDatabaseIn
 	refreshCurrentInput := &RefreshCurrentStateInput{
 		DatabaseID: input.DatabaseID,
 		TaskID:     input.TaskID,
+		Variables:  input.Variables,
 	}
 	refreshCurrentOutput, err := w.ExecuteRefreshCurrentState(ctx, refreshCurrentInput).Get(ctx)
 	if err != nil {
@@ -98,7 +101,7 @@ func (w *Workflows) DeleteDatabase(ctx workflow.Context, input *DeleteDatabaseIn
 		return nil, handleError(err)
 	}
 
-	err = w.applyPlans(ctx, input.DatabaseID, input.TaskID, current, plans)
+	err = w.applyPlans(ctx, input.DatabaseID, input.TaskID, current, input.Variables, plans)
 	if err != nil {
 		return nil, handleError(err)
 	}

--- a/server/internal/workflows/pgbackrest_restore.go
+++ b/server/internal/workflows/pgbackrest_restore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/pgEdge/control-plane/server/internal/database"
+	"github.com/pgEdge/control-plane/server/internal/resource"
 	"github.com/pgEdge/control-plane/server/internal/task"
 	"github.com/pgEdge/control-plane/server/internal/workflows/activities"
 )
@@ -19,6 +20,7 @@ type PgBackRestRestoreInput struct {
 	TargetNodes   []string                `json:"target_nodes"`
 	RestoreConfig *database.RestoreConfig `json:"restore_config"`
 	NodeTaskIDs   map[string]uuid.UUID    `json:"node_tasks_ids"`
+	Variables     resource.Variables      `json:"variables"`
 }
 
 type PgBackRestRestoreOutput struct{}
@@ -62,6 +64,7 @@ func (w *Workflows) PgBackRestRestore(ctx workflow.Context, input *PgBackRestRes
 	refreshCurrentInput := &RefreshCurrentStateInput{
 		DatabaseID: input.Spec.DatabaseID,
 		TaskID:     input.TaskID,
+		Variables:  input.Variables,
 	}
 	refreshCurrentOutput, err := w.
 		ExecuteRefreshCurrentState(ctx, refreshCurrentInput).
@@ -87,7 +90,7 @@ func (w *Workflows) PgBackRestRestore(ctx workflow.Context, input *PgBackRestRes
 		return nil, handleError(err)
 	}
 
-	err = w.applyPlans(ctx, input.Spec.DatabaseID, input.TaskID, current, planOutput.Plans)
+	err = w.applyPlans(ctx, input.Spec.DatabaseID, input.TaskID, current, input.Variables, planOutput.Plans)
 	if err != nil {
 		return nil, handleError(err)
 	}

--- a/server/internal/workflows/plan_restore.go
+++ b/server/internal/workflows/plan_restore.go
@@ -94,6 +94,7 @@ func (w *Workflows) getRestoreResources(
 	}
 
 	nodeRestore := &operations.NodeRestoreResources{
+		DatabaseID:    node.DatabaseID,
 		DatabaseName:  node.DatabaseName,
 		DatabaseOwner: node.DatabaseOwner,
 		NodeName:      node.NodeName,

--- a/server/internal/workflows/refresh_current_state.go
+++ b/server/internal/workflows/refresh_current_state.go
@@ -12,9 +12,10 @@ import (
 )
 
 type RefreshCurrentStateInput struct {
-	DatabaseID  string    `json:"database_id"`
-	TaskID      uuid.UUID `json:"task_id"`
-	RemoveHosts []string  `json:"remove_hosts,omitempty"`
+	DatabaseID  string             `json:"database_id"`
+	TaskID      uuid.UUID          `json:"task_id"`
+	RemoveHosts []string           `json:"remove_hosts,omitempty"`
+	Variables   resource.Variables `json:"variables"`
 }
 
 type RefreshCurrentStateOutput struct {
@@ -73,7 +74,7 @@ func (w *Workflows) RefreshCurrentState(ctx workflow.Context, input *RefreshCurr
 	if err != nil {
 		return nil, err
 	}
-	if err := w.applyEvents(ctx, input.DatabaseID, input.TaskID, current, planRefreshOutput.Plan, input.RemoveHosts...); err != nil {
+	if err := w.applyEvents(ctx, input.DatabaseID, input.TaskID, current, input.Variables, planRefreshOutput.Plan, input.RemoveHosts...); err != nil {
 		return nil, fmt.Errorf("failed to apply refresh events: %w", err)
 	}
 	duration := workflow.Now(ctx).Sub(start)

--- a/server/internal/workflows/service.go
+++ b/server/internal/workflows/service.go
@@ -44,8 +44,8 @@ func NewService(
 	}
 }
 
-func (s *Service) CreateDatabase(ctx context.Context, spec *database.Spec) (*task.Task, error) {
-	databaseID := spec.DatabaseID
+func (s *Service) CreateDatabase(ctx context.Context, db *database.Database) (*task.Task, error) {
+	databaseID := db.DatabaseID
 	// Clear out any old tasks. This can happen if you were to recreate a
 	// database with the same ID.
 	if err := s.taskSvc.DeleteAllTasks(ctx, task.ScopeDatabase, databaseID); err != nil {
@@ -60,8 +60,9 @@ func (s *Service) CreateDatabase(ctx context.Context, spec *database.Spec) (*tas
 		return nil, fmt.Errorf("failed to create new task: %w", err)
 	}
 	input := &UpdateDatabaseInput{
-		TaskID: t.TaskID,
-		Spec:   spec,
+		TaskID:    t.TaskID,
+		Spec:      db.Spec,
+		Variables: db.Variables(),
 	}
 	err = s.createWorkflow(ctx, t, s.workflows.UpdateDatabase, input)
 	if err != nil {
@@ -71,8 +72,8 @@ func (s *Service) CreateDatabase(ctx context.Context, spec *database.Spec) (*tas
 	return t, nil
 }
 
-func (s *Service) UpdateDatabase(ctx context.Context, spec *database.Spec, forceUpdate bool, removeHosts ...string) (*task.Task, error) {
-	databaseID := spec.DatabaseID
+func (s *Service) UpdateDatabase(ctx context.Context, db *database.Database, forceUpdate bool, removeHosts ...string) (*task.Task, error) {
+	databaseID := db.DatabaseID
 	t, err := s.taskSvc.CreateTask(ctx, task.Options{
 		Scope:      task.ScopeDatabase,
 		DatabaseID: databaseID,
@@ -83,9 +84,10 @@ func (s *Service) UpdateDatabase(ctx context.Context, spec *database.Spec, force
 	}
 	input := &UpdateDatabaseInput{
 		TaskID:      t.TaskID,
-		Spec:        spec,
+		Spec:        db.Spec,
 		ForceUpdate: forceUpdate,
 		RemoveHosts: removeHosts,
+		Variables:   db.Variables(),
 	}
 	err = s.createWorkflow(ctx, t, s.workflows.UpdateDatabase, input)
 	if err != nil {
@@ -95,18 +97,19 @@ func (s *Service) UpdateDatabase(ctx context.Context, spec *database.Spec, force
 	return t, nil
 }
 
-func (s *Service) DeleteDatabase(ctx context.Context, databaseID string) (*task.Task, error) {
+func (s *Service) DeleteDatabase(ctx context.Context, db *database.Database) (*task.Task, error) {
 	t, err := s.taskSvc.CreateTask(ctx, task.Options{
 		Scope:      task.ScopeDatabase,
-		DatabaseID: databaseID,
+		DatabaseID: db.DatabaseID,
 		Type:       task.TypeDelete,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new task: %w", err)
 	}
 	input := &DeleteDatabaseInput{
-		DatabaseID: databaseID,
+		DatabaseID: db.DatabaseID,
 		TaskID:     t.TaskID,
+		Variables:  db.Variables(),
 	}
 	err = s.createWorkflow(ctx, t, s.workflows.DeleteDatabase, input)
 	if err != nil {
@@ -150,11 +153,11 @@ func (s *Service) CreatePgBackRestBackup(
 
 func (s *Service) PgBackRestRestore(
 	ctx context.Context,
-	spec *database.Spec,
+	db *database.Database,
 	targetNodes []string,
 	restoreConfig *database.RestoreConfig,
 ) (*task.Task, []*task.Task, error) {
-	databaseID := spec.DatabaseID
+	databaseID := db.DatabaseID
 
 	t, err := s.taskSvc.CreateTask(ctx, task.Options{
 		Scope:      task.ScopeDatabase,
@@ -187,10 +190,11 @@ func (s *Service) PgBackRestRestore(
 
 	input := &PgBackRestRestoreInput{
 		TaskID:        t.TaskID,
-		Spec:          spec,
+		Spec:          db.Spec,
 		TargetNodes:   targetNodes,
 		RestoreConfig: restoreConfig.Clone(),
 		NodeTaskIDs:   nodeTaskIDs,
+		Variables:     db.Variables(),
 	}
 	err = s.createWorkflow(ctx, t, s.workflows.PgBackRestRestore, input)
 	if err != nil {

--- a/server/internal/workflows/update_database.go
+++ b/server/internal/workflows/update_database.go
@@ -15,10 +15,11 @@ import (
 )
 
 type UpdateDatabaseInput struct {
-	TaskID      uuid.UUID      `json:"task_id"`
-	Spec        *database.Spec `json:"spec"`
-	ForceUpdate bool           `json:"force_update"`
-	RemoveHosts []string       `json:"remove_hosts"`
+	TaskID      uuid.UUID          `json:"task_id"`
+	Spec        *database.Spec     `json:"spec"`
+	ForceUpdate bool               `json:"force_update"`
+	RemoveHosts []string           `json:"remove_hosts"`
+	Variables   resource.Variables `json:"variables"`
 }
 
 type UpdateDatabaseOutput struct {
@@ -88,6 +89,7 @@ func (w *Workflows) UpdateDatabase(ctx workflow.Context, input *UpdateDatabaseIn
 		DatabaseID:  input.Spec.DatabaseID,
 		TaskID:      input.TaskID,
 		RemoveHosts: input.RemoveHosts,
+		Variables:   input.Variables,
 	}
 	refreshCurrentOutput, err := w.ExecuteRefreshCurrentState(ctx, refreshCurrentInput).Get(ctx)
 	if err != nil {
@@ -114,7 +116,7 @@ func (w *Workflows) UpdateDatabase(ctx workflow.Context, input *UpdateDatabaseIn
 		return nil, handleError(err)
 	}
 
-	err = w.applyPlans(ctx, input.Spec.DatabaseID, input.TaskID, current, planOutput.Plans, input.RemoveHosts...)
+	err = w.applyPlans(ctx, input.Spec.DatabaseID, input.TaskID, current, input.Variables, planOutput.Plans, input.RemoveHosts...)
 	if err != nil {
 		return nil, handleError(err)
 	}


### PR DESCRIPTION
## Summary

Adds the ability to run arbitrary SQL at two different points in the database creation process:

- `post_init`: This script runs immediately after the database is created, before any users are created.
- `post_database_create`: This script runs immediately after Spock is initialized, before any subscriptions have been created.

This feature can be used to perform first-time setup for roles and similar operations.

## Changes

- Added a `scripts` field to the database spec:

```js
{
  // ...
  "scripts": {
    "post_init": [
      "CREATE ROLE read_only NOLOGIN",
      "...",
      "..."
    ],
    "post_database_create": [
      "ALTER DEFAULT PRIVILEGES FOR ROLE admin GRANT USAGE ON SCHEMAS TO read_only",
      "...",
      "..."
    ]
  }
}
```

## Testing

Basic usage:

```sh
cp1-req create-database <<EOF | cp-follow-task
{
  "id": "storefront",
  "spec": {
    "database_name": "storefront",
    "database_users": [
      {
        "username": "admin",
        "password": "password",
        "db_owner": true,
        "attributes": ["SUPERUSER", "LOGIN"]
      },
      {
        "username": "app",
        "password": "password",
        "roles": ["foo_role"]
      }
    ],
    "port": 0,
    "patroni_port": 0,
    "nodes": [
      { "name": "n1", "host_ids": ["host-1"] },
      { "name": "n2", "host_ids": ["host-2"] }
    ],
    "scripts": {
      "post_init": [
        "CREATE ROLE foo_role NOLOGIN"
      ],
      "post_database_create": [
        "CREATE TABLE foo (id int primary key, val text)",
        "INSERT INTO foo (id, val) VALUES (1, 'foo')"
      ]
    }
  }
}
EOF

# validate that admin has foo_role role
cp-psql -U admin -i storefront-n1-689qacsi -- -c "SELECT oid, rolname FROM pg_roles WHERE pg_has_role('admin', oid, 'member') and rolname = 'foo_role'"
cp-psql -U admin -i storefront-n2-9ptayhma -- -c "SELECT oid, rolname FROM pg_roles WHERE pg_has_role('admin', oid, 'member') and rolname = 'foo_role'"

# validate that foo table is populated
cp-psql -U admin -i storefront-n1-689qacsi -- -c "SELECT val FROM foo WHERE id = 1"
cp-psql -U admin -i storefront-n2-9ptayhma -- -c "SELECT val FROM foo WHERE id = 1"

# validate that replication works for table foo
cp-psql -U admin -i storefront-n1-689qacsi -- -c "INSERT INTO foo (id, val) VALUES (2, 'bar')"
cp-psql -U admin -i storefront-n2-9ptayhma -- -c "INSERT INTO foo (id, val) VALUES (3, 'baz')."
cp-psql -U admin -i storefront-n2-9ptayhma -- -c "SELECT val FROM foo WHERE id = 2"
cp-psql -U admin -i storefront-n1-689qacsi -- -c "SELECT val FROM foo WHERE id = 3"
```

After that, you can try changing your statements and validating that the changed statements do not run.

You can also try specifying an invalid statement in `post_init` for a new database, like `CREATE DATABASE foo`, and observe that the database creation process fails with an error about how `CREATE DATABASE` is not allowed within a transaction. Then remove or replace the bad statement, submit an `update-database` request, and verify that the creation process resumes where it left off and executes your updated statement.

You can also look at the included examples in the API reference, docs, and tests for other things to try.

## Notes for Reviewers

Roles added in the `pre_init` field will not carry over to new nodes. This will be addressed in a subsequent PR.

PLAT-543