### PR TITLE
feat: restart RAG container on config change

### DIFF
--- a/server/internal/docker/docker.go
+++ b/server/internal/docker/docker.go
@@ -486,8 +486,11 @@ func (d *Docker) WaitForService(ctx context.Context, serviceID string, timeout t
 				Strs("task_states", taskStates).
 				Msg("checking service task status")
 
-			// If we have failed tasks and no running or transitional tasks, the service won't start
-			if failed > 0 && running == 0 && preparing == 0 && pending == 0 {
+			// If we have failed tasks and no running or transitional tasks, the
+			// service won't start. Skip this check when scaling to 0: task
+			// failures (e.g. bind-mount errors, non-zero exits) are expected
+			// because the containers are being stopped, not started.
+			if desired > 0 && failed > 0 && running == 0 && preparing == 0 && pending == 0 {
 				if lastFailureMsg != "" {
 					return fmt.Errorf("service tasks failed: %s", lastFailureMsg)
 				}

--- a/server/internal/orchestrator/swarm/service_spec.go
+++ b/server/internal/orchestrator/swarm/service_spec.go
@@ -1,6 +1,8 @@
 package swarm
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -36,6 +38,16 @@ func buildPostgRESTEnvVars() []string {
 		"PGRST_SERVER_PORT=8080",
 		"PGRST_ADMIN_SERVER_PORT=3001",
 	}
+}
+
+// ragConfigHash returns a short hex digest of the RAG service configuration.
+// It is embedded in the container spec as PGEDGE_CONFIG_VERSION so that Docker
+// Swarm detects a TaskTemplate change and restarts the container whenever the
+// pipeline configuration or API keys change.
+func ragConfigHash(config map[string]any) string {
+	b, _ := json.Marshal(config)
+	sum := sha256.Sum256(b)
+	return fmt.Sprintf("%x", sum[:8])
 }
 
 // ServiceContainerSpecOptions contains all parameters needed to build a service container spec.
@@ -180,6 +192,10 @@ func ServiceContainerSpec(opts *ServiceContainerSpecOptions) (swarm.ServiceSpec,
 		user = fmt.Sprintf("%d", ragContainerUID)
 		command = []string{"/app/pgedge-rag-server"}
 		args = []string{"-config", "/app/data/pgedge-rag-server.yaml"}
+		// Embed a hash of the service config so that Docker Swarm detects a
+		// TaskTemplate change and restarts the container when pipelines or API
+		// keys change. Without this, bind-mount updates are invisible to Swarm.
+		env = []string{"PGEDGE_CONFIG_VERSION=" + ragConfigHash(opts.ServiceSpec.Config)}
 		// No curl in the RHEL minimal image — use a TCP probe instead.
 		healthcheck = &container.HealthConfig{
 			Test:        []string{"CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080"},

--- a/server/internal/orchestrator/swarm/service_spec_test.go
+++ b/server/internal/orchestrator/swarm/service_spec_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pgEdge/control-plane/server/internal/database"
 )
@@ -356,6 +358,84 @@ func TestServiceContainerSpec_ExtraNetworks(t *testing.T) {
 	if networks[3].Target != "monitoring" {
 		t.Errorf("networks[3].Target = %q, want %q", networks[3].Target, "monitoring")
 	}
+}
+
+func TestRagConfigHash(t *testing.T) {
+	cfg := map[string]any{
+		"pipelines": []any{
+			map[string]any{"name": "default", "api_key": "sk-abc"},
+		},
+	}
+
+	h1 := ragConfigHash(cfg)
+	h2 := ragConfigHash(cfg)
+	assert.Equal(t, h1, h2, "same config must produce the same hash")
+	assert.Len(t, h1, 16, "hash should be 16 hex chars (8 bytes)")
+
+	changed := map[string]any{
+		"pipelines": []any{
+			map[string]any{"name": "default", "api_key": "sk-xyz"},
+		},
+	}
+	assert.NotEqual(t, h1, ragConfigHash(changed), "different config must produce a different hash")
+}
+
+func TestServiceContainerSpec_RAGHasConfigVersionEnv(t *testing.T) {
+	config := map[string]any{
+		"pipelines": []any{
+			map[string]any{"name": "default", "api_key": "sk-test"},
+		},
+	}
+	opts := &ServiceContainerSpecOptions{
+		ServiceSpec: &database.ServiceSpec{
+			ServiceID:   "rag",
+			ServiceType: "rag",
+			Version:     "latest",
+			Config:      config,
+		},
+		ServiceInstanceID: "db1-rag-host1",
+		DatabaseID:        "db1",
+		DatabaseName:      "testdb",
+		HostID:            "host1",
+		ServiceName:       "db1-rag-host1",
+		Hostname:          "rag-host1",
+		CohortMemberID:    "node-123",
+		ServiceImage:      &ServiceImage{Tag: "ghcr.io/pgedge/rag-server:latest"},
+		Credentials:       &database.ServiceUser{Username: "svc_rag", Password: "pw"},
+		DatabaseNetworkID: "db1-database",
+		Port:              intPtr(0),
+		DataPath:          "/var/lib/pgedge/services/db1-rag-host1",
+		KeysPath:          "/var/lib/pgedge/services/db1-rag-host1/keys",
+	}
+
+	spec, err := ServiceContainerSpec(opts)
+	require.NoError(t, err)
+
+	env := spec.TaskTemplate.ContainerSpec.Env
+	var configVersion string
+	for _, e := range env {
+		if strings.HasPrefix(e, "PGEDGE_CONFIG_VERSION=") {
+			configVersion = strings.TrimPrefix(e, "PGEDGE_CONFIG_VERSION=")
+		}
+	}
+	require.NotEmpty(t, configVersion, "RAG container spec must have PGEDGE_CONFIG_VERSION env var")
+	assert.Equal(t, ragConfigHash(config), configVersion)
+
+	// Changing the config must produce a different env var value.
+	opts.ServiceSpec.Config = map[string]any{
+		"pipelines": []any{
+			map[string]any{"name": "default", "api_key": "sk-new"},
+		},
+	}
+	spec2, err := ServiceContainerSpec(opts)
+	require.NoError(t, err)
+	var configVersion2 string
+	for _, e := range spec2.TaskTemplate.ContainerSpec.Env {
+		if strings.HasPrefix(e, "PGEDGE_CONFIG_VERSION=") {
+			configVersion2 = strings.TrimPrefix(e, "PGEDGE_CONFIG_VERSION=")
+		}
+	}
+	assert.NotEqual(t, configVersion, configVersion2, "changed config must produce a different PGEDGE_CONFIG_VERSION")
 }
 
 func TestServiceContainerSpec_NoExtraNetworks(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR restart the RAG container when `config.pipelines` changes via a Control
Plane update, so new pipeline settings and API keys take effect without
manual intervention.


## Changes
- Embed `PGEDGE_CONFIG_VERSION=<hash>` as an env var in the RAG container
  spec. Docker Swarm only restarts a service when its `TaskTemplate`
  changes; a config-only update writes a new YAML to the bind mount but
  the container would otherwise keep running with the old config in memory.
  The hash (SHA256 of `config.pipelines`, truncated to 8 bytes) changes
  whenever pipelines or API keys change, making the update visible to Swarm.

## Testing
Verification:
1. Created a cluster
2. Created DB using [rag_create_db.json](https://github.com/user-attachments/files/26679996/rag_create_db.json)


Verified hash

```
docker service inspect rag-storefront-rag-689qacsi \
  --format '{{range .Spec.TaskTemplate.ContainerSpec.Env}}{{println .}}{{end}}' \
  | grep PGEDGE_CONFIG_VERSION

PGEDGE_CONFIG_VERSION=0f5c8aee2d69bf90

```
3. Updated DB using [rag_update_db.json](https://github.com/user-attachments/files/26679968/rag_update_db.json) 
 Verified hash
```
 docker service inspect rag-storefront-rag-689qacsi \                                   
  --format '{{range .Spec.TaskTemplate.ContainerSpec.Env}}{{println .}}{{end}}' \
  | grep PGEDGE_CONFIG_VERSION

PGEDGE_CONFIG_VERSION=72685a12bfb356af

```

4. Confirmed that the rag service restarted successfully when there is a change in config
```
docker service ps rag-storefront-rag-689qacsi 2>/dev/null


ID             NAME                                IMAGE                              NODE             DESIRED STATE   CURRENT STATE                ERROR     PORTS
8z7r3d52noy6   rag-storefront-rag-689qacsi.1       ghcr.io/pgedge/rag-server:latest   docker-desktop   Running         Running about an hour ago              *:55020->8080/tcp
nyhyhx6vqjze    \_ rag-storefront-rag-689qacsi.1   ghcr.io/pgedge/rag-server:latest   docker-desktop   Shutdown        Shutdown about an hour ago 
```

## Checklist

- [x] Tests added 

## Notes for Reviewers
The hot-reload acceptance criteria (in-flight query continuity, no downtime) are for the RAG server repo in a parallel ticket. This PR covers the control-plane side: ensuring the container is restarted with the updated config file on disk.
