### PR TITLE
test: mitigate clock drift in lima e2e fixture

### DIFF
--- a/e2e/fixtures/Makefile
+++ b/e2e/fixtures/Makefile
@@ -17,6 +17,10 @@ ansible_playbook_lima=ansible-playbook \
 	--extra-vars='@$(variant_vars_file)' \
 	--extra-vars='$(EXTRA_VARS)'
 
+.PHONY: fix-lima-clocks
+fix-lima-clocks:
+	ansible --become --inventory=outputs/lima.inventory.yaml all -m command -a 'chronyc -a makestep'
+
 .PHONY: deploy-lima-machines
 deploy-lima-machines:
 	$(ansible_playbook_lima) deploy_lima_machines.yaml
@@ -36,7 +40,7 @@ setup-lima-hosts:
 		setup_hosts.yaml
 
 .PHONY: deploy-lima-control-plane
-deploy-lima-control-plane:
+deploy-lima-control-plane: fix-lima-clocks
 	$(ansible_playbook_lima) \
 		--inventory=outputs/lima.inventory.yaml \
 		--extra-vars='version=$(CONTROL_PLANE_VERSION:v%=%)' \

--- a/e2e/fixtures/roles/install_prerequisites/tasks/main.yaml
+++ b/e2e/fixtures/roles/install_prerequisites/tasks/main.yaml
@@ -49,3 +49,15 @@
       - "--strip-components=1"
       - "{{ etcd_archive_name }}/etcdctl"
     creates: /usr/bin/etcdctl
+- name: Allow large time jumps in chronyd
+  ansible.builtin.lineinfile:
+    path: /etc/chrony.conf
+    regexp: '^makestep'
+    line: 'makestep 1 -1'
+  register: chronycfg
+  when: provider == "lima"
+- name: Restart chronyd
+  ansible.builtin.systemd_service:
+    name: chronyd
+    state: restarted
+  when: provider == "lima" and chronycfg.changed


### PR DESCRIPTION
## Summary

Lima has a known issue where the guest OS clock can drift on macOS. This causes issues with certificates, scheduled tasks, and other operations that depend on the system time.

This commit mitigates the issue by:

- Altering the chronyd configuration to allow for large time jumps
- Running `chronyc -a makestep` every time we deploy control plane

This fixes the clock drift every time you run one of these make targets:

```sh
make deploy-lima-fixture
make update-lima-fixture
make reset-lima-fixture
```

## Testing

```sh
# update your fixture to get the chronyd config change
make deploy-lima-fixture

# verify the system clocks are accurate
ansible -i ./e2e/fixtures/outputs/lima.inventory.yaml all -m command -a 'date'
```
