### PR TITLE
test: verify db_owner wiring and CreateUserRole with built-in PG roles

### DIFF
--- a/server/internal/database/spec_test.go
+++ b/server/internal/database/spec_test.go
@@ -509,3 +509,60 @@ func TestSpec(t *testing.T) {
 		})
 	})
 }
+
+func TestSpec_NodeInstances_DBOwner(t *testing.T) {
+	minimalSpec := func(users []*database.User) *database.Spec {
+		return &database.Spec{
+			DatabaseID:      "test-db",
+			DatabaseName:    "testdb",
+			PostgresVersion: "17.6",
+			SpockVersion:    "5",
+			DatabaseUsers:   users,
+			Nodes: []*database.Node{
+				{Name: "n1", HostIDs: []string{"host-1"}},
+			},
+		}
+	}
+
+	t.Run("single db_owner is propagated", func(t *testing.T) {
+		spec := minimalSpec([]*database.User{
+			{Username: "app", DBOwner: true},
+			{Username: "admin"},
+		})
+		nodes, err := spec.NodeInstances()
+		assert.NoError(t, err)
+		assert.Equal(t, "app", nodes[0].DatabaseOwner)
+	})
+
+	t.Run("no db_owner results in empty owner", func(t *testing.T) {
+		spec := minimalSpec([]*database.User{
+			{Username: "app"},
+			{Username: "admin"},
+		})
+		nodes, err := spec.NodeInstances()
+		assert.NoError(t, err)
+		assert.Empty(t, nodes[0].DatabaseOwner)
+	})
+
+	t.Run("multiple db_owners returns error", func(t *testing.T) {
+		spec := minimalSpec([]*database.User{
+			{Username: "app", DBOwner: true},
+			{Username: "other", DBOwner: true},
+		})
+		_, err := spec.NodeInstances()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only one user can have db_owner=true")
+	})
+
+	t.Run("owner propagates to all nodes", func(t *testing.T) {
+		spec := minimalSpec([]*database.User{
+			{Username: "app", DBOwner: true},
+		})
+		spec.Nodes = append(spec.Nodes, &database.Node{Name: "n2", HostIDs: []string{"host-2"}})
+		nodes, err := spec.NodeInstances()
+		assert.NoError(t, err)
+		assert.Len(t, nodes, 2)
+		assert.Equal(t, "app", nodes[0].DatabaseOwner)
+		assert.Equal(t, "app", nodes[1].DatabaseOwner)
+	})
+}

--- a/server/internal/postgres/roles_test.go
+++ b/server/internal/postgres/roles_test.go
@@ -89,6 +89,33 @@ func TestCreateUserRole(t *testing.T) {
 			},
 		},
 		{
+			name: "app user with built-in PostgreSQL roles",
+			opts: postgres.UserRoleOptions{
+				Name:       "app",
+				Password:   "password",
+				Attributes: []string{"LOGIN"},
+				Roles:      []string{"pg_read_all_data", "pg_read_all_settings", "pg_read_all_stats"},
+			},
+			expected: postgres.Statements{
+				postgres.ConditionalStatement{
+					If: postgres.Query[bool]{
+						SQL: `SELECT NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = @name);`,
+						Args: pgx.NamedArgs{
+							"name": "app",
+						},
+					},
+					Then: postgres.Statement{
+						SQL: `CREATE ROLE "app"`,
+					},
+				},
+				postgres.Statement{SQL: `ALTER ROLE "app" WITH PASSWORD 'password';`},
+				postgres.Statement{SQL: `ALTER ROLE "app" WITH LOGIN;`},
+				postgres.Statement{SQL: `GRANT "pg_read_all_data" TO "app" WITH INHERIT TRUE;`},
+				postgres.Statement{SQL: `GRANT "pg_read_all_settings" TO "app" WITH INHERIT TRUE;`},
+				postgres.Statement{SQL: `GRANT "pg_read_all_stats" TO "app" WITH INHERIT TRUE;`},
+			},
+		},
+		{
 			name: "role conflict",
 			opts: postgres.UserRoleOptions{
 				Name: "pgedge_application",


### PR DESCRIPTION
## Summary 

  - Add unit tests verifying `db_owner` and `CreateUserRole` with built-in PostgreSQL roles work as expected for the `connect_as` design                                                                                                 
  - No code changes — tests only
                                                                                                                                                                                                                                         
## Test plan                                                                                                 
                                                                                                                                                                                                                                         
  - [x] `TestSpec_NodeInstances_DBOwner` — single owner propagated, no owner is empty, multiple owners rejected, owner propagates to all nodes                                                                                           
  - [x] `TestCreateUserRole_BuiltinPgRoles` — `pg_read_all_data`, `pg_read_all_settings`, `pg_read_all_stats` produce correct GRANT statements
  - [x] Full test suite passes (1005 tests)

PLAT-550
PLAT-551