### PR TITLE
chore: pin redoc image to v2.5.1

### DIFF
--- a/docker/control-plane-dev/docker-compose.yaml
+++ b/docker/control-plane-dev/docker-compose.yaml
@@ -109,7 +109,7 @@ services:
       timeout: 1s
       retries: 30
   api-docs:
-    image: redocly/redoc
+    image: redocly/redoc:v2.5.1
     ports:
       - 8999:80
     volumes:


### PR DESCRIPTION
## Summary

The latest version is broken for some folks, and it doesn't render examples correctly.

## Testing

```sh
make api-docs
```
