### PR TITLE
chore: use separate ports for dev-lima

### DIFF
--- a/hack/dev-env.zsh
+++ b/hack/dev-env.zsh
@@ -248,12 +248,12 @@ use-dev-lima() {
 	export E2E_FIXTURE=dev-lima
 
 	_update-restish-config \
-		http://localhost:3000 \
-		http://localhost:3001 \
-		http://localhost:3002 \
-		http://localhost:3003 \
-		http://localhost:3004 \
-		http://localhost:3005 \
+		http://localhost:3010 \
+		http://localhost:3011 \
+		http://localhost:3012 \
+		http://localhost:3013 \
+		http://localhost:3014 \
+		http://localhost:3015 \
 
 	local i
 	for ((i = 1; i <= 6; i++ )); do
@@ -629,12 +629,15 @@ cp-follow-task() {
 
 cp-etcdctl() {
 	local data_dir
+	local host_1_port
 	case ${CP_ENV} in
 		compose)
 			data_dir="${_cp_dir}/docker/control-plane-dev/data"
+			host_1_port=2379
 			;;
 		dev-lima)
 			data_dir="${_cp_dir}/lima/data"
+			host_1_port=2389
 			;;
 		*)
 			echo "cannot use cp-etcdctl with environment ${CP_ENV}"
@@ -647,7 +650,7 @@ cp-etcdctl() {
 	local host_1_cfg="${host_1_data}/generated.config.json"
 
 	etcdctl \
-		--endpoints=https://localhost:2379 \
+		--endpoints="https://localhost:${host_1_port}" \
 		--cacert "${host_1_certs}/ca.crt" \
 		--cert "${host_1_certs}/etcd-user.crt" \
 		--key "${host_1_certs}/etcd-user.key" \

--- a/lima/run.sh
+++ b/lima/run.sh
@@ -8,32 +8,35 @@ set_env() {
     case ${HOSTNAME} in
         lima-control-plane-dev-1)
             export PGEDGE_HOST_ID=host-1
+            export PGEDGE_HTTP__PORT=3010
+            export PGEDGE_ETCD_SERVER__PEER_PORT=2390
+            export PGEDGE_ETCD_SERVER__CLIENT_PORT=2389
             ;;
         lima-control-plane-dev-2)
             export PGEDGE_HOST_ID=host-2
-            export PGEDGE_HTTP__PORT=3001
-            export PGEDGE_ETCD_SERVER__PEER_PORT=2480
-            export PGEDGE_ETCD_SERVER__CLIENT_PORT=2479
+            export PGEDGE_HTTP__PORT=3011
+            export PGEDGE_ETCD_SERVER__PEER_PORT=2490
+            export PGEDGE_ETCD_SERVER__CLIENT_PORT=2489
             ;;
         lima-control-plane-dev-3)
             export PGEDGE_HOST_ID=host-3
-            export PGEDGE_HTTP__PORT=3002
-            export PGEDGE_ETCD_SERVER__PEER_PORT=2580
-            export PGEDGE_ETCD_SERVER__CLIENT_PORT=2579
+            export PGEDGE_HTTP__PORT=3012
+            export PGEDGE_ETCD_SERVER__PEER_PORT=2590
+            export PGEDGE_ETCD_SERVER__CLIENT_PORT=2589
             ;;
         lima-control-plane-dev-4)
             export PGEDGE_HOST_ID=host-4
-            export PGEDGE_HTTP__PORT=3003
+            export PGEDGE_HTTP__PORT=3013
             export PGEDGE_ETCD_MODE=client
             ;;
         lima-control-plane-dev-5)
             export PGEDGE_HOST_ID=host-5
-            export PGEDGE_HTTP__PORT=3004
+            export PGEDGE_HTTP__PORT=3014
             export PGEDGE_ETCD_MODE=client
             ;;
         lima-control-plane-dev-6)
             export PGEDGE_HOST_ID=host-6
-            export PGEDGE_HTTP__PORT=3005
+            export PGEDGE_HTTP__PORT=3015
             export PGEDGE_ETCD_MODE=client
             ;;
         *)

--- a/lima/vars.yaml
+++ b/lima/vars.yaml
@@ -1,20 +1,20 @@
 ---
 machines:
   - name: control-plane-dev-1
-    http_port: 3000
+    http_port: 3010
     host_id: host-1
   - name: control-plane-dev-2
-    http_port: 3001
+    http_port: 3011
     host_id: host-2
   - name: control-plane-dev-3
-    http_port: 3002
+    http_port: 3012
     host_id: host-3
   - name: control-plane-dev-4
-    http_port: 3003
+    http_port: 3013
     host_id: host-4
   - name: control-plane-dev-5
-    http_port: 3004
+    http_port: 3014
     host_id: host-5
   - name: control-plane-dev-6
-    http_port: 3005
+    http_port: 3015
     host_id: host-6


### PR DESCRIPTION
## Summary

Using the same ports made it too easy to mix up environments and make broken clusters. This change increments all port numbers in the dev-lima environment by 10 to keep everything on separate ports from the compose environment.

## Notes for Reviewers

You'll want to open a new terminal to get the `dev-env.zsh` changes and run `make dev-lima-reset` to stop and remove your current `dev-lima` cluster.
