### PR TITLE
fix: missing restore config in in-place restore

### DIFF
--- a/server/internal/database/operations/restore_database.go
+++ b/server/internal/database/operations/restore_database.go
@@ -18,6 +18,7 @@ type NodeRestoreResources struct {
 	PrimaryInstance  *database.InstanceResources
 	RestoreInstance  *database.InstanceResources
 	ReplicaInstances []*database.InstanceResources
+	RestoreConfig    *database.RestoreConfig
 }
 
 func (n *NodeRestoreResources) ToNodeResources() *NodeResources {
@@ -32,7 +33,7 @@ func (n *NodeRestoreResources) ToNodeResources() *NodeResources {
 		NodeName:          n.NodeName,
 		PrimaryInstanceID: n.PrimaryInstance.InstanceID(),
 		InstanceResources: all,
-		RestoreConfig:     n.PrimaryInstance.RestoreConfig(),
+		RestoreConfig:     n.RestoreConfig,
 	}
 }
 

--- a/server/internal/database/orchestrator.go
+++ b/server/internal/database/orchestrator.go
@@ -95,10 +95,6 @@ func (r *InstanceResources) NodeName() string {
 	return r.Instance.Spec.NodeName
 }
 
-func (r *InstanceResources) RestoreConfig() *RestoreConfig {
-	return r.Instance.Spec.RestoreConfig
-}
-
 func (r *InstanceResources) State() (*resource.State, error) {
 	state := resource.NewState()
 	state.Add(r.Resources...)

--- a/server/internal/workflows/plan_restore.go
+++ b/server/internal/workflows/plan_restore.go
@@ -98,6 +98,7 @@ func (w *Workflows) getRestoreResources(
 		DatabaseName:  node.DatabaseName,
 		DatabaseOwner: node.DatabaseOwner,
 		NodeName:      node.NodeName,
+		RestoreConfig: restoreConfig,
 	}
 	for _, instance := range node.Instances {
 		if instance.InstanceID == primaryInstanceID {


### PR DESCRIPTION
## Summary

The restore config on the database/instance spec is used to bootstrap a new node. It is not used during an in-place restore, where the active restore configuration is provided as a separate argument.

This change takes that into account and propagates that argument through to the `HasRestoreConfig` property on the database resource. Now that we're setting this property correctly, the "post restore" logic triggers as expected.

## Testing

```sh
# the TestS3BackupRestore test fails on main, but passes on this branch
make test-e2e E2E_FIXTURE=lima E2E_RUN=TestS3BackupRestore
```

PLAT-564