### PR TITLE
chore: rename dev-teardown to dev-reset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ make dev-build
 # Stop development environment
 make dev-down
 
-# Complete teardown (removes databases, networks, data)
-make dev-teardown
+# Reset development environment (removes databases, networks, data)
+make dev-reset
 ```
 
 ### Testing

--- a/Makefile
+++ b/Makefile
@@ -384,8 +384,8 @@ dev-detached: dev-build docker-swarm-init
 dev-down:
 	$(docker_compose_dev) down
 
-.PHONY: dev-teardown
-dev-teardown: dev-down
+.PHONY: dev-reset
+dev-reset: dev-down
 	# remove postgres and supported services
 	ids=$$(docker service ls -q); \
 	if [ -n "$$ids" ]; then \

--- a/docs/development/running-locally.md
+++ b/docs/development/running-locally.md
@@ -160,7 +160,7 @@ Endpoints that are unimplemented will return a `not implemented` error.
 To reset your environment to its initial state, run:
 
 ```
-make dev-teardown
+make dev-reset
 ```
 
 This will:


### PR DESCRIPTION
## Summary

Renames the `dev-teardown` target to `dev-reset`. This target is more analogous to the `reset` targets (`dev-lima-reset`, `reset-fixture-lima`, `reset-fixture-ec2`) than the `teardown` targets, which also remove the VMs.

I'm hoping this change will make me less likely to run the other `teardown` targets by accident.