### PR TITLE
chore: quit circus in dev-lima-reset

### DIFF
--- a/lima/.gitignore
+++ b/lima/.gitignore
@@ -1,0 +1,1 @@
+circus.pid

--- a/lima/Makefile
+++ b/lima/Makefile
@@ -1,17 +1,22 @@
 ansible_playbook=ansible-playbook \
 	--extra-vars='@vars.yaml'
 
+.PHONY: quit
+quit:
+	[ -e ./circus.pid ] && circusctl --timeout 2 quit 2>/dev/null || true
+	rm -f ./circus.pid
+
 .PHONY: deploy
 deploy:
 	$(ansible_playbook) deploy.yaml
 
 .PHONY: teardown
-teardown:
+teardown: quit
 	$(ansible_playbook) teardown.yaml
 	rm -rf ./data
 
 .PHONY: reset
-reset:
+reset: quit
 	$(ansible_playbook) stop-dbs.yaml
 	rm -rf ./data
 
@@ -27,5 +32,5 @@ fix-clocks:
 	ansible --become -i ./inventory.yaml all -m command -a 'chronyc -a makestep'
 
 .PHONY: run
-run: build fix-clocks
-	LIMA_DIR=$(shell pwd) circusd ./circus.ini
+run: quit build fix-clocks
+	LIMA_DIR=$(shell pwd) circusd --pidfile ./circus.pid ./circus.ini


### PR DESCRIPTION
## Summary

Circus can keep running after your shell is disconnected, for example if your terminal program restarts. This commit updates the lima Makefile to ensure that circus and its control-plane processes are stopped in the `teardown`, `reset`, and `run` targets.

## Testing

```sh
# in one terminal
make dev-lima-run

# in another terminal
make dev-lima-reset

# this should quit the running instance in your dev-lima-run terminal.

# there should not be any error if you re-run dev-lima-reset
make dev-lima-reset
```