### PR TITLE
fix: invalidate services for systemd clusters

### DIFF
--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -137,19 +137,28 @@ func validateDatabaseSpec(orchestrator config.Orchestrator, spec *api.DatabaseSp
 	portOwner := make(servicePortOwnerMap)
 	seedPostgresPorts(spec, portOwner)
 
-	seenServiceIDs := make(ds.Set[string], len(spec.Services))
-	for i, svc := range spec.Services {
-		svcPath := []string{"services", arrayIndexPath(i)}
+	servicesPath := []string{"services"}
 
-		// Check for duplicate service IDs
-		if seenServiceIDs.Has(string(svc.ServiceID)) {
-			err := errors.New("service IDs must be unique within a database")
-			errs = append(errs, newValidationError(err, svcPath))
+	switch orchestrator {
+	case config.OrchestratorSystemD:
+		if len(spec.Services) != 0 {
+			errs = append(errs, newValidationError(errors.New("services are not yet supported for systemd clusters"), servicesPath))
 		}
-		seenServiceIDs.Add(string(svc.ServiceID))
+	default:
+		seenServiceIDs := make(ds.Set[string], len(spec.Services))
+		for i, svc := range spec.Services {
+			svcPath := appendPath(servicesPath, arrayIndexPath(i))
 
-		errs = append(errs, validateServicePortConflicts(svc, svcPath, portOwner)...)
-		errs = append(errs, validateServiceSpec(svc, svcPath, false, spec.DatabaseUsers, seenNodeNames)...)
+			// Check for duplicate service IDs
+			if seenServiceIDs.Has(string(svc.ServiceID)) {
+				err := errors.New("service IDs must be unique within a database")
+				errs = append(errs, newValidationError(err, svcPath))
+			}
+			seenServiceIDs.Add(string(svc.ServiceID))
+
+			errs = append(errs, validateServicePortConflicts(svc, svcPath, portOwner)...)
+			errs = append(errs, validateServiceSpec(svc, svcPath, false, spec.DatabaseUsers, seenNodeNames)...)
+		}
 	}
 
 	return errors.Join(errs...)


### PR DESCRIPTION
## Summary

We do not yet support services for systemd clusters. This commit adds API validation to return errors early.

## Testing

```sh
# try making a database with services on a systemd cluster
cp1-req create-database <<EOF
{
  "id": "storefront",
  "spec": {
    "database_name": "storefront",
    "database_users": [
      {
        "username": "admin",
        "password": "password",
        "db_owner": true,
        "attributes": ["SUPERUSER", "LOGIN"]
      }
    ],
    "port": 0,
    "patroni_port": 0,
    "nodes": [
      { "name": "n1", "host_ids": ["host-1"] }
    ],
    "services": [
      {
        "service_id": "mcp",
        "service_type": "mcp",
        "version": "latest",
        "connect_as": "admin",
        "host_ids": ["host-1"],
        "port": 0,
        "config": {
          "llm_enabled": true,
          "llm_provider": "ollama",
          "llm_model": "gpt-oss:120b",
          "ollama_url": "172.17.0.1:11435"
        }
      }
    ]
  }
}
EOF
```