### PR TITLE
fix: ability to change ports with systemd

### DIFF
--- a/e2e/port_change_test.go
+++ b/e2e/port_change_test.go
@@ -1,0 +1,130 @@
+//go:build e2e_test
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	api "github.com/pgEdge/control-plane/api/apiv1/gen/control_plane"
+)
+
+func TestPortChange(t *testing.T) {
+	t.Parallel()
+
+	host1 := fixture.HostIDs()[0]
+	host2 := fixture.HostIDs()[1]
+
+	username := "admin"
+	password := "password"
+
+	tLog(t, "creating database")
+
+	ctx := t.Context()
+	db := fixture.NewDatabaseFixture(ctx, t, &api.CreateDatabaseRequest{
+		Spec: &api.DatabaseSpec{
+			DatabaseName: "test_port_change",
+			DatabaseUsers: []*api.DatabaseUserSpec{
+				{
+					Username:   username,
+					Password:   pointerTo(password),
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+			},
+			// We want to use uncommon ports that are below the ephemeral range
+			// and our default random range to minimize the chance of conflicts.
+			Nodes: []*api.DatabaseNodeSpec{
+				{
+					Name:        "n1",
+					HostIds:     []api.Identifier{api.Identifier(host1)},
+					Port:        pointerTo(1024),
+					PatroniPort: pointerTo(1124),
+				},
+				{
+					Name:        "n2",
+					HostIds:     []api.Identifier{api.Identifier(host2)},
+					Port:        pointerTo(1026),
+					PatroniPort: pointerTo(1126),
+				},
+			},
+		},
+	})
+
+	tLog(t, "updating database to change ports")
+
+	require.NoError(t, db.Update(ctx, UpdateOptions{
+		Spec: &api.DatabaseSpec{
+			DatabaseName: "test_port_change",
+			DatabaseUsers: []*api.DatabaseUserSpec{
+				{
+					Username:   username,
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+			},
+			Nodes: []*api.DatabaseNodeSpec{
+				{
+					Name:        "n1",
+					HostIds:     []api.Identifier{api.Identifier(host1)},
+					Port:        pointerTo(1025),
+					PatroniPort: pointerTo(1125),
+				},
+				{
+					Name:        "n2",
+					HostIds:     []api.Identifier{api.Identifier(host2)},
+					Port:        pointerTo(1027),
+					PatroniPort: pointerTo(1127),
+				},
+			},
+		},
+	}))
+
+	tLog(t, "validating that the database is usable")
+
+	n1Opts := ConnectionOptions{
+		Username: username,
+		Password: password,
+		Matcher:  WithNode("n1"),
+	}
+	db.WithConnection(ctx, n1Opts, t, func(conn *pgx.Conn) {
+		if fixture.Orchestrator() == "systemd" {
+			// This assertion won't work for swarm because we only change the
+			// port binding. The postgres port always stays the same.
+			var port string
+			require.NoError(t, conn.QueryRow(ctx, "SHOW port").Scan(&port))
+			require.Equal(t, "1025", port)
+		}
+
+		_, err := conn.Exec(ctx, `CREATE TABLE foo (id INT PRIMARY KEY, val TEXT)`)
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, `INSERT INTO foo (id, val) VALUES (1, 'foo')`)
+		require.NoError(t, err)
+	})
+
+	tLog(t, "waiting for replication")
+
+	db.WaitForReplication(ctx, t, username, password)
+
+	tLog(t, "validating that replication is functioning")
+
+	n2Opts := ConnectionOptions{
+		Username: username,
+		Password: password,
+		Matcher:  WithNode("n2"),
+	}
+	db.WithConnection(ctx, n2Opts, t, func(conn *pgx.Conn) {
+		if fixture.Orchestrator() == "systemd" {
+			var port string
+			require.NoError(t, conn.QueryRow(ctx, "SHOW port").Scan(&port))
+			require.Equal(t, "1027", port)
+		}
+
+		var foo string
+		require.NoError(t, conn.QueryRow(ctx, "SELECT val FROM foo WHERE id = 1").Scan(&foo))
+		require.Equal(t, "foo", foo)
+	})
+}

--- a/server/internal/database/instance_resource.go
+++ b/server/internal/database/instance_resource.go
@@ -101,7 +101,17 @@ func (r *InstanceResource) Create(ctx context.Context, rc *resource.Context) err
 }
 
 func (r *InstanceResource) Update(ctx context.Context, rc *resource.Context) error {
-	if err := r.updateConnectionInfo(ctx, rc); err != nil {
+	// Get connection info from previous instance state in case the ports have
+	// changed.
+	previous, err := resource.FromContext[*InstanceResource](rc, r.Identifier())
+	if err != nil {
+		return r.recordError(ctx, rc, fmt.Errorf("failed to get previous instance state: %w", err))
+	}
+	// We fallback to computing the connection info from the spec if the
+	// previous instance state is malformed.
+	if previous.ConnectionInfo != nil {
+		r.ConnectionInfo = previous.ConnectionInfo
+	} else if err := r.updateConnectionInfo(ctx, rc); err != nil {
 		return r.recordError(ctx, rc, err)
 	}
 
@@ -159,9 +169,12 @@ func (r *InstanceResource) initializeInstance(ctx context.Context, rc *resource.
 	}
 
 	patroniClient := r.patroniClient()
-	err := WaitForPatroniRunning(ctx, patroniClient, 0)
-	if err != nil {
+
+	if err := WaitForPatroniRunning(ctx, patroniClient, 0); err != nil {
 		return fmt.Errorf("failed to wait for patroni to enter running state: %w", err)
+	}
+	if err := r.restartIfNeeded(ctx, patroniClient); err != nil {
+		return err
 	}
 
 	primaryInstanceID, err := GetPrimaryInstanceID(ctx, patroniClient, time.Minute)
@@ -329,6 +342,24 @@ func (r *InstanceResource) createRolesFromSpec(ctx context.Context, tx pgx.Tx) e
 		if err := statement.Exec(ctx, tx); err != nil {
 			return fmt.Errorf("failed to create user role %q: %w", user.Username, err)
 		}
+	}
+
+	return nil
+}
+
+func (r *InstanceResource) restartIfNeeded(ctx context.Context, client *patroni.Client) error {
+	status, err := client.GetInstanceStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get patroni instance status: %w", err)
+	}
+	if status.PendingRestart == nil || !*status.PendingRestart {
+		return nil
+	}
+	if err := client.ScheduleRestart(ctx, &patroni.Restart{}); err != nil {
+		return fmt.Errorf("failed to submit restart request: %w", err)
+	}
+	if err := WaitForPatroniRunning(ctx, client, 0); err != nil {
+		return fmt.Errorf("failed to wait for patroni to re-enter a running state after restart: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Fixes a bug where changing the Patroni or Postgres port would cause the update operation to fail on systemd. This happened because, in the update method, we were setting the connection info based on the updated spec.

This change means we copy the connection info from the previous instance state to retrieve the previously active Patroni port. Then, it adds a restart operation to handle cases where the Postgres port has changed.

## Changes

- Get connection info from previous instance state in `InstanceResource.Update` with a fallback to the current spec (the previous behavior) when the previous state is malformed.
- Restart Postgres if needed in `InstanceResource`
  - We need this to change the port on systemd. On Swarm, the container was already restarted at this point due to changing the port binding.
  - Note that this is a necessary change to our earlier decision to leave it up to the user to restart after updating. I think it's a net improvement to the user experience.

## Testing

The `TestPortChange` E2E exercises this fix:

```sh
make test-e2e E2E_RUN=TestPortChange
```

## Notes for Reviewers

PLAT-548
