### PR TITLE
feat: switch RAG service to connect_as credentials

### DIFF
--- a/e2e/rag_service_test.go
+++ b/e2e/rag_service_test.go
@@ -49,6 +49,11 @@ func TestProvisionRAGService(t *testing.T) {
 					DbOwner:    pointerTo(true),
 					Attributes: []string{"LOGIN", "SUPERUSER"},
 				},
+				{
+					Username:   "rag_user",
+					Password:   pointerTo("ragpassword"),
+					Attributes: []string{"LOGIN"},
+				},
 			},
 			Port:        pointerTo(0),
 			PatroniPort: pointerTo(0),
@@ -65,6 +70,7 @@ func TestProvisionRAGService(t *testing.T) {
 					Version:     "latest",
 					HostIds:     []controlplane.Identifier{controlplane.Identifier(host1)},
 					Port:        pointerTo(0),
+					ConnectAs: "rag_user",
 					Config: map[string]any{
 						"pipelines": []any{
 							map[string]any{
@@ -137,6 +143,11 @@ func TestRAGPipelineQuery(t *testing.T) {
 					DbOwner:    pointerTo(true),
 					Attributes: []string{"LOGIN", "SUPERUSER"},
 				},
+				{
+					Username:   "rag_user",
+					Password:   pointerTo("ragpassword"),
+					Attributes: []string{"LOGIN"},
+				},
 			},
 			Port:        pointerTo(0),
 			PatroniPort: pointerTo(0),
@@ -153,6 +164,7 @@ func TestRAGPipelineQuery(t *testing.T) {
 					Version:     "latest",
 					HostIds:     []controlplane.Identifier{controlplane.Identifier(host1)},
 					Port:        pointerTo(0),
+					ConnectAs:   "rag_user",
 					Config: map[string]any{
 						"pipelines": []any{
 							map[string]any{
@@ -377,6 +389,11 @@ func TestProvisionMultiHostRAGService(t *testing.T) {
 					DbOwner:    pointerTo(true),
 					Attributes: []string{"LOGIN", "SUPERUSER"},
 				},
+				{
+					Username:   "rag_user",
+					Password:   pointerTo("ragpassword"),
+					Attributes: []string{"LOGIN"},
+				},
 			},
 			Port:        pointerTo(0),
 			PatroniPort: pointerTo(0),
@@ -395,7 +412,8 @@ func TestProvisionMultiHostRAGService(t *testing.T) {
 						controlplane.Identifier(host2),
 						controlplane.Identifier(host3),
 					},
-					Port: pointerTo(0),
+					Port:      pointerTo(0),
+					ConnectAs: "rag_user",
 					Config: map[string]any{
 						"pipelines": []any{
 							map[string]any{
@@ -470,6 +488,11 @@ func TestAddRAGServiceToExistingDatabase(t *testing.T) {
 					DbOwner:    pointerTo(true),
 					Attributes: []string{"LOGIN", "SUPERUSER"},
 				},
+				{
+					Username:   "rag_user",
+					Password:   pointerTo("ragpassword"),
+					Attributes: []string{"LOGIN"},
+				},
 			},
 			Port:        pointerTo(0),
 			PatroniPort: pointerTo(0),
@@ -493,6 +516,11 @@ func TestAddRAGServiceToExistingDatabase(t *testing.T) {
 					DbOwner:    pointerTo(true),
 					Attributes: []string{"LOGIN", "SUPERUSER"},
 				},
+				{
+					Username:   "rag_user",
+					Password:   pointerTo("ragpassword"),
+					Attributes: []string{"LOGIN"},
+				},
 			},
 			Port:        pointerTo(0),
 			PatroniPort: pointerTo(0),
@@ -506,6 +534,7 @@ func TestAddRAGServiceToExistingDatabase(t *testing.T) {
 					Version:     "latest",
 					HostIds:     []controlplane.Identifier{controlplane.Identifier(host1)},
 					Port:        pointerTo(0),
+					ConnectAs:   "rag_user",
 					Config: map[string]any{
 						"pipelines": []any{
 							map[string]any{
@@ -572,6 +601,11 @@ func TestProvisionRAGServiceUnsupportedVersion(t *testing.T) {
 					DbOwner:    pointerTo(true),
 					Attributes: []string{"LOGIN", "SUPERUSER"},
 				},
+				{
+					Username:   "rag_user",
+					Password:   pointerTo("ragpassword"),
+					Attributes: []string{"LOGIN"},
+				},
 			},
 			Port:        pointerTo(0),
 			PatroniPort: pointerTo(0),
@@ -585,6 +619,7 @@ func TestProvisionRAGServiceUnsupportedVersion(t *testing.T) {
 					Version:     "99.99.99", // Valid semver but not registered
 					HostIds:     []controlplane.Identifier{controlplane.Identifier(host1)},
 					Port:        pointerTo(0),
+					ConnectAs:   "rag_user",
 					Config: map[string]any{
 						"pipelines": []any{
 							map[string]any{

--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -360,9 +360,9 @@ func validateServiceSpec(svc *api.ServiceSpec, path []string, isUpdate bool, dbU
 		errs = append(errs, validateDatabaseConnection(svc.DatabaseConnection, dcPath, nn)...)
 	}
 
-	// Validate connect_as references a valid database_users entry (MCP only for now;
-	// RAG and PostgREST will adopt connect_as in a future change).
-	if svc.ServiceType == "mcp" {
+	// Validate connect_as references a valid database_users entry.
+	// MCP and RAG both require connect_as; PostgREST will adopt it in a future change.
+	if svc.ServiceType == "mcp" || svc.ServiceType == "rag" {
 		errs = append(errs, validateConnectAs(svc, dbUsers, path)...)
 	}
 

--- a/server/internal/orchestrator/swarm/orchestrator.go
+++ b/server/internal/orchestrator/swarm/orchestrator.go
@@ -695,34 +695,7 @@ func (o *Orchestrator) generateRAGInstanceResources(spec *database.ServiceInstan
 		Allocator: o.dbNetworkAllocator,
 	}
 
-	canonicalROID := ServiceUserRoleIdentifier(spec.ServiceSpec.ServiceID, ServiceUserRoleRO)
-
-	// Canonical read-only role — runs on the node co-located with this instance.
-	canonicalRO := &ServiceUserRole{
-		ServiceID:    spec.ServiceSpec.ServiceID,
-		DatabaseID:   spec.DatabaseID,
-		DatabaseName: spec.DatabaseName,
-		NodeName:     spec.NodeName,
-		Mode:         ServiceUserRoleRO,
-	}
-
-	orchestratorResources := []resource.Resource{databaseNetwork, canonicalRO}
-
-	// Per-node RO role for each additional database node so that RAG instances
-	// on other hosts can authenticate against their co-located Postgres.
-	for _, nodeInst := range spec.DatabaseNodes {
-		if nodeInst.NodeName == spec.NodeName {
-			continue
-		}
-		orchestratorResources = append(orchestratorResources, &ServiceUserRole{
-			ServiceID:        spec.ServiceSpec.ServiceID,
-			DatabaseID:       spec.DatabaseID,
-			DatabaseName:     spec.DatabaseName,
-			NodeName:         nodeInst.NodeName,
-			Mode:             ServiceUserRoleRO,
-			CredentialSource: &canonicalROID,
-		})
-	}
+	orchestratorResources := []resource.Resource{databaseNetwork}
 
 	// Service data directory resource (host-side bind mount directory).
 	dataDirID := spec.ServiceInstanceID + "-data"
@@ -743,6 +716,16 @@ func (o *Orchestrator) generateRAGInstanceResources(spec *database.ServiceInstan
 		Keys:              extractRAGAPIKeys(ragConfig),
 	}
 
+	// RAG preflight resource — waits for Patroni to finish bootstrapping
+	// the database and for the connect_as user (if any) to exist before the
+	// config file is written and the Docker service is started.
+	ragPreflight := &RAGPreflightResource{
+		ServiceInstanceID: spec.ServiceInstanceID,
+		NodeName:          spec.NodeName,
+		DatabaseName:      spec.DatabaseName,
+		ConnectAsUsername: spec.ConnectAsUsername,
+	}
+
 	// RAG config resource — generates pgedge-rag-server.yaml in the data directory.
 	var dbHost string
 	var dbPort int
@@ -759,6 +742,8 @@ func (o *Orchestrator) generateRAGInstanceResources(spec *database.ServiceInstan
 		DatabaseName:      spec.DatabaseName,
 		DatabaseHost:      dbHost,
 		DatabasePort:      dbPort,
+		ConnectAsUsername: spec.ConnectAsUsername,
+		ConnectAsPassword: spec.ConnectAsPassword,
 	}
 
 	// Service instance spec resource — holds the computed Docker Swarm service spec.
@@ -790,10 +775,11 @@ func (o *Orchestrator) generateRAGInstanceResources(spec *database.ServiceInstan
 		ServiceID:         spec.ServiceSpec.ServiceID,
 		ServiceSpecID:     spec.ServiceSpec.ServiceID,
 		ServiceType:       spec.ServiceSpec.ServiceType,
+		ConnectAsUsername: spec.ConnectAsUsername,
 		HostID:            spec.HostID,
 	}
 
-	orchestratorResources = append(orchestratorResources, dataDir, keysResource, ragConfigRes, serviceInstanceSpec, serviceInstance)
+	orchestratorResources = append(orchestratorResources, dataDir, keysResource, ragPreflight, ragConfigRes, serviceInstanceSpec, serviceInstance)
 
 	return o.buildServiceInstanceResources(spec, orchestratorResources)
 }

--- a/server/internal/orchestrator/swarm/rag_config_resource.go
+++ b/server/internal/orchestrator/swarm/rag_config_resource.go
@@ -34,7 +34,8 @@ func RAGConfigResourceIdentifier(serviceInstanceID string) resource.Identifier {
 // host filesystem. The file is written to the service data directory
 // (managed by a DirResource) which is bind-mounted into the container at
 // /app/data. On every Create or Update the file is regenerated from the
-// current RAGServiceConfig and database credentials.
+// current RAGServiceConfig and the connect_as credentials sourced from
+// database_users.
 type RAGConfigResource struct {
 	ServiceInstanceID string                     `json:"service_instance_id"`
 	ServiceID         string                     `json:"service_id"`
@@ -44,10 +45,12 @@ type RAGConfigResource struct {
 	DatabaseName      string                     `json:"database_name"`
 	DatabaseHost      string                     `json:"database_host"`
 	DatabasePort      int                        `json:"database_port"`
+	ConnectAsUsername string                     `json:"connect_as_username"`
+	ConnectAsPassword string                     `json:"connect_as_password"`
 }
 
 func (r *RAGConfigResource) ResourceVersion() string {
-	return "1"
+	return "2"
 }
 
 func (r *RAGConfigResource) DiffIgnore() []string {
@@ -65,8 +68,8 @@ func (r *RAGConfigResource) Executor() resource.Executor {
 func (r *RAGConfigResource) Dependencies() []resource.Identifier {
 	return []resource.Identifier{
 		filesystem.DirResourceIdentifier(r.DirResourceID),
-		ServiceUserRoleIdentifier(r.ServiceID, ServiceUserRoleRO),
 		RAGServiceKeysResourceIdentifier(r.ServiceInstanceID),
+		RAGPreflightResourceIdentifier(r.ServiceInstanceID),
 	}
 }
 
@@ -104,7 +107,7 @@ func (r *RAGConfigResource) Create(ctx context.Context, rc *resource.Context) er
 		return fmt.Errorf("failed to get service data dir path: %w", err)
 	}
 
-	return r.writeConfigFile(fs, dirPath, rc)
+	return r.writeConfigFile(fs, dirPath)
 }
 
 func (r *RAGConfigResource) Update(ctx context.Context, rc *resource.Context) error {
@@ -118,7 +121,7 @@ func (r *RAGConfigResource) Update(ctx context.Context, rc *resource.Context) er
 		return fmt.Errorf("failed to get service data dir path: %w", err)
 	}
 
-	return r.writeConfigFile(fs, dirPath, rc)
+	return r.writeConfigFile(fs, dirPath)
 }
 
 func (r *RAGConfigResource) Delete(ctx context.Context, rc *resource.Context) error {
@@ -126,19 +129,14 @@ func (r *RAGConfigResource) Delete(ctx context.Context, rc *resource.Context) er
 	return nil
 }
 
-func (r *RAGConfigResource) writeConfigFile(fs afero.Fs, dirPath string, rc *resource.Context) error {
-	userRole, err := resource.FromContext[*ServiceUserRole](rc, ServiceUserRoleIdentifier(r.ServiceID, ServiceUserRoleRO))
-	if err != nil {
-		return fmt.Errorf("failed to get RAG service user role from state: %w", err)
-	}
-
+func (r *RAGConfigResource) writeConfigFile(fs afero.Fs, dirPath string) error {
 	content, err := GenerateRAGConfig(&RAGConfigParams{
 		Config:       r.Config,
 		DatabaseName: r.DatabaseName,
 		DatabaseHost: r.DatabaseHost,
 		DatabasePort: r.DatabasePort,
-		Username:     userRole.Username,
-		Password:     userRole.Password,
+		Username:     r.ConnectAsUsername,
+		Password:     r.ConnectAsPassword,
 		KeysDir:      ragKeysContainerDir,
 	})
 	if err != nil {

--- a/server/internal/orchestrator/swarm/rag_config_resource_test.go
+++ b/server/internal/orchestrator/swarm/rag_config_resource_test.go
@@ -3,74 +3,50 @@ package swarm
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pgEdge/control-plane/server/internal/filesystem"
 	"github.com/pgEdge/control-plane/server/internal/resource"
 )
 
 func TestRAGConfigResource_ResourceVersion(t *testing.T) {
 	r := &RAGConfigResource{}
-	if got := r.ResourceVersion(); got != "1" {
-		t.Errorf("ResourceVersion() = %q, want %q", got, "1")
-	}
+	assert.Equal(t, "2", r.ResourceVersion())
 }
 
 func TestRAGConfigResource_Identifier(t *testing.T) {
 	r := &RAGConfigResource{ServiceInstanceID: "storefront-rag-host1"}
 	id := r.Identifier()
-	if id.ID != "storefront-rag-host1" {
-		t.Errorf("Identifier().ID = %q, want %q", id.ID, "storefront-rag-host1")
-	}
-	if id.Type != ResourceTypeRAGConfig {
-		t.Errorf("Identifier().Type = %q, want %q", id.Type, ResourceTypeRAGConfig)
-	}
+	assert.Equal(t, "storefront-rag-host1", id.ID)
+	assert.Equal(t, ResourceTypeRAGConfig, id.Type)
 }
 
 func TestRAGConfigResourceIdentifier(t *testing.T) {
 	id := RAGConfigResourceIdentifier("my-instance")
-	if id.ID != "my-instance" {
-		t.Errorf("ID = %q, want %q", id.ID, "my-instance")
-	}
-	if id.Type != ResourceTypeRAGConfig {
-		t.Errorf("Type = %q, want %q", id.Type, ResourceTypeRAGConfig)
-	}
+	assert.Equal(t, "my-instance", id.ID)
+	assert.Equal(t, ResourceTypeRAGConfig, id.Type)
 }
 
 func TestRAGConfigResource_Executor(t *testing.T) {
 	r := &RAGConfigResource{HostID: "host-1"}
-	exec := r.Executor()
-	if exec != resource.HostExecutor("host-1") {
-		t.Errorf("Executor() = %v, want HostExecutor(%q)", exec, "host-1")
-	}
+	assert.Equal(t, resource.HostExecutor("host-1"), r.Executor())
 }
 
 func TestRAGConfigResource_DiffIgnore(t *testing.T) {
 	r := &RAGConfigResource{}
-	ignored := r.DiffIgnore()
-	if len(ignored) != 0 {
-		t.Errorf("DiffIgnore() = %v, want empty", ignored)
-	}
+	assert.Empty(t, r.DiffIgnore())
 }
 
 func TestRAGConfigResource_Dependencies(t *testing.T) {
 	r := &RAGConfigResource{
 		ServiceInstanceID: "storefront-rag-host1",
-		ServiceID:         "rag",
 		DirResourceID:     "storefront-rag-host1-data",
 	}
 	deps := r.Dependencies()
 
-	if len(deps) != 3 {
-		t.Fatalf("Dependencies() len = %d, want 3", len(deps))
-	}
-
-	wantDeps := []resource.Identifier{
-		filesystem.DirResourceIdentifier("storefront-rag-host1-data"),
-		ServiceUserRoleIdentifier("rag", ServiceUserRoleRO),
-		RAGServiceKeysResourceIdentifier("storefront-rag-host1"),
-	}
-	for i, want := range wantDeps {
-		if deps[i] != want {
-			t.Errorf("Dependencies()[%d] = %v, want %v", i, deps[i], want)
-		}
-	}
+	require.Len(t, deps, 3)
+	assert.Equal(t, filesystem.DirResourceIdentifier("storefront-rag-host1-data"), deps[0])
+	assert.Equal(t, RAGServiceKeysResourceIdentifier("storefront-rag-host1"), deps[1])
+	assert.Equal(t, RAGPreflightResourceIdentifier("storefront-rag-host1"), deps[2])
 }

--- a/server/internal/orchestrator/swarm/rag_instance_resources_test.go
+++ b/server/internal/orchestrator/swarm/rag_instance_resources_test.go
@@ -58,11 +58,14 @@ func TestGenerateRAGInstanceResources_ResourceList(t *testing.T) {
 			ServiceType: "rag",
 			Version:     "latest",
 			Config:      minimalRAGConfig(),
+			ConnectAs:   "app_read_only",
 		},
-		DatabaseID:   "storefront",
-		DatabaseName: "storefront",
-		HostID:       "host-1",
-		NodeName:     "n1",
+		DatabaseID:        "storefront",
+		DatabaseName:      "storefront",
+		HostID:            "host-1",
+		NodeName:          "n1",
+		ConnectAsUsername: "app_read_only",
+		ConnectAsPassword: "secret",
 	}
 
 	result, err := o.generateRAGInstanceResources(spec)
@@ -73,13 +76,12 @@ func TestGenerateRAGInstanceResources_ResourceList(t *testing.T) {
 	assert.Equal(t, spec.HostID, result.ServiceInstance.HostID)
 	assert.Equal(t, database.ServiceInstanceStateCreating, result.ServiceInstance.State)
 
-	// Single node: Network + canonical RO + DirResource + Keys + Config + InstanceSpec + ServiceInstance = 7.
+	// Network + DirResource + Keys + Preflight + Config + InstanceSpec + ServiceInstance = 7.
 	require.Len(t, result.Resources, 7)
 	assert.Equal(t, ResourceTypeNetwork, result.Resources[0].Identifier.Type)
-	assert.Equal(t, ResourceTypeServiceUserRole, result.Resources[1].Identifier.Type)
-	assert.Equal(t, ServiceUserRoleIdentifier("rag", ServiceUserRoleRO), result.Resources[1].Identifier)
-	assert.Equal(t, filesystem.ResourceTypeDir, result.Resources[2].Identifier.Type)
-	assert.Equal(t, ResourceTypeRAGServiceKeys, result.Resources[3].Identifier.Type)
+	assert.Equal(t, filesystem.ResourceTypeDir, result.Resources[1].Identifier.Type)
+	assert.Equal(t, ResourceTypeRAGServiceKeys, result.Resources[2].Identifier.Type)
+	assert.Equal(t, ResourceTypeRAGPreflightResource, result.Resources[3].Identifier.Type)
 	assert.Equal(t, ResourceTypeRAGConfig, result.Resources[4].Identifier.Type)
 	assert.Equal(t, ResourceTypeServiceInstanceSpec, result.Resources[5].Identifier.Type)
 	assert.Equal(t, ResourceTypeServiceInstance, result.Resources[6].Identifier.Type)
@@ -94,11 +96,14 @@ func TestGenerateRAGInstanceResources_MultiNode(t *testing.T) {
 			ServiceType: "rag",
 			Version:     "latest",
 			Config:      minimalRAGConfig(),
+			ConnectAs:   "app_read_only",
 		},
-		DatabaseID:   "storefront",
-		DatabaseName: "storefront",
-		HostID:       "host-1",
-		NodeName:     "n1",
+		DatabaseID:        "storefront",
+		DatabaseName:      "storefront",
+		HostID:            "host-1",
+		NodeName:          "n1",
+		ConnectAsUsername: "app_read_only",
+		ConnectAsPassword: "secret",
 		DatabaseNodes: []*database.NodeInstances{
 			{NodeName: "n1"},
 			{NodeName: "n2"},
@@ -109,81 +114,16 @@ func TestGenerateRAGInstanceResources_MultiNode(t *testing.T) {
 	result, err := o.generateRAGInstanceResources(spec)
 	require.NoError(t, err)
 
-	// 3 nodes → Network + canonical(n1) + per-node(n2) + per-node(n3) + dir + keys + config + spec + instance = 9.
-	require.Len(t, result.Resources, 9)
-
-	// Resources[0] is Network; Resources[1..3] are ServiceUserRole resources.
-	for i := 1; i < 4; i++ {
-		assert.Equal(t, ResourceTypeServiceUserRole, result.Resources[i].Identifier.Type)
-	}
-
-	// Canonical is index 1 and has no CredentialSource.
-	canonical, err := resource.ToResource[*ServiceUserRole](result.Resources[1])
-	require.NoError(t, err)
-	assert.Nil(t, canonical.CredentialSource)
-	assert.Equal(t, ServiceUserRoleRO, canonical.Mode)
-
-	// Per-node resources point back to canonical.
-	canonicalID := ServiceUserRoleIdentifier("rag", ServiceUserRoleRO)
-	for i, rd := range result.Resources[2:4] {
-		perNode, err := resource.ToResource[*ServiceUserRole](rd)
-		require.NoErrorf(t, err, "ToResource per-node[%d]", i)
-		assert.Equalf(t, &canonicalID, perNode.CredentialSource, "per-node[%d].CredentialSource", i)
-		assert.Equalf(t, ServiceUserRoleRO, perNode.Mode, "per-node[%d].Mode", i)
-	}
-
-	assert.Equal(t, filesystem.ResourceTypeDir, result.Resources[4].Identifier.Type)
-	assert.Equal(t, ResourceTypeRAGServiceKeys, result.Resources[5].Identifier.Type)
-	assert.Equal(t, ResourceTypeRAGConfig, result.Resources[6].Identifier.Type)
-	assert.Equal(t, ResourceTypeServiceInstanceSpec, result.Resources[7].Identifier.Type)
-	assert.Equal(t, ResourceTypeServiceInstance, result.Resources[8].Identifier.Type)
-}
-
-func TestGenerateRAGInstanceResources_MultiNode_CanonicalNotFirst(t *testing.T) {
-	o := newTestOrchestrator()
-	spec := &database.ServiceInstanceSpec{
-		ServiceInstanceID: "storefront-rag-host2",
-		ServiceSpec: &database.ServiceSpec{
-			ServiceID:   "rag",
-			ServiceType: "rag",
-			Version:     "latest",
-			Config:      minimalRAGConfig(),
-		},
-		DatabaseID:   "storefront",
-		DatabaseName: "storefront",
-		HostID:       "host-2",
-		NodeName:     "n2", // canonical is n2, not at index 0
-		DatabaseNodes: []*database.NodeInstances{
-			{NodeName: "n1"},
-			{NodeName: "n2"},
-			{NodeName: "n3"},
-		},
-	}
-
-	result, err := o.generateRAGInstanceResources(spec)
-	require.NoError(t, err)
-
-	// 3 nodes → Network + canonical(n2) + per-node(n1) + per-node(n3) + dir + keys + config + spec + instance = 9.
-	require.Len(t, result.Resources, 9)
-
-	// Canonical (index 1, after Network) must be n2 with no CredentialSource.
-	canonical, err := resource.ToResource[*ServiceUserRole](result.Resources[1])
-	require.NoError(t, err)
-	assert.Nil(t, canonical.CredentialSource)
-	assert.Equal(t, "n2", canonical.NodeName)
-
-	// Per-node resources must cover n1 and n3, not n2.
-	canonicalID := ServiceUserRoleIdentifier("rag", ServiceUserRoleRO)
-	perNodeNames := make(map[string]bool)
-	for i, rd := range result.Resources[2:4] {
-		perNode, err := resource.ToResource[*ServiceUserRole](rd)
-		require.NoErrorf(t, err, "ToResource per-node[%d]", i)
-		assert.Equalf(t, &canonicalID, perNode.CredentialSource, "per-node[%d].CredentialSource", i)
-		perNodeNames[perNode.NodeName] = true
-	}
-	assert.False(t, perNodeNames["n2"], "canonical node n2 must not appear in per-node resources")
-	assert.True(t, perNodeNames["n1"], "n1 must be a per-node resource")
-	assert.True(t, perNodeNames["n3"], "n3 must be a per-node resource")
+	// Multi-node with connect_as: no ServiceUserRole resources regardless of node count.
+	// Network + DirResource + Keys + Preflight + Config + InstanceSpec + ServiceInstance = 7.
+	require.Len(t, result.Resources, 7)
+	assert.Equal(t, ResourceTypeNetwork, result.Resources[0].Identifier.Type)
+	assert.Equal(t, filesystem.ResourceTypeDir, result.Resources[1].Identifier.Type)
+	assert.Equal(t, ResourceTypeRAGServiceKeys, result.Resources[2].Identifier.Type)
+	assert.Equal(t, ResourceTypeRAGPreflightResource, result.Resources[3].Identifier.Type)
+	assert.Equal(t, ResourceTypeRAGConfig, result.Resources[4].Identifier.Type)
+	assert.Equal(t, ResourceTypeServiceInstanceSpec, result.Resources[5].Identifier.Type)
+	assert.Equal(t, ResourceTypeServiceInstance, result.Resources[6].Identifier.Type)
 }
 
 func TestGenerateServiceInstanceResources_RAGDispatch(t *testing.T) {
@@ -195,11 +135,14 @@ func TestGenerateServiceInstanceResources_RAGDispatch(t *testing.T) {
 			ServiceType: "rag",
 			Version:     "latest",
 			Config:      minimalRAGConfig(),
+			ConnectAs:   "app_read_only",
 		},
-		DatabaseID:   "db1",
-		DatabaseName: "db1",
-		HostID:       "host-1",
-		NodeName:     "n1",
+		DatabaseID:        "db1",
+		DatabaseName:      "db1",
+		HostID:            "host-1",
+		NodeName:          "n1",
+		ConnectAsUsername: "app_read_only",
+		ConnectAsPassword: "secret",
 	}
 
 	result, err := o.GenerateServiceInstanceResources(spec)
@@ -226,6 +169,40 @@ func TestGenerateServiceInstanceResources_UnknownTypeReturnsError(t *testing.T) 
 	require.Error(t, err)
 }
 
+func TestGenerateRAGInstanceResources_ConnectAs_CredentialsPopulated(t *testing.T) {
+	o := newTestOrchestrator()
+	spec := &database.ServiceInstanceSpec{
+		ServiceInstanceID: "storefront-rag-host1",
+		ServiceSpec: &database.ServiceSpec{
+			ServiceID:   "rag",
+			ServiceType: "rag",
+			Version:     "latest",
+			Config:      minimalRAGConfig(),
+			ConnectAs:   "app_read_only",
+		},
+		DatabaseID:        "storefront",
+		DatabaseName:      "storefront",
+		HostID:            "host-1",
+		NodeName:          "n1",
+		ConnectAsUsername: "app_read_only",
+		ConnectAsPassword: "secret",
+	}
+
+	result, err := o.generateRAGInstanceResources(spec)
+	require.NoError(t, err)
+
+	// RAGConfigResource should carry the connect_as credentials.
+	configRes, err := resource.ToResource[*RAGConfigResource](result.Resources[4])
+	require.NoError(t, err)
+	assert.Equal(t, "app_read_only", configRes.ConnectAsUsername)
+	assert.Equal(t, "secret", configRes.ConnectAsPassword)
+
+	// ServiceInstanceResource should also carry ConnectAsUsername.
+	svcInst, err := resource.ToResource[*ServiceInstanceResource](result.Resources[6])
+	require.NoError(t, err)
+	assert.Equal(t, "app_read_only", svcInst.ConnectAsUsername)
+}
+
 func TestGenerateRAGInstanceResources_IncompatibleVersion(t *testing.T) {
 	o := newTestOrchestrator()
 	// Override the "rag/latest" image with a constraint requiring PG >= 18.
@@ -243,12 +220,15 @@ func TestGenerateRAGInstanceResources_IncompatibleVersion(t *testing.T) {
 			ServiceType: "rag",
 			Version:     "latest",
 			Config:      minimalRAGConfig(),
+			ConnectAs:   "app_read_only",
 		},
-		DatabaseID:    "db1",
-		DatabaseName:  "db1",
-		HostID:        "host-1",
-		NodeName:      "n1",
-		PgEdgeVersion: ds.MustPgEdgeVersion("17", "5.0.0"),
+		DatabaseID:        "db1",
+		DatabaseName:      "db1",
+		HostID:            "host-1",
+		NodeName:          "n1",
+		ConnectAsUsername: "app_read_only",
+		ConnectAsPassword: "secret",
+		PgEdgeVersion:     ds.MustPgEdgeVersion("17", "5.0.0"),
 	}
 
 	_, err := o.generateRAGInstanceResources(spec)

--- a/server/internal/orchestrator/swarm/rag_preflight_resource.go
+++ b/server/internal/orchestrator/swarm/rag_preflight_resource.go
@@ -1,0 +1,110 @@
+package swarm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pgEdge/control-plane/server/internal/database"
+	"github.com/pgEdge/control-plane/server/internal/resource"
+)
+
+var _ resource.Resource = (*RAGPreflightResource)(nil)
+
+const ResourceTypeRAGPreflightResource resource.Type = "swarm.rag_preflight"
+
+func RAGPreflightResourceIdentifier(serviceInstanceID string) resource.Identifier {
+	return resource.Identifier{
+		ID:   serviceInstanceID,
+		Type: ResourceTypeRAGPreflightResource,
+	}
+}
+
+// RAGPreflightResource verifies that the Postgres database is available and
+// the connect_as user exists before the RAG config file is written and the
+// Docker service is started. It uses PrimaryExecutor so it runs on a host
+// with guaranteed database connectivity.
+//
+// Refresh returns ErrNotFound until all checks pass, causing the resource
+// engine to retry on each reconciliation cycle — effectively acting as a
+// readiness gate that prevents the RAG container from starting while Patroni
+// is still bootstrapping.
+type RAGPreflightResource struct {
+	ServiceInstanceID string `json:"service_instance_id"`
+	NodeName          string `json:"node_name"`
+	DatabaseName      string `json:"database_name"`
+	// ConnectAsUsername is the database role the RAG service connects as.
+	// It must be declared in database_users.
+	ConnectAsUsername string `json:"connect_as_username"`
+}
+
+func (r *RAGPreflightResource) ResourceVersion() string { return "1" }
+func (r *RAGPreflightResource) DiffIgnore() []string    { return nil }
+
+func (r *RAGPreflightResource) Identifier() resource.Identifier {
+	return RAGPreflightResourceIdentifier(r.ServiceInstanceID)
+}
+
+func (r *RAGPreflightResource) Executor() resource.Executor {
+	return resource.PrimaryExecutor(r.NodeName)
+}
+
+func (r *RAGPreflightResource) Dependencies() []resource.Identifier {
+	return []resource.Identifier{
+		database.NodeResourceIdentifier(r.NodeName),
+		database.PostgresDatabaseResourceIdentifier(r.NodeName, r.DatabaseName),
+	}
+}
+
+func (r *RAGPreflightResource) TypeDependencies() []resource.Type {
+	return nil
+}
+
+// Refresh returns ErrNotFound when the database or connect_as user is not yet
+// ready, causing the resource engine to retry rather than treating the service
+// as permanently failed.
+func (r *RAGPreflightResource) Refresh(ctx context.Context, rc *resource.Context) error {
+	if err := r.validate(ctx, rc); err != nil {
+		return fmt.Errorf("%w: %s", resource.ErrNotFound, err.Error())
+	}
+	return nil
+}
+
+func (r *RAGPreflightResource) Create(ctx context.Context, rc *resource.Context) error {
+	return r.validate(ctx, rc)
+}
+
+func (r *RAGPreflightResource) Update(ctx context.Context, rc *resource.Context) error {
+	return r.validate(ctx, rc)
+}
+
+func (r *RAGPreflightResource) Delete(ctx context.Context, rc *resource.Context) error {
+	return nil
+}
+
+func (r *RAGPreflightResource) validate(ctx context.Context, rc *resource.Context) error {
+	primary, err := database.GetPrimaryInstance(ctx, rc, r.NodeName)
+	if err != nil {
+		return fmt.Errorf("preflight: failed to get primary instance: %w", err)
+	}
+
+	conn, err := primary.Connection(ctx, rc, r.DatabaseName)
+	if err != nil {
+		return fmt.Errorf("preflight: database %q is not yet available on node %s: %w",
+			r.DatabaseName, r.NodeName, err)
+	}
+	defer conn.Close(ctx)
+
+	var exists bool
+	if err := conn.QueryRow(ctx,
+		"SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = $1)",
+		r.ConnectAsUsername,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("preflight: failed to check role %q: %w", r.ConnectAsUsername, err)
+	}
+	if !exists {
+		return fmt.Errorf("preflight: role %q does not exist; ensure it is declared in database_users",
+			r.ConnectAsUsername)
+	}
+
+	return nil
+}

--- a/server/internal/orchestrator/swarm/rag_preflight_resource.go
+++ b/server/internal/orchestrator/swarm/rag_preflight_resource.go
@@ -3,6 +3,7 @@ package swarm
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pgEdge/control-plane/server/internal/database"
 	"github.com/pgEdge/control-plane/server/internal/resource"
@@ -82,6 +83,9 @@ func (r *RAGPreflightResource) Delete(ctx context.Context, rc *resource.Context)
 }
 
 func (r *RAGPreflightResource) validate(ctx context.Context, rc *resource.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	primary, err := database.GetPrimaryInstance(ctx, rc, r.NodeName)
 	if err != nil {
 		return fmt.Errorf("preflight: failed to get primary instance: %w", err)

--- a/server/internal/orchestrator/swarm/rag_preflight_resource_test.go
+++ b/server/internal/orchestrator/swarm/rag_preflight_resource_test.go
@@ -1,0 +1,23 @@
+package swarm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pgEdge/control-plane/server/internal/database"
+)
+
+func TestRAGPreflightResource_Dependencies(t *testing.T) {
+	r := &RAGPreflightResource{
+		ServiceInstanceID: "storefront-rag-host1",
+		NodeName:          "n1",
+		DatabaseName:      "storefront",
+	}
+	deps := r.Dependencies()
+
+	require.Len(t, deps, 2)
+	assert.Equal(t, database.NodeResourceIdentifier("n1"), deps[0])
+	assert.Equal(t, database.PostgresDatabaseResourceIdentifier("n1", "storefront"), deps[1])
+}

--- a/server/internal/orchestrator/swarm/resources.go
+++ b/server/internal/orchestrator/swarm/resources.go
@@ -24,6 +24,7 @@ func RegisterResourceTypes(registry *resource.Registry) {
 	resource.RegisterResourceType[*PostgRESTPreflightResource](registry, ResourceTypePostgRESTPreflightResource)
 	resource.RegisterResourceType[*PostgRESTConfigResource](registry, ResourceTypePostgRESTConfig)
 	resource.RegisterResourceType[*PostgRESTAuthenticatorResource](registry, ResourceTypePostgRESTAuthenticator)
+	resource.RegisterResourceType[*RAGPreflightResource](registry, ResourceTypeRAGPreflightResource)
 	resource.RegisterResourceType[*RAGServiceKeysResource](registry, ResourceTypeRAGServiceKeys)
 	resource.RegisterResourceType[*RAGConfigResource](registry, ResourceTypeRAGConfig)
 }

--- a/server/internal/orchestrator/swarm/service_instance.go
+++ b/server/internal/orchestrator/swarm/service_instance.go
@@ -32,9 +32,10 @@ type ServiceInstanceResource struct {
 	ServiceInstanceID string `json:"service_instance_id"`
 	DatabaseID        string `json:"database_id"`
 	ServiceName       string `json:"service_name"`
-	ServiceID         string `json:"service_id"`      // Docker Swarm service ID (set by Refresh)
-	ServiceSpecID     string `json:"service_spec_id"` // Logical service ID from the spec (e.g. "mcp-server")
-	ServiceType       string `json:"service_type"`    // Service type (e.g. "mcp", "rag", "postgrest")
+	ServiceID         string `json:"service_id"`        // Docker Swarm service ID (set by Refresh)
+	ServiceSpecID     string `json:"service_spec_id"`   // Logical service ID from the spec (e.g. "mcp-server")
+	ServiceType       string `json:"service_type"`      // Service type (e.g. "mcp", "rag", "postgrest")
+	ConnectAsUsername string `json:"connect_as_username"` // Non-empty when RAG uses connect_as credentials
 	HostID            string `json:"host_id"`
 	NeedsUpdate       bool   `json:"needs_update"`
 }
@@ -64,14 +65,11 @@ func (s *ServiceInstanceResource) Dependencies() []resource.Identifier {
 	deps := []resource.Identifier{
 		ServiceInstanceSpecResourceIdentifier(s.ServiceInstanceID),
 	}
-	// MCP uses connect_as credentials — no ServiceUserRole dependency.
-	// Other service types still use ServiceUserRole until they adopt connect_as.
-	// RAG only has an RO role; other service types (PostgREST) also require an RW role.
-	if s.ServiceType != "mcp" {
+	// MCP and RAG get credentials from database_users (connect_as) —
+	// no ServiceUserRole dependency. PostgREST still uses ServiceUserRole.
+	if s.ServiceType == "postgrest" {
 		deps = append(deps, ServiceUserRoleIdentifier(s.ServiceSpecID, ServiceUserRoleRO))
-		if s.ServiceType != "rag" {
-			deps = append(deps, ServiceUserRoleIdentifier(s.ServiceSpecID, ServiceUserRoleRW))
-		}
+		deps = append(deps, ServiceUserRoleIdentifier(s.ServiceSpecID, ServiceUserRoleRW))
 	}
 	return deps
 }

--- a/server/internal/orchestrator/swarm/service_instance.go
+++ b/server/internal/orchestrator/swarm/service_instance.go
@@ -88,6 +88,7 @@ func (s *ServiceInstanceResource) Refresh(ctx context.Context, rc *resource.Cont
 	if err != nil {
 		return fmt.Errorf("failed to get desired service spec from state: %w", err)
 	}
+	s.ConnectAsUsername = desired.ServiceSpec.ConnectAs
 
 	resp, err := client.ServiceInspectByLabels(ctx, map[string]string{
 		"pgedge.component":           "service",

--- a/server/internal/orchestrator/swarm/service_instance_spec.go
+++ b/server/internal/orchestrator/swarm/service_instance_spec.go
@@ -66,14 +66,11 @@ func (s *ServiceInstanceSpecResource) Dependencies() []resource.Identifier {
 		NetworkResourceIdentifier(s.DatabaseNetworkID),
 	}
 
-	// MCP uses connect_as credentials from database_users — no ServiceUserRole dependency.
-	// Other service types (PostgREST, RAG) still use ServiceUserRole until they adopt connect_as.
-	// RAG only has an RO role; other service types (PostgREST) also require an RW role.
-	if s.ServiceSpec.ServiceType != "mcp" {
+	// MCP and RAG get credentials from database_users (connect_as) —
+	// no ServiceUserRole dependency. PostgREST still uses ServiceUserRole.
+	if s.ServiceSpec.ServiceType == "postgrest" {
 		deps = append(deps, ServiceUserRoleIdentifier(s.ServiceSpec.ServiceID, ServiceUserRoleRO))
-		if s.ServiceSpec.ServiceType != "rag" {
-			deps = append(deps, ServiceUserRoleIdentifier(s.ServiceSpec.ServiceID, ServiceUserRoleRW))
-		}
+		deps = append(deps, ServiceUserRoleIdentifier(s.ServiceSpec.ServiceID, ServiceUserRoleRW))
 	}
 
 	switch s.ServiceSpec.ServiceType {
@@ -97,12 +94,14 @@ func (s *ServiceInstanceSpecResource) TypeDependencies() []resource.Type {
 }
 
 func (s *ServiceInstanceSpecResource) populateCredentials(rc *resource.Context) error {
-	// MCP uses connect_as credentials from the spec — no ServiceUserRole lookup needed.
-	if s.ServiceSpec.ServiceType == "mcp" {
+	// MCP and RAG source credentials from database_users (connect_as).
+	// RAG credentials go into the config file via RAGConfigResource, not the
+	// container spec, so s.Credentials remains nil for RAG regardless.
+	if s.ServiceSpec.ServiceType == "mcp" || s.ServiceSpec.ServiceType == "rag" {
 		return nil
 	}
 
-	// Other service types (PostgREST, RAG) still use ServiceUserRole.
+	// PostgREST still uses ServiceUserRole.
 	userRole, err := resource.FromContext[*ServiceUserRole](rc, ServiceUserRoleIdentifier(s.ServiceSpec.ServiceID, ServiceUserRoleRO))
 	if err != nil {
 		return fmt.Errorf("failed to get service user role from state: %w", err)

--- a/server/internal/orchestrator/swarm/service_instance_spec.go
+++ b/server/internal/orchestrator/swarm/service_instance_spec.go
@@ -97,7 +97,10 @@ func (s *ServiceInstanceSpecResource) populateCredentials(rc *resource.Context) 
 	// MCP and RAG source credentials from database_users (connect_as).
 	// RAG credentials go into the config file via RAGConfigResource, not the
 	// container spec, so s.Credentials remains nil for RAG regardless.
+	// Clear any stale credentials that may have been persisted by the legacy
+	// ServiceUserRole path before this migration.
 	if s.ServiceSpec.ServiceType == "mcp" || s.ServiceSpec.ServiceType == "rag" {
+		s.Credentials = nil
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
This PR switch the RAG service from auto-generated `ServiceUserRole` credentials to
`connect_as` credentials sourced from `database_users`. `connect_as` is now required when provisioning a
RAG service.

## Changes
- **Validation**: `connect_as` is now required for RAG service specs; 
API returns 400 if omitted or if the referenced user is not in
  `database_users`
- **Removed legacy `ServiceUserRole` path for RAG**: no auto-generated Postgres
  roles are created; `generateRAGInstanceResources` no longer emits
  `ServiceUserRole` resources
- **`RAGConfigResource`**: always uses `ConnectAsUsername`/`ConnectAsPassword`
  from the spec; removed `ServiceUserRole` dependency and legacy credential
  lookup from `writeConfigFile`
- **`ServiceInstanceSpecResource` / `ServiceInstanceResource`**: RAG no longer
  depends on `ServiceUserRole`; 
- **`RAGPreflightResource`**: added `PostgresDatabaseResourceIdentifier` as a
  dependency so the preflight runs after the database is created.
- **E2E tests**: all RAG fixtures updated to include a `rag_user` in
  `database_users` and `connect_as: "rag_user"` on the service spec

## Testing
Verification:
1. Created a cluster
2. Created database with RAG service using connect_as: "app_read_only" 
[rag_create_db_connect_as.json](https://github.com/user-attachments/files/26783317/rag_create_db_connect_as.json)

```
ID             NAME                          MODE         REPLICAS   IMAGE
gcmqn1rgtdyl   rag-storefront-rag-689qacsi   replicated   1/1        ghcr.io/pgedge/rag-server:latest

```
3. Verified config file contains connect_as credentials 
[pgedge-rag-server.yaml](https://github.com/user-attachments/files/26783360/pgedge-rag-server.yaml)

4. Verified API returns 400 when connect_as is omitted from a RAG service spec
5. Verified API returns 400 when connect_as references a user not in database_users

## Checklist

- [x] Tests added & updated 


[PLAT-552](https://pgedge.atlassian.net/browse/PLAT-552)

[PLAT-552]: https://pgedge.atlassian.net/browse/PLAT-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ