### PR TITLE
fix: enforce Swarm service name length limits

### DIFF
--- a/api/apiv1/design/common.go
+++ b/api/apiv1/design/common.go
@@ -5,14 +5,14 @@ import (
 )
 
 var Identifier = g.Type("Identifier", g.String, func() {
-	g.Description("A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.")
+	g.Description("A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.")
 	// Intentionally not using a pattern here for two reasons:
 	// - Go regex doesn't support lookahead, so we can't express the consecutive
 	//   hyphen rule.
 	// - The pattern is somewhat complex, so the error message is hard to
 	//   interpret when the value doesn't match.
 	g.MinLength(1)
-	g.MaxLength(63)
+	g.MaxLength(36)
 	g.Example("Human-readable", func() {
 		g.Description("Identifiers can be human-readable for ease of use.")
 		g.Value("production")

--- a/api/apiv1/gen/control_plane/service.go
+++ b/api/apiv1/gen/control_plane/service.go
@@ -647,7 +647,7 @@ type HostStatus struct {
 	Components map[string]*ComponentStatus `json:"components"`
 }
 
-// A user-specified identifier. Must be 1-63 characters, contain only
+// A user-specified identifier. Must be 1-36 characters, contain only
 // lower-cased letters and hyphens, start and end with a letter or number, and
 // not contain consecutive hyphens.
 type Identifier string

--- a/api/apiv1/gen/http/control_plane/client/cli.go
+++ b/api/apiv1/gen/http/control_plane/client/cli.go
@@ -28,8 +28,8 @@ func BuildInitClusterPayload(controlPlaneInitClusterClusterID string) (*controlp
 			if utf8.RuneCountInString(*clusterID) < 1 {
 				err = goa.MergeErrors(err, goa.InvalidLengthError("cluster_id", *clusterID, utf8.RuneCountInString(*clusterID), 1, true))
 			}
-			if utf8.RuneCountInString(*clusterID) > 63 {
-				err = goa.MergeErrors(err, goa.InvalidLengthError("cluster_id", *clusterID, utf8.RuneCountInString(*clusterID), 63, false))
+			if utf8.RuneCountInString(*clusterID) > 36 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("cluster_id", *clusterID, utf8.RuneCountInString(*clusterID), 36, false))
 			}
 			if err != nil {
 				return nil, err
@@ -94,8 +94,8 @@ func BuildGetJoinOptionsPayload(controlPlaneGetJoinOptionsBody string) (*control
 		if utf8.RuneCountInString(body.HostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_id", body.HostID, utf8.RuneCountInString(body.HostID), 1, true))
 		}
-		if utf8.RuneCountInString(body.HostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_id", body.HostID, utf8.RuneCountInString(body.HostID), 63, false))
+		if utf8.RuneCountInString(body.HostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_id", body.HostID, utf8.RuneCountInString(body.HostID), 36, false))
 		}
 		for _, e := range body.Addresses {
 			if utf8.RuneCountInString(e) < 3 {
@@ -136,8 +136,8 @@ func BuildGetHostPayload(controlPlaneGetHostHostID string) (*controlplane.GetHos
 		if utf8.RuneCountInString(hostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 1, true))
 		}
-		if utf8.RuneCountInString(hostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 63, false))
+		if utf8.RuneCountInString(hostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -159,8 +159,8 @@ func BuildRemoveHostPayload(controlPlaneRemoveHostHostID string, controlPlaneRem
 		if utf8.RuneCountInString(hostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 1, true))
 		}
-		if utf8.RuneCountInString(hostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 63, false))
+		if utf8.RuneCountInString(hostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -201,8 +201,8 @@ func BuildCreateDatabasePayload(controlPlaneCreateDatabaseBody string) (*control
 			}
 		}
 		if body.ID != nil {
-			if utf8.RuneCountInString(*body.ID) > 63 {
-				err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 63, false))
+			if utf8.RuneCountInString(*body.ID) > 36 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 36, false))
 			}
 		}
 		if body.TenantID != nil {
@@ -211,8 +211,8 @@ func BuildCreateDatabasePayload(controlPlaneCreateDatabaseBody string) (*control
 			}
 		}
 		if body.TenantID != nil {
-			if utf8.RuneCountInString(*body.TenantID) > 63 {
-				err = goa.MergeErrors(err, goa.InvalidLengthError("body.tenant_id", *body.TenantID, utf8.RuneCountInString(*body.TenantID), 63, false))
+			if utf8.RuneCountInString(*body.TenantID) > 36 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("body.tenant_id", *body.TenantID, utf8.RuneCountInString(*body.TenantID), 36, false))
 			}
 		}
 		if body.Spec != nil {
@@ -250,8 +250,8 @@ func BuildGetDatabasePayload(controlPlaneGetDatabaseDatabaseID string) (*control
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -282,8 +282,8 @@ func BuildUpdateDatabasePayload(controlPlaneUpdateDatabaseBody string, controlPl
 			}
 		}
 		if body.TenantID != nil {
-			if utf8.RuneCountInString(*body.TenantID) > 63 {
-				err = goa.MergeErrors(err, goa.InvalidLengthError("body.tenant_id", *body.TenantID, utf8.RuneCountInString(*body.TenantID), 63, false))
+			if utf8.RuneCountInString(*body.TenantID) > 36 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("body.tenant_id", *body.TenantID, utf8.RuneCountInString(*body.TenantID), 36, false))
 			}
 		}
 		if body.Spec != nil {
@@ -301,8 +301,8 @@ func BuildUpdateDatabasePayload(controlPlaneUpdateDatabaseBody string, controlPl
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -354,8 +354,8 @@ func BuildDeleteDatabasePayload(controlPlaneDeleteDatabaseDatabaseID string, con
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -400,8 +400,8 @@ func BuildBackupDatabaseNodePayload(controlPlaneBackupDatabaseNodeBody string, c
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -476,8 +476,8 @@ func BuildSwitchoverDatabaseNodePayload(controlPlaneSwitchoverDatabaseNodeBody s
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -518,8 +518,8 @@ func BuildFailoverDatabaseNodePayload(controlPlaneFailoverDatabaseNodeBody strin
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -559,8 +559,8 @@ func BuildListDatabaseTasksPayload(controlPlaneListDatabaseTasksDatabaseID strin
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -619,8 +619,8 @@ func BuildGetDatabaseTaskPayload(controlPlaneGetDatabaseTaskDatabaseID string, c
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -651,8 +651,8 @@ func BuildGetDatabaseTaskLogPayload(controlPlaneGetDatabaseTaskLogDatabaseID str
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -707,8 +707,8 @@ func BuildListHostTasksPayload(controlPlaneListHostTasksHostID string, controlPl
 		if utf8.RuneCountInString(hostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 1, true))
 		}
-		if utf8.RuneCountInString(hostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 63, false))
+		if utf8.RuneCountInString(hostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -767,8 +767,8 @@ func BuildGetHostTaskPayload(controlPlaneGetHostTaskHostID string, controlPlaneG
 		if utf8.RuneCountInString(hostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 1, true))
 		}
-		if utf8.RuneCountInString(hostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 63, false))
+		if utf8.RuneCountInString(hostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -799,8 +799,8 @@ func BuildGetHostTaskLogPayload(controlPlaneGetHostTaskLogHostID string, control
 		if utf8.RuneCountInString(hostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 1, true))
 		}
-		if utf8.RuneCountInString(hostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 63, false))
+		if utf8.RuneCountInString(hostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -868,8 +868,8 @@ func BuildListTasksPayload(controlPlaneListTasksScope string, controlPlaneListTa
 			if utf8.RuneCountInString(*entityID) < 1 {
 				err = goa.MergeErrors(err, goa.InvalidLengthError("entity_id", *entityID, utf8.RuneCountInString(*entityID), 1, true))
 			}
-			if utf8.RuneCountInString(*entityID) > 63 {
-				err = goa.MergeErrors(err, goa.InvalidLengthError("entity_id", *entityID, utf8.RuneCountInString(*entityID), 63, false))
+			if utf8.RuneCountInString(*entityID) > 36 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("entity_id", *entityID, utf8.RuneCountInString(*entityID), 36, false))
 			}
 			if err != nil {
 				return nil, err
@@ -954,8 +954,8 @@ func BuildRestoreDatabasePayload(controlPlaneRestoreDatabaseBody string, control
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1009,8 +1009,8 @@ func BuildRestartInstancePayload(controlPlaneRestartInstanceBody string, control
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1022,8 +1022,8 @@ func BuildRestartInstancePayload(controlPlaneRestartInstanceBody string, control
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
+		if utf8.RuneCountInString(instanceID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1048,8 +1048,8 @@ func BuildStopInstancePayload(controlPlaneStopInstanceDatabaseID string, control
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1061,8 +1061,8 @@ func BuildStopInstancePayload(controlPlaneStopInstanceDatabaseID string, control
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
+		if utf8.RuneCountInString(instanceID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1095,8 +1095,8 @@ func BuildStartInstancePayload(controlPlaneStartInstanceDatabaseID string, contr
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1108,8 +1108,8 @@ func BuildStartInstancePayload(controlPlaneStartInstanceDatabaseID string, contr
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
+		if utf8.RuneCountInString(instanceID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1142,8 +1142,8 @@ func BuildCancelDatabaseTaskPayload(controlPlaneCancelDatabaseTaskDatabaseID str
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1155,8 +1155,8 @@ func BuildCancelDatabaseTaskPayload(controlPlaneCancelDatabaseTaskDatabaseID str
 		if utf8.RuneCountInString(taskID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("task_id", taskID, utf8.RuneCountInString(taskID), 1, true))
 		}
-		if utf8.RuneCountInString(taskID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("task_id", taskID, utf8.RuneCountInString(taskID), 63, false))
+		if utf8.RuneCountInString(taskID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("task_id", taskID, utf8.RuneCountInString(taskID), 36, false))
 		}
 		if err != nil {
 			return nil, err

--- a/api/apiv1/gen/http/control_plane/client/types.go
+++ b/api/apiv1/gen/http/control_plane/client/types.go
@@ -5848,8 +5848,8 @@ func ValidateDatabaseNodeSpecRequestBody(body *DatabaseNodeSpecRequestBody) (err
 		if utf8.RuneCountInString(e) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 1, true))
 		}
-		if utf8.RuneCountInString(e) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 63, false))
+		if utf8.RuneCountInString(e) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 36, false))
 		}
 	}
 	if body.PostgresVersion != nil {
@@ -5939,8 +5939,8 @@ func ValidateBackupRepositorySpecRequestBody(body *BackupRepositorySpecRequestBo
 		}
 	}
 	if body.ID != nil {
-		if utf8.RuneCountInString(*body.ID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 63, false))
+		if utf8.RuneCountInString(*body.ID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 36, false))
 		}
 	}
 	if !(body.Type == "s3" || body.Type == "gcs" || body.Type == "azure" || body.Type == "posix" || body.Type == "cifs") {
@@ -6093,8 +6093,8 @@ func ValidateRestoreConfigSpecRequestBody(body *RestoreConfigSpecRequestBody) (e
 	if utf8.RuneCountInString(body.SourceDatabaseID) < 1 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.source_database_id", body.SourceDatabaseID, utf8.RuneCountInString(body.SourceDatabaseID), 1, true))
 	}
-	if utf8.RuneCountInString(body.SourceDatabaseID) > 63 {
-		err = goa.MergeErrors(err, goa.InvalidLengthError("body.source_database_id", body.SourceDatabaseID, utf8.RuneCountInString(body.SourceDatabaseID), 63, false))
+	if utf8.RuneCountInString(body.SourceDatabaseID) > 36 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.source_database_id", body.SourceDatabaseID, utf8.RuneCountInString(body.SourceDatabaseID), 36, false))
 	}
 	err = goa.MergeErrors(err, goa.ValidatePattern("body.source_node_name", body.SourceNodeName, "n[0-9]+"))
 	if utf8.RuneCountInString(body.SourceDatabaseName) < 1 {
@@ -6123,8 +6123,8 @@ func ValidateRestoreRepositorySpecRequestBody(body *RestoreRepositorySpecRequest
 		}
 	}
 	if body.ID != nil {
-		if utf8.RuneCountInString(*body.ID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 63, false))
+		if utf8.RuneCountInString(*body.ID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 36, false))
 		}
 	}
 	if !(body.Type == "s3" || body.Type == "gcs" || body.Type == "azure" || body.Type == "posix" || body.Type == "cifs") {
@@ -6325,8 +6325,8 @@ func ValidateServiceSpecRequestBody(body *ServiceSpecRequestBody) (err error) {
 	if utf8.RuneCountInString(body.ServiceID) < 1 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.service_id", body.ServiceID, utf8.RuneCountInString(body.ServiceID), 1, true))
 	}
-	if utf8.RuneCountInString(body.ServiceID) > 63 {
-		err = goa.MergeErrors(err, goa.InvalidLengthError("body.service_id", body.ServiceID, utf8.RuneCountInString(body.ServiceID), 63, false))
+	if utf8.RuneCountInString(body.ServiceID) > 36 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.service_id", body.ServiceID, utf8.RuneCountInString(body.ServiceID), 36, false))
 	}
 	if !(body.ServiceType == "mcp" || body.ServiceType == "postgrest" || body.ServiceType == "rag") {
 		err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.service_type", body.ServiceType, []any{"mcp", "postgrest", "rag"}))
@@ -6339,8 +6339,8 @@ func ValidateServiceSpecRequestBody(body *ServiceSpecRequestBody) (err error) {
 		if utf8.RuneCountInString(e) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 1, true))
 		}
-		if utf8.RuneCountInString(e) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 63, false))
+		if utf8.RuneCountInString(e) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 36, false))
 		}
 	}
 	if body.Port != nil {
@@ -6654,8 +6654,8 @@ func ValidateDatabaseNodeSpecRequestBodyRequestBody(body *DatabaseNodeSpecReques
 		if utf8.RuneCountInString(e) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 1, true))
 		}
-		if utf8.RuneCountInString(e) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 63, false))
+		if utf8.RuneCountInString(e) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 36, false))
 		}
 	}
 	if body.PostgresVersion != nil {
@@ -6745,8 +6745,8 @@ func ValidateBackupRepositorySpecRequestBodyRequestBody(body *BackupRepositorySp
 		}
 	}
 	if body.ID != nil {
-		if utf8.RuneCountInString(*body.ID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 63, false))
+		if utf8.RuneCountInString(*body.ID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 36, false))
 		}
 	}
 	if !(body.Type == "s3" || body.Type == "gcs" || body.Type == "azure" || body.Type == "posix" || body.Type == "cifs") {
@@ -6899,8 +6899,8 @@ func ValidateRestoreConfigSpecRequestBodyRequestBody(body *RestoreConfigSpecRequ
 	if utf8.RuneCountInString(body.SourceDatabaseID) < 1 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.source_database_id", body.SourceDatabaseID, utf8.RuneCountInString(body.SourceDatabaseID), 1, true))
 	}
-	if utf8.RuneCountInString(body.SourceDatabaseID) > 63 {
-		err = goa.MergeErrors(err, goa.InvalidLengthError("body.source_database_id", body.SourceDatabaseID, utf8.RuneCountInString(body.SourceDatabaseID), 63, false))
+	if utf8.RuneCountInString(body.SourceDatabaseID) > 36 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.source_database_id", body.SourceDatabaseID, utf8.RuneCountInString(body.SourceDatabaseID), 36, false))
 	}
 	err = goa.MergeErrors(err, goa.ValidatePattern("body.source_node_name", body.SourceNodeName, "n[0-9]+"))
 	if utf8.RuneCountInString(body.SourceDatabaseName) < 1 {
@@ -6929,8 +6929,8 @@ func ValidateRestoreRepositorySpecRequestBodyRequestBody(body *RestoreRepository
 		}
 	}
 	if body.ID != nil {
-		if utf8.RuneCountInString(*body.ID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 63, false))
+		if utf8.RuneCountInString(*body.ID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 36, false))
 		}
 	}
 	if !(body.Type == "s3" || body.Type == "gcs" || body.Type == "azure" || body.Type == "posix" || body.Type == "cifs") {
@@ -7131,8 +7131,8 @@ func ValidateServiceSpecRequestBodyRequestBody(body *ServiceSpecRequestBodyReque
 	if utf8.RuneCountInString(body.ServiceID) < 1 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.service_id", body.ServiceID, utf8.RuneCountInString(body.ServiceID), 1, true))
 	}
-	if utf8.RuneCountInString(body.ServiceID) > 63 {
-		err = goa.MergeErrors(err, goa.InvalidLengthError("body.service_id", body.ServiceID, utf8.RuneCountInString(body.ServiceID), 63, false))
+	if utf8.RuneCountInString(body.ServiceID) > 36 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.service_id", body.ServiceID, utf8.RuneCountInString(body.ServiceID), 36, false))
 	}
 	if !(body.ServiceType == "mcp" || body.ServiceType == "postgrest" || body.ServiceType == "rag") {
 		err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.service_type", body.ServiceType, []any{"mcp", "postgrest", "rag"}))
@@ -7145,8 +7145,8 @@ func ValidateServiceSpecRequestBodyRequestBody(body *ServiceSpecRequestBodyReque
 		if utf8.RuneCountInString(e) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 1, true))
 		}
-		if utf8.RuneCountInString(e) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 63, false))
+		if utf8.RuneCountInString(e) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 36, false))
 		}
 	}
 	if body.Port != nil {

--- a/api/apiv1/gen/http/control_plane/server/encode_decode.go
+++ b/api/apiv1/gen/http/control_plane/server/encode_decode.go
@@ -50,8 +50,8 @@ func DecodeInitClusterRequest(mux goahttp.Muxer, decoder func(*http.Request) goa
 			}
 		}
 		if clusterID != nil {
-			if utf8.RuneCountInString(*clusterID) > 63 {
-				err = goa.MergeErrors(err, goa.InvalidLengthError("cluster_id", *clusterID, utf8.RuneCountInString(*clusterID), 63, false))
+			if utf8.RuneCountInString(*clusterID) > 36 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("cluster_id", *clusterID, utf8.RuneCountInString(*clusterID), 36, false))
 			}
 		}
 		if err != nil {
@@ -521,8 +521,8 @@ func DecodeGetHostRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 		if utf8.RuneCountInString(hostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 1, true))
 		}
-		if utf8.RuneCountInString(hostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 63, false))
+		if utf8.RuneCountInString(hostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -628,8 +628,8 @@ func DecodeRemoveHostRequest(mux goahttp.Muxer, decoder func(*http.Request) goah
 		if utf8.RuneCountInString(hostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 1, true))
 		}
-		if utf8.RuneCountInString(hostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 63, false))
+		if utf8.RuneCountInString(hostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 36, false))
 		}
 		{
 			forceRaw := r.URL.Query().Get("force")
@@ -920,8 +920,8 @@ func DecodeGetDatabaseRequest(mux goahttp.Muxer, decoder func(*http.Request) goa
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1047,8 +1047,8 @@ func DecodeUpdateDatabaseRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		qp := r.URL.Query()
 		{
@@ -1192,8 +1192,8 @@ func DecodeDeleteDatabaseRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		{
 			forceRaw := r.URL.Query().Get("force")
@@ -1355,8 +1355,8 @@ func DecodeBackupDatabaseNodeRequest(mux goahttp.Muxer, decoder func(*http.Reque
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		nodeName = params["node_name"]
 		err = goa.MergeErrors(err, goa.ValidatePattern("node_name", nodeName, "n[0-9]+"))
@@ -1519,8 +1519,8 @@ func DecodeSwitchoverDatabaseNodeRequest(mux goahttp.Muxer, decoder func(*http.R
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		nodeName = params["node_name"]
 		err = goa.MergeErrors(err, goa.ValidatePattern("node_name", nodeName, "n[0-9]+"))
@@ -1669,8 +1669,8 @@ func DecodeFailoverDatabaseNodeRequest(mux goahttp.Muxer, decoder func(*http.Req
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		nodeName = params["node_name"]
 		err = goa.MergeErrors(err, goa.ValidatePattern("node_name", nodeName, "n[0-9]+"))
@@ -1806,8 +1806,8 @@ func DecodeListDatabaseTasksRequest(mux goahttp.Muxer, decoder func(*http.Reques
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		qp := r.URL.Query()
 		afterTaskIDRaw := qp.Get("after_task_id")
@@ -1941,8 +1941,8 @@ func DecodeGetDatabaseTaskRequest(mux goahttp.Muxer, decoder func(*http.Request)
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		taskID = params["task_id"]
 		err = goa.MergeErrors(err, goa.ValidateFormat("task_id", taskID, goa.FormatUUID))
@@ -2052,8 +2052,8 @@ func DecodeGetDatabaseTaskLogRequest(mux goahttp.Muxer, decoder func(*http.Reque
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		taskID = params["task_id"]
 		err = goa.MergeErrors(err, goa.ValidateFormat("task_id", taskID, goa.FormatUUID))
@@ -2182,8 +2182,8 @@ func DecodeListHostTasksRequest(mux goahttp.Muxer, decoder func(*http.Request) g
 		if utf8.RuneCountInString(hostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 1, true))
 		}
-		if utf8.RuneCountInString(hostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 63, false))
+		if utf8.RuneCountInString(hostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 36, false))
 		}
 		qp := r.URL.Query()
 		afterTaskIDRaw := qp.Get("after_task_id")
@@ -2317,8 +2317,8 @@ func DecodeGetHostTaskRequest(mux goahttp.Muxer, decoder func(*http.Request) goa
 		if utf8.RuneCountInString(hostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 1, true))
 		}
-		if utf8.RuneCountInString(hostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 63, false))
+		if utf8.RuneCountInString(hostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 36, false))
 		}
 		taskID = params["task_id"]
 		err = goa.MergeErrors(err, goa.ValidateFormat("task_id", taskID, goa.FormatUUID))
@@ -2428,8 +2428,8 @@ func DecodeGetHostTaskLogRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 		if utf8.RuneCountInString(hostID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 1, true))
 		}
-		if utf8.RuneCountInString(hostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 63, false))
+		if utf8.RuneCountInString(hostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("host_id", hostID, utf8.RuneCountInString(hostID), 36, false))
 		}
 		taskID = params["task_id"]
 		err = goa.MergeErrors(err, goa.ValidateFormat("task_id", taskID, goa.FormatUUID))
@@ -2573,8 +2573,8 @@ func DecodeListTasksRequest(mux goahttp.Muxer, decoder func(*http.Request) goaht
 			}
 		}
 		if entityID != nil {
-			if utf8.RuneCountInString(*entityID) > 63 {
-				err = goa.MergeErrors(err, goa.InvalidLengthError("entity_id", *entityID, utf8.RuneCountInString(*entityID), 63, false))
+			if utf8.RuneCountInString(*entityID) > 36 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("entity_id", *entityID, utf8.RuneCountInString(*entityID), 36, false))
 			}
 		}
 		afterTaskIDRaw := qp.Get("after_task_id")
@@ -2714,8 +2714,8 @@ func DecodeRestoreDatabaseRequest(mux goahttp.Muxer, decoder func(*http.Request)
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		{
 			forceRaw := r.URL.Query().Get("force")
@@ -2922,15 +2922,15 @@ func DecodeRestartInstanceRequest(mux goahttp.Muxer, decoder func(*http.Request)
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		instanceID = params["instance_id"]
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
+		if utf8.RuneCountInString(instanceID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
 		}
 		if err != nil {
 			return nil, err
@@ -3037,15 +3037,15 @@ func DecodeStopInstanceRequest(mux goahttp.Muxer, decoder func(*http.Request) go
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		instanceID = params["instance_id"]
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
+		if utf8.RuneCountInString(instanceID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
 		}
 		{
 			forceRaw := r.URL.Query().Get("force")
@@ -3162,15 +3162,15 @@ func DecodeStartInstanceRequest(mux goahttp.Muxer, decoder func(*http.Request) g
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		instanceID = params["instance_id"]
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
+		if utf8.RuneCountInString(instanceID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
 		}
 		{
 			forceRaw := r.URL.Query().Get("force")
@@ -3286,15 +3286,15 @@ func DecodeCancelDatabaseTaskRequest(mux goahttp.Muxer, decoder func(*http.Reque
 		if utf8.RuneCountInString(databaseID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 1, true))
 		}
-		if utf8.RuneCountInString(databaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 63, false))
+		if utf8.RuneCountInString(databaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
 		taskID = params["task_id"]
 		if utf8.RuneCountInString(taskID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("task_id", taskID, utf8.RuneCountInString(taskID), 1, true))
 		}
-		if utf8.RuneCountInString(taskID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("task_id", taskID, utf8.RuneCountInString(taskID), 63, false))
+		if utf8.RuneCountInString(taskID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("task_id", taskID, utf8.RuneCountInString(taskID), 36, false))
 		}
 		if err != nil {
 			return nil, err

--- a/api/apiv1/gen/http/control_plane/server/types.go
+++ b/api/apiv1/gen/http/control_plane/server/types.go
@@ -5039,8 +5039,8 @@ func ValidateGetJoinOptionsRequestBody(body *GetJoinOptionsRequestBody) (err err
 		}
 	}
 	if body.HostID != nil {
-		if utf8.RuneCountInString(*body.HostID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_id", *body.HostID, utf8.RuneCountInString(*body.HostID), 63, false))
+		if utf8.RuneCountInString(*body.HostID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_id", *body.HostID, utf8.RuneCountInString(*body.HostID), 36, false))
 		}
 	}
 	for _, e := range body.Addresses {
@@ -5066,8 +5066,8 @@ func ValidateCreateDatabaseRequestBody(body *CreateDatabaseRequestBody) (err err
 		}
 	}
 	if body.ID != nil {
-		if utf8.RuneCountInString(*body.ID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 63, false))
+		if utf8.RuneCountInString(*body.ID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 36, false))
 		}
 	}
 	if body.TenantID != nil {
@@ -5076,8 +5076,8 @@ func ValidateCreateDatabaseRequestBody(body *CreateDatabaseRequestBody) (err err
 		}
 	}
 	if body.TenantID != nil {
-		if utf8.RuneCountInString(*body.TenantID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.tenant_id", *body.TenantID, utf8.RuneCountInString(*body.TenantID), 63, false))
+		if utf8.RuneCountInString(*body.TenantID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.tenant_id", *body.TenantID, utf8.RuneCountInString(*body.TenantID), 36, false))
 		}
 	}
 	if body.Spec != nil {
@@ -5100,8 +5100,8 @@ func ValidateUpdateDatabaseRequestBody(body *UpdateDatabaseRequestBody) (err err
 		}
 	}
 	if body.TenantID != nil {
-		if utf8.RuneCountInString(*body.TenantID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.tenant_id", *body.TenantID, utf8.RuneCountInString(*body.TenantID), 63, false))
+		if utf8.RuneCountInString(*body.TenantID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.tenant_id", *body.TenantID, utf8.RuneCountInString(*body.TenantID), 36, false))
 		}
 	}
 	if body.Spec != nil {
@@ -5280,8 +5280,8 @@ func ValidateDatabaseNodeSpecRequestBody(body *DatabaseNodeSpecRequestBody) (err
 		if utf8.RuneCountInString(e) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 1, true))
 		}
-		if utf8.RuneCountInString(e) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 63, false))
+		if utf8.RuneCountInString(e) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 36, false))
 		}
 	}
 	if body.PostgresVersion != nil {
@@ -5374,8 +5374,8 @@ func ValidateBackupRepositorySpecRequestBody(body *BackupRepositorySpecRequestBo
 		}
 	}
 	if body.ID != nil {
-		if utf8.RuneCountInString(*body.ID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 63, false))
+		if utf8.RuneCountInString(*body.ID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 36, false))
 		}
 	}
 	if body.Type != nil {
@@ -5557,8 +5557,8 @@ func ValidateRestoreConfigSpecRequestBody(body *RestoreConfigSpecRequestBody) (e
 		}
 	}
 	if body.SourceDatabaseID != nil {
-		if utf8.RuneCountInString(*body.SourceDatabaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.source_database_id", *body.SourceDatabaseID, utf8.RuneCountInString(*body.SourceDatabaseID), 63, false))
+		if utf8.RuneCountInString(*body.SourceDatabaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.source_database_id", *body.SourceDatabaseID, utf8.RuneCountInString(*body.SourceDatabaseID), 36, false))
 		}
 	}
 	if body.SourceNodeName != nil {
@@ -5597,8 +5597,8 @@ func ValidateRestoreRepositorySpecRequestBody(body *RestoreRepositorySpecRequest
 		}
 	}
 	if body.ID != nil {
-		if utf8.RuneCountInString(*body.ID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 63, false))
+		if utf8.RuneCountInString(*body.ID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 36, false))
 		}
 	}
 	if body.Type != nil {
@@ -5834,8 +5834,8 @@ func ValidateServiceSpecRequestBody(body *ServiceSpecRequestBody) (err error) {
 		}
 	}
 	if body.ServiceID != nil {
-		if utf8.RuneCountInString(*body.ServiceID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.service_id", *body.ServiceID, utf8.RuneCountInString(*body.ServiceID), 63, false))
+		if utf8.RuneCountInString(*body.ServiceID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.service_id", *body.ServiceID, utf8.RuneCountInString(*body.ServiceID), 36, false))
 		}
 	}
 	if body.ServiceType != nil {
@@ -5853,8 +5853,8 @@ func ValidateServiceSpecRequestBody(body *ServiceSpecRequestBody) (err error) {
 		if utf8.RuneCountInString(e) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 1, true))
 		}
-		if utf8.RuneCountInString(e) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 63, false))
+		if utf8.RuneCountInString(e) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 36, false))
 		}
 	}
 	if body.Port != nil {
@@ -6061,8 +6061,8 @@ func ValidateDatabaseNodeSpecRequestBodyRequestBody(body *DatabaseNodeSpecReques
 		if utf8.RuneCountInString(e) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 1, true))
 		}
-		if utf8.RuneCountInString(e) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 63, false))
+		if utf8.RuneCountInString(e) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 36, false))
 		}
 	}
 	if body.PostgresVersion != nil {
@@ -6155,8 +6155,8 @@ func ValidateBackupRepositorySpecRequestBodyRequestBody(body *BackupRepositorySp
 		}
 	}
 	if body.ID != nil {
-		if utf8.RuneCountInString(*body.ID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 63, false))
+		if utf8.RuneCountInString(*body.ID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 36, false))
 		}
 	}
 	if body.Type != nil {
@@ -6338,8 +6338,8 @@ func ValidateRestoreConfigSpecRequestBodyRequestBody(body *RestoreConfigSpecRequ
 		}
 	}
 	if body.SourceDatabaseID != nil {
-		if utf8.RuneCountInString(*body.SourceDatabaseID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.source_database_id", *body.SourceDatabaseID, utf8.RuneCountInString(*body.SourceDatabaseID), 63, false))
+		if utf8.RuneCountInString(*body.SourceDatabaseID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.source_database_id", *body.SourceDatabaseID, utf8.RuneCountInString(*body.SourceDatabaseID), 36, false))
 		}
 	}
 	if body.SourceNodeName != nil {
@@ -6378,8 +6378,8 @@ func ValidateRestoreRepositorySpecRequestBodyRequestBody(body *RestoreRepository
 		}
 	}
 	if body.ID != nil {
-		if utf8.RuneCountInString(*body.ID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 63, false))
+		if utf8.RuneCountInString(*body.ID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 36, false))
 		}
 	}
 	if body.Type != nil {
@@ -6615,8 +6615,8 @@ func ValidateServiceSpecRequestBodyRequestBody(body *ServiceSpecRequestBodyReque
 		}
 	}
 	if body.ServiceID != nil {
-		if utf8.RuneCountInString(*body.ServiceID) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.service_id", *body.ServiceID, utf8.RuneCountInString(*body.ServiceID), 63, false))
+		if utf8.RuneCountInString(*body.ServiceID) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.service_id", *body.ServiceID, utf8.RuneCountInString(*body.ServiceID), 36, false))
 		}
 	}
 	if body.ServiceType != nil {
@@ -6634,8 +6634,8 @@ func ValidateServiceSpecRequestBodyRequestBody(body *ServiceSpecRequestBodyReque
 		if utf8.RuneCountInString(e) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 1, true))
 		}
-		if utf8.RuneCountInString(e) > 63 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 63, false))
+		if utf8.RuneCountInString(e) > 36 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.host_ids[*]", e, utf8.RuneCountInString(e), 36, false))
 		}
 	}
 	if body.Port != nil {

--- a/api/apiv1/gen/http/openapi.json
+++ b/api/apiv1/gen/http/openapi.json
@@ -81,7 +81,7 @@
           {
             "name": "cluster_id",
             "in": "query",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": false,
             "type": "string"
           }
@@ -402,7 +402,7 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           }
@@ -501,7 +501,7 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
@@ -595,7 +595,7 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           }
@@ -674,14 +674,14 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
           {
             "name": "instance_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
@@ -784,14 +784,14 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
           {
             "name": "instance_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           }
@@ -878,14 +878,14 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
           {
             "name": "instance_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           }
@@ -972,7 +972,7 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
@@ -1067,7 +1067,7 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
@@ -1162,7 +1162,7 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
@@ -1265,7 +1265,7 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
@@ -1384,7 +1384,7 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           }
@@ -1463,7 +1463,7 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
@@ -1555,14 +1555,14 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
           {
             "name": "task_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           }
@@ -1651,7 +1651,7 @@
           {
             "name": "database_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
@@ -1792,7 +1792,7 @@
           {
             "name": "host_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           }
@@ -1882,7 +1882,7 @@
           {
             "name": "host_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           }
@@ -1992,7 +1992,7 @@
           {
             "name": "host_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           }
@@ -2071,7 +2071,7 @@
           {
             "name": "host_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
@@ -2178,7 +2178,7 @@
           {
             "name": "host_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": true,
             "type": "string"
           },
@@ -2280,7 +2280,7 @@
           {
             "name": "entity_id",
             "in": "query",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "required": false,
             "type": "string"
           },
@@ -2738,7 +2738,7 @@
           "description": "The unique identifier of this repository.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "retention_full": {
           "type": "integer",
@@ -3020,7 +3020,7 @@
           "description": "Unique identifier for the cluster.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "status": {
           "$ref": "#/definitions/ClusterStatus"
@@ -3296,7 +3296,7 @@
           "description": "Unique identifier for the database.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "spec": {
           "$ref": "#/definitions/DatabaseSpec"
@@ -3306,7 +3306,7 @@
           "description": "Unique identifier for the database's owner.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         }
       },
       "example": {
@@ -3436,7 +3436,7 @@
           "description": "Unique identifier for the database.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "instances": {
           "type": "array",
@@ -3663,7 +3663,7 @@
           "description": "Unique identifier for the database's owner.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "updated_at": {
           "type": "string",
@@ -3891,7 +3891,7 @@
             "type": "string",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
           "example": [
@@ -5652,7 +5652,7 @@
           "description": "Unique identifier for the database.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "instances": {
           "type": "array",
@@ -5819,7 +5819,7 @@
           "description": "Unique identifier for the database's owner.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "updated_at": {
           "type": "string",
@@ -6267,7 +6267,7 @@
           "description": "Unique identifier for the host.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "memory": {
           "type": "string",
@@ -8198,7 +8198,7 @@
           "description": "The ID of the database to restore this database from.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "source_database_name": {
           "type": "string",
@@ -8601,7 +8601,7 @@
           "description": "The unique identifier of this repository.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "s3_bucket": {
           "type": "string",
@@ -8688,7 +8688,7 @@
           "description": "The ID of the database this service belongs to.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "error": {
           "type": "string",
@@ -8917,7 +8917,7 @@
             "type": "string",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
           "example": [
@@ -8949,7 +8949,7 @@
           "description": "The unique identifier for this service.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         },
         "service_type": {
           "type": "string",
@@ -9559,7 +9559,7 @@
           "description": "Unique identifier for the database's owner.",
           "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
           "minLength": 1,
-          "maxLength": 63
+          "maxLength": 36
         }
       },
       "example": {

--- a/api/apiv1/gen/http/openapi.yaml
+++ b/api/apiv1/gen/http/openapi.yaml
@@ -59,7 +59,7 @@ paths:
       parameters:
         - name: cluster_id
           in: query
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: false
           type: string
       responses:
@@ -278,7 +278,7 @@ paths:
       parameters:
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
       responses:
@@ -348,7 +348,7 @@ paths:
           collectionFormat: multi
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: Update-DatabaseRequestBody
@@ -413,7 +413,7 @@ paths:
           default: false
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
       responses:
@@ -467,12 +467,12 @@ paths:
       parameters:
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: instance_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: object
@@ -543,12 +543,12 @@ paths:
           default: false
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: instance_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
       responses:
@@ -608,12 +608,12 @@ paths:
           default: false
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: instance_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
       responses:
@@ -673,7 +673,7 @@ paths:
           default: false
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: node_name
@@ -738,7 +738,7 @@ paths:
       parameters:
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: node_name
@@ -803,7 +803,7 @@ paths:
       parameters:
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: node_name
@@ -874,7 +874,7 @@ paths:
           default: false
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: Restore-DatabaseRequestBody
@@ -958,7 +958,7 @@ paths:
             - descending
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
       responses:
@@ -1012,7 +1012,7 @@ paths:
       parameters:
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: task_id
@@ -1077,12 +1077,12 @@ paths:
       parameters:
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: task_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
       responses:
@@ -1145,7 +1145,7 @@ paths:
           type: integer
         - name: database_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: task_id
@@ -1243,7 +1243,7 @@ paths:
       parameters:
         - name: host_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
       responses:
@@ -1307,7 +1307,7 @@ paths:
           default: false
         - name: host_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
       responses:
@@ -1385,7 +1385,7 @@ paths:
             - descending
         - name: host_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
       responses:
@@ -1439,7 +1439,7 @@ paths:
       parameters:
         - name: host_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: task_id
@@ -1515,7 +1515,7 @@ paths:
           type: integer
         - name: host_id
           in: path
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: true
           type: string
         - name: task_id
@@ -1587,7 +1587,7 @@ paths:
             - host
         - name: entity_id
           in: query
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           required: false
           type: string
         - name: after_task_id
@@ -1931,7 +1931,7 @@ definitions:
         description: The unique identifier of this repository.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       retention_full:
         type: integer
         description: The count of full backups to retain or the time to retain full backups.
@@ -2144,7 +2144,7 @@ definitions:
         description: Unique identifier for the cluster.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       status:
         $ref: '#/definitions/ClusterStatus'
     example:
@@ -2339,7 +2339,7 @@ definitions:
         description: Unique identifier for the database.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       spec:
         $ref: '#/definitions/DatabaseSpec'
       tenant_id:
@@ -2347,7 +2347,7 @@ definitions:
         description: Unique identifier for the database's owner.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
     example:
       id: storefront
       spec:
@@ -2432,7 +2432,7 @@ definitions:
         description: Unique identifier for the database.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       instances:
         type: array
         items:
@@ -2595,7 +2595,7 @@ definitions:
         description: Unique identifier for the database's owner.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       updated_at:
         type: string
         description: The time that the database was last updated.
@@ -2757,7 +2757,7 @@ definitions:
           type: string
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
         example:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -4019,7 +4019,7 @@ definitions:
         description: Unique identifier for the database.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       instances:
         type: array
         items:
@@ -4141,7 +4141,7 @@ definitions:
         description: Unique identifier for the database's owner.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       updated_at:
         type: string
         description: The time that the database was last updated.
@@ -4475,7 +4475,7 @@ definitions:
         description: Unique identifier for the host.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       memory:
         type: string
         description: The amount of memory available on this host.
@@ -5855,7 +5855,7 @@ definitions:
         description: The ID of the database to restore this database from.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       source_database_name:
         type: string
         description: The name of the database in this repository. The database will be renamed to the database_name in the DatabaseSpec after it's restored.
@@ -6155,7 +6155,7 @@ definitions:
         description: The unique identifier of this repository.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       s3_bucket:
         type: string
         description: The S3 bucket name for this repository. Only applies when type = 's3'.
@@ -6228,7 +6228,7 @@ definitions:
         description: The ID of the database this service belongs to.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       error:
         type: string
         description: An error message if the service instance is in an error state.
@@ -6400,7 +6400,7 @@ definitions:
           type: string
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         description: The IDs of the hosts that should run this service. One service instance will be created per host.
         example:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -6426,7 +6426,7 @@ definitions:
         description: The unique identifier for this service.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
       service_type:
         type: string
         description: The type of service to run.
@@ -6861,7 +6861,7 @@ definitions:
         description: Unique identifier for the database's owner.
         example: 76f9b8c0-4958-11f0-a489-3bb29577c696
         minLength: 1
-        maxLength: 63
+        maxLength: 36
     example:
       spec:
         database_name: storefront

--- a/api/apiv1/gen/http/openapi3.json
+++ b/api/apiv1/gen/http/openapi3.json
@@ -234,10 +234,10 @@
             "allowEmptyValue": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "examples": {
               "Human-readable": {
@@ -1359,10 +1359,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           }
@@ -1474,10 +1474,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           }
@@ -1773,10 +1773,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           }
@@ -2169,10 +2169,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "68f50878-44d2-4524-a823-e31bd478706d"
           },
@@ -2183,10 +2183,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi"
           }
@@ -2343,10 +2343,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "68f50878-44d2-4524-a823-e31bd478706d"
           },
@@ -2357,10 +2357,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi"
           }
@@ -2493,10 +2493,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "68f50878-44d2-4524-a823-e31bd478706d"
           },
@@ -2507,10 +2507,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi"
           }
@@ -2643,10 +2643,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           },
@@ -2805,10 +2805,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           },
@@ -2949,10 +2949,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           },
@@ -3106,10 +3106,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           }
@@ -3498,10 +3498,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           }
@@ -3651,10 +3651,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           },
@@ -3782,10 +3782,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "abc123"
           },
@@ -3796,10 +3796,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "def456"
           }
@@ -3926,10 +3926,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           },
@@ -4399,10 +4399,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "host-1"
           }
@@ -4559,10 +4559,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "host-1"
           }
@@ -4763,10 +4763,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "host-1"
           }
@@ -4885,10 +4885,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "host-1"
           },
@@ -5042,10 +5042,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "host-1"
           },
@@ -5310,10 +5310,10 @@
             "allowEmptyValue": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "example": "my-app"
           },
@@ -5883,10 +5883,10 @@
           },
           "id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "retention_full": {
             "type": "integer",
@@ -6019,17 +6019,17 @@
         "properties": {
           "database_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "task_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           }
         },
         "example": {
@@ -6190,10 +6190,10 @@
           },
           "id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "status": {
             "$ref": "#/components/schemas/ClusterStatus"
@@ -6465,10 +6465,10 @@
           },
           "host_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "token": {
             "type": "string",
@@ -6586,20 +6586,20 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "spec": {
             "$ref": "#/components/schemas/DatabaseSpec"
           },
           "tenant_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           }
         },
         "example": {
@@ -6655,7 +6655,7 @@
             "description": "Unique identifier for the database.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "spec": {
             "$ref": "#/components/schemas/DatabaseSpec2"
@@ -6665,7 +6665,7 @@
             "description": "Unique identifier for the database's owner.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           }
         },
         "example": {
@@ -6856,10 +6856,10 @@
           },
           "id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "instances": {
             "type": "array",
@@ -7103,10 +7103,10 @@
           },
           "tenant_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "updated_at": {
             "type": "string",
@@ -7291,7 +7291,7 @@
             "description": "Unique identifier for the database.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "instances": {
             "type": "array",
@@ -7657,7 +7657,7 @@
             "description": "Unique identifier for the database's owner.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "updated_at": {
             "type": "string",
@@ -7842,7 +7842,7 @@
             "description": "Unique identifier for the database.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "instances": {
             "type": "array",
@@ -8114,7 +8114,7 @@
             "description": "Unique identifier for the database's owner.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "updated_at": {
             "type": "string",
@@ -8299,7 +8299,7 @@
             "description": "Unique identifier for the database.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "instances": {
             "type": "array",
@@ -8710,7 +8710,7 @@
             "description": "Unique identifier for the database's owner.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "updated_at": {
             "type": "string",
@@ -8895,7 +8895,7 @@
             "description": "Unique identifier for the database.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "instances": {
             "type": "array",
@@ -9212,7 +9212,7 @@
             "description": "Unique identifier for the database's owner.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "updated_at": {
             "type": "string",
@@ -9436,10 +9436,10 @@
             "type": "array",
             "items": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
@@ -9691,7 +9691,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
@@ -9968,7 +9968,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
@@ -10246,7 +10246,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
@@ -10522,7 +10522,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
@@ -10799,7 +10799,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
@@ -11075,7 +11075,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
@@ -21832,10 +21832,10 @@
           },
           "id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "instances": {
             "type": "array",
@@ -21984,10 +21984,10 @@
           },
           "tenant_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "updated_at": {
             "type": "string",
@@ -22386,10 +22386,10 @@
           },
           "database_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "node_name": {
             "type": "string",
@@ -22534,10 +22534,10 @@
           },
           "id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "memory": {
             "type": "string",
@@ -22796,10 +22796,10 @@
         "properties": {
           "cluster_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           }
         },
         "description": "Request to initialize a cluster",
@@ -24583,10 +24583,10 @@
           },
           "source_database_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "source_database_name": {
             "type": "string",
@@ -25251,10 +25251,10 @@
           },
           "id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "s3_bucket": {
             "type": "string",
@@ -25354,10 +25354,10 @@
           },
           "database_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "error": {
             "type": "string",
@@ -25587,10 +25587,10 @@
             "type": "array",
             "items": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
@@ -25618,10 +25618,10 @@
           },
           "service_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "service_type": {
             "type": "string",
@@ -25759,7 +25759,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
@@ -25789,7 +25789,7 @@
             "description": "The unique identifier for this service.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "service_type": {
             "type": "string",
@@ -25928,7 +25928,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
@@ -25958,7 +25958,7 @@
             "description": "The unique identifier for this service.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "service_type": {
             "type": "string",
@@ -26098,7 +26098,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
@@ -26129,7 +26129,7 @@
             "description": "The unique identifier for this service.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "service_type": {
             "type": "string",
@@ -26269,7 +26269,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
@@ -26301,7 +26301,7 @@
             "description": "The unique identifier for this service.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "service_type": {
             "type": "string",
@@ -26441,7 +26441,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
@@ -26473,7 +26473,7 @@
             "description": "The unique identifier for this service.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "service_type": {
             "type": "string",
@@ -26613,7 +26613,7 @@
               "type": "string",
               "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "minLength": 1,
-              "maxLength": 63
+              "maxLength": 36
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
@@ -26643,7 +26643,7 @@
             "description": "The unique identifier for this service.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "service_type": {
             "type": "string",
@@ -26938,10 +26938,10 @@
           },
           "database_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           },
           "node_name": {
             "type": "string",
@@ -27313,10 +27313,10 @@
           },
           "tenant_id": {
             "type": "string",
-            "description": "A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           }
         },
         "example": {
@@ -27403,7 +27403,7 @@
             "description": "Unique identifier for the database's owner.",
             "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "minLength": 1,
-            "maxLength": 63
+            "maxLength": 36
           }
         },
         "example": {

--- a/api/apiv1/gen/http/openapi3.yaml
+++ b/api/apiv1/gen/http/openapi3.yaml
@@ -159,10 +159,10 @@ paths:
           allowEmptyValue: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           examples:
             Human-readable:
               summary: Human-readable
@@ -878,10 +878,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
       responses:
         "200":
@@ -955,10 +955,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
       responses:
         "200":
@@ -1159,10 +1159,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
       requestBody:
         required: true
@@ -1413,10 +1413,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: 68f50878-44d2-4524-a823-e31bd478706d
         - name: instance_id
           in: path
@@ -1424,10 +1424,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
       requestBody:
         required: true
@@ -1532,10 +1532,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: 68f50878-44d2-4524-a823-e31bd478706d
         - name: instance_id
           in: path
@@ -1543,10 +1543,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
       responses:
         "200":
@@ -1635,10 +1635,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: 68f50878-44d2-4524-a823-e31bd478706d
         - name: instance_id
           in: path
@@ -1646,10 +1646,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
       responses:
         "200":
@@ -1738,10 +1738,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
         - name: node_name
           in: path
@@ -1847,10 +1847,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
         - name: node_name
           in: path
@@ -1944,10 +1944,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
         - name: node_name
           in: path
@@ -2051,10 +2051,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
       requestBody:
         required: true
@@ -2323,10 +2323,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
       responses:
         "200":
@@ -2429,10 +2429,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
         - name: task_id
           in: path
@@ -2519,10 +2519,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: abc123
         - name: task_id
           in: path
@@ -2530,10 +2530,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: def456
       responses:
         "200":
@@ -2621,10 +2621,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
         - name: task_id
           in: path
@@ -2932,10 +2932,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: host-1
       responses:
         "200":
@@ -3045,10 +3045,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: host-1
       responses:
         "200":
@@ -3187,10 +3187,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: host-1
       responses:
         "200":
@@ -3268,10 +3268,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: host-1
         - name: task_id
           in: path
@@ -3378,10 +3378,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: host-1
         - name: task_id
           in: path
@@ -3552,10 +3552,10 @@ paths:
           allowEmptyValue: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           example: my-app
         - name: after_task_id
           in: query
@@ -3980,10 +3980,10 @@ components:
           maxLength: 1024
         id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         retention_full:
           type: integer
           description: The count of full backups to retain or the time to retain full backups.
@@ -4092,16 +4092,16 @@ components:
       properties:
         database_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         task_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
       example:
         database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
         task_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -4212,10 +4212,10 @@ components:
                   spock_version: "5"
         id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         status:
           $ref: '#/components/schemas/ClusterStatus'
       example:
@@ -4412,10 +4412,10 @@ components:
           example: true
         host_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         token:
           type: string
           description: Token to join the cluster.
@@ -4500,18 +4500,18 @@ components:
       properties:
         id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         spec:
           $ref: '#/components/schemas/DatabaseSpec'
         tenant_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
       example:
         id: storefront
         spec:
@@ -4546,7 +4546,7 @@ components:
           description: Unique identifier for the database.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         spec:
           $ref: '#/components/schemas/DatabaseSpec2'
         tenant_id:
@@ -4554,7 +4554,7 @@ components:
           description: Unique identifier for the database's owner.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
       example:
         id: storefront
         spec:
@@ -4677,10 +4677,10 @@ components:
           format: date-time
         id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         instances:
           type: array
           items:
@@ -4857,10 +4857,10 @@ components:
             - unknown
         tenant_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         updated_at:
           type: string
           description: The time that the database was last updated.
@@ -4989,7 +4989,7 @@ components:
           description: Unique identifier for the database.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         instances:
           type: array
           items:
@@ -5250,7 +5250,7 @@ components:
           description: Unique identifier for the database's owner.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         updated_at:
           type: string
           description: The time that the database was last updated.
@@ -5379,7 +5379,7 @@ components:
           description: Unique identifier for the database.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         instances:
           type: array
           items:
@@ -5574,7 +5574,7 @@ components:
           description: Unique identifier for the database's owner.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         updated_at:
           type: string
           description: The time that the database was last updated.
@@ -5703,7 +5703,7 @@ components:
           description: Unique identifier for the database.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         instances:
           type: array
           items:
@@ -5996,7 +5996,7 @@ components:
           description: Unique identifier for the database's owner.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         updated_at:
           type: string
           description: The time that the database was last updated.
@@ -6125,7 +6125,7 @@ components:
           description: Unique identifier for the database.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         instances:
           type: array
           items:
@@ -6352,7 +6352,7 @@ components:
           description: Unique identifier for the database's owner.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         updated_at:
           type: string
           description: The time that the database was last updated.
@@ -6510,10 +6510,10 @@ components:
           type: array
           items:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
             - de3b1388-1f0c-42f1-a86c-59ab72f255ec
@@ -6702,7 +6702,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -6913,7 +6913,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -7125,7 +7125,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -7335,7 +7335,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -7546,7 +7546,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -7756,7 +7756,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -15324,10 +15324,10 @@ components:
           format: date-time
         id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         instances:
           type: array
           items:
@@ -15437,10 +15437,10 @@ components:
             - unknown
         tenant_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         updated_at:
           type: string
           description: The time that the database was last updated.
@@ -15734,10 +15734,10 @@ components:
           example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
         database_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         node_name:
           type: string
           description: Name of the node to initiate the failover from.
@@ -15847,10 +15847,10 @@ components:
             - client
         id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         memory:
           type: string
           description: The amount of memory available on this host.
@@ -16030,10 +16030,10 @@ components:
       properties:
         cluster_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
       description: Request to initialize a cluster
       example:
         cluster_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -17310,10 +17310,10 @@ components:
             example: Dolor autem eum.
         source_database_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         source_database_name:
           type: string
           description: The name of the database in this repository. The database will be renamed to the database_name in the DatabaseSpec after it's restored.
@@ -17798,10 +17798,10 @@ components:
           maxLength: 1024
         id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         s3_bucket:
           type: string
           description: The S3 bucket name for this repository. Only applies when type = 's3'.
@@ -17884,10 +17884,10 @@ components:
           format: date-time
         database_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         error:
           type: string
           description: An error message if the service instance is in an error state.
@@ -18058,10 +18058,10 @@ components:
           type: array
           items:
             type: string
-            description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
             - de3b1388-1f0c-42f1-a86c-59ab72f255ec
@@ -18083,10 +18083,10 @@ components:
           maximum: 65535
         service_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         service_type:
           type: string
           description: The type of service to run.
@@ -18184,7 +18184,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -18208,7 +18208,7 @@ components:
           description: The unique identifier for this service.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         service_type:
           type: string
           description: The type of service to run.
@@ -18307,7 +18307,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -18331,7 +18331,7 @@ components:
           description: The unique identifier for this service.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         service_type:
           type: string
           description: The type of service to run.
@@ -18431,7 +18431,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -18456,7 +18456,7 @@ components:
           description: The unique identifier for this service.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         service_type:
           type: string
           description: The type of service to run.
@@ -18556,7 +18556,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -18582,7 +18582,7 @@ components:
           description: The unique identifier for this service.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         service_type:
           type: string
           description: The type of service to run.
@@ -18682,7 +18682,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -18708,7 +18708,7 @@ components:
           description: The unique identifier for this service.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         service_type:
           type: string
           description: The type of service to run.
@@ -18808,7 +18808,7 @@ components:
             type: string
             example: 76f9b8c0-4958-11f0-a489-3bb29577c696
             minLength: 1
-            maxLength: 63
+            maxLength: 36
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
@@ -18832,7 +18832,7 @@ components:
           description: The unique identifier for this service.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         service_type:
           type: string
           description: The type of service to run.
@@ -19028,10 +19028,10 @@ components:
           example: 3c875a27-f6a6-4c1c-ba5f-6972fb1fc348
         database_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
         node_name:
           type: string
           description: Name of the node to initiate the switchover from (informational).
@@ -19311,10 +19311,10 @@ components:
           $ref: '#/components/schemas/DatabaseSpec'
         tenant_id:
           type: string
-          description: A user-specified identifier. Must be 1-63 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
       example:
         spec:
           database_name: storefront
@@ -19366,7 +19366,7 @@ components:
           description: Unique identifier for the database's owner.
           example: 76f9b8c0-4958-11f0-a489-3bb29577c696
           minLength: 1
-          maxLength: 63
+          maxLength: 36
       example:
         spec:
           database_name: storefront

--- a/server/internal/api/apiv1/convert.go
+++ b/server/internal/api/apiv1/convert.go
@@ -765,7 +765,7 @@ func apiToDatabaseSpec(
 		}
 		tenantID = &t
 	}
-	if err := validateDatabaseSpec(orchestrator, apiSpec); err != nil {
+	if err := validateDatabaseSpec(orchestrator, databaseID, apiSpec); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -64,7 +64,7 @@ func appendPath(path []string, new ...string) []string {
 	return append(slices.Clone(path), new...)
 }
 
-func validateDatabaseSpec(orchestrator config.Orchestrator, spec *api.DatabaseSpec) error {
+func validateDatabaseSpec(orchestrator config.Orchestrator, databaseID string, spec *api.DatabaseSpec) error {
 	var errs []error
 
 	errs = append(errs, validateCPUs(spec.Cpus, []string{"cpus"})...)
@@ -157,7 +157,7 @@ func validateDatabaseSpec(orchestrator config.Orchestrator, spec *api.DatabaseSp
 			seenServiceIDs.Add(string(svc.ServiceID))
 
 			errs = append(errs, validateServicePortConflicts(svc, svcPath, portOwner)...)
-			errs = append(errs, validateServiceSpec(svc, svcPath, false, spec.DatabaseUsers, seenNodeNames)...)
+			errs = append(errs, validateServiceSpec(svc, svcPath, false, databaseID, spec.DatabaseUsers, seenNodeNames)...)
 		}
 	}
 
@@ -225,7 +225,7 @@ func validateDatabaseUpdate(old *database.Spec, new *api.DatabaseSpec) error {
 		isExistingService := existingServiceIDs.Has(string(svc.ServiceID))
 
 		errs = append(errs, validateServicePortConflicts(svc, svcPath, portOwner)...)
-		errs = append(errs, validateServiceSpec(svc, svcPath, isExistingService, new.DatabaseUsers, newNodeNames)...)
+		errs = append(errs, validateServiceSpec(svc, svcPath, isExistingService, old.DatabaseID, new.DatabaseUsers, newNodeNames)...)
 	}
 
 	return errors.Join(errs...)
@@ -312,12 +312,18 @@ func validateNode(
 	return errs
 }
 
-func validateServiceSpec(svc *api.ServiceSpec, path []string, isUpdate bool, dbUsers []*api.DatabaseUserSpec, nodeNames ...ds.Set[string]) []error {
+func validateServiceSpec(svc *api.ServiceSpec, path []string, isUpdate bool, databaseID string, dbUsers []*api.DatabaseUserSpec, nodeNames ...ds.Set[string]) []error {
 	var errs []error
 
 	// Validate service_id
 	serviceIDPath := appendPath(path, "service_id")
 	errs = append(errs, validateIdentifier(string(svc.ServiceID), serviceIDPath))
+
+	// Enforce Docker Swarm service name budget: "{databaseID}-{serviceID}-{8charHash}" must be ≤63 chars.
+	if len(databaseID)+len(string(svc.ServiceID)) > 53 {
+		err := fmt.Errorf("database ID and service ID combined must not exceed 53 characters (got %d)", len(databaseID)+len(string(svc.ServiceID)))
+		errs = append(errs, newValidationError(err, serviceIDPath))
+	}
 
 	// Validate service_type allowlist
 	supportedServiceTypes := []string{"mcp", "postgrest", "rag"}

--- a/server/internal/api/apiv1/validate_test.go
+++ b/server/internal/api/apiv1/validate_test.go
@@ -1270,7 +1270,7 @@ func TestValidateDatabaseSpec(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateDatabaseSpec(config.OrchestratorSwarm, tc.spec)
+			err := validateDatabaseSpec(config.OrchestratorSwarm, "test-db", tc.spec)
 			if len(tc.expected) < 1 {
 				assert.NoError(t, err)
 			} else {
@@ -1867,7 +1867,7 @@ func TestValidateServiceSpec(t *testing.T) {
 			testDBUsers := []*api.DatabaseUserSpec{
 				{Username: "app", DbOwner: utils.PointerTo(true)},
 			}
-			err := errors.Join(validateServiceSpec(tc.svc, nil, false, testDBUsers)...)
+			err := errors.Join(validateServiceSpec(tc.svc, nil, false, "test-db", testDBUsers)...)
 			if len(tc.expected) < 1 {
 				assert.NoError(t, err)
 			} else {
@@ -1877,6 +1877,37 @@ func TestValidateServiceSpec(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateServiceSpec_NameBudget(t *testing.T) {
+	testDBUsers := []*api.DatabaseUserSpec{
+		{Username: "app", DbOwner: utils.PointerTo(true)},
+	}
+	baseSvc := func(serviceID string) *api.ServiceSpec {
+		return &api.ServiceSpec{
+			ServiceID:   api.Identifier(serviceID),
+			ServiceType: "mcp",
+			Version:     "latest",
+			HostIds:     []api.Identifier{"host-1"},
+			ConnectAs:   "app",
+			Config:      map[string]any{},
+		}
+	}
+
+	// 26-char DB ID + 27-char service ID = 53 (at the limit, valid)
+	dbID26 := "abcdefghijklmnopqrstuvwxyz"           // 26 chars
+	svcID27 := "svc-aaaaaaaaaaaaaaaaaaaaaaa"          // 27 chars
+	err := errors.Join(validateServiceSpec(baseSvc(svcID27), nil, false, dbID26, testDBUsers)...)
+	assert.NoError(t, err, "combined length of 53 should be valid")
+
+	// 27-char DB ID + 27-char service ID = 54 (one over the limit, invalid)
+	dbID27 := "abcdefghijklmnopqrstuvwxyz1"          // 27 chars
+	err = errors.Join(validateServiceSpec(baseSvc(svcID27), nil, false, dbID27, testDBUsers)...)
+	assert.ErrorContains(t, err, "database ID and service ID combined must not exceed 53 characters (got 54)")
+
+	// Short IDs well within budget
+	err = errors.Join(validateServiceSpec(baseSvc("my-svc"), nil, false, "my-db", testDBUsers)...)
+	assert.NoError(t, err, "short IDs should always be valid")
 }
 
 func TestValidateDatabaseConnection(t *testing.T) {
@@ -1984,7 +2015,7 @@ func TestValidateServiceSpec_DatabaseConnectionCrossValidation(t *testing.T) {
 				TargetSessionAttrs: utils.PointerTo("prefer-standby"),
 			},
 		}
-		err := errors.Join(validateServiceSpec(svc, nil, false, testDBUsers, nodeNames)...)
+		err := errors.Join(validateServiceSpec(svc, nil, false, "test-db", testDBUsers, nodeNames)...)
 		assert.ErrorContains(t, err, "allow_writes requires target_session_attrs 'primary' or 'read-write'")
 	})
 
@@ -2006,7 +2037,7 @@ func TestValidateServiceSpec_DatabaseConnectionCrossValidation(t *testing.T) {
 				TargetSessionAttrs: utils.PointerTo("primary"),
 			},
 		}
-		err := errors.Join(validateServiceSpec(svc, nil, false, testDBUsers, nodeNames)...)
+		err := errors.Join(validateServiceSpec(svc, nil, false, "test-db", testDBUsers, nodeNames)...)
 		assert.NoError(t, err)
 	})
 
@@ -2027,7 +2058,7 @@ func TestValidateServiceSpec_DatabaseConnectionCrossValidation(t *testing.T) {
 				TargetNodes: []string{"n1", "nonexistent"},
 			},
 		}
-		err := errors.Join(validateServiceSpec(svc, nil, false, testDBUsers, nodeNames)...)
+		err := errors.Join(validateServiceSpec(svc, nil, false, "test-db", testDBUsers, nodeNames)...)
 		assert.ErrorContains(t, err, `node "nonexistent" does not exist in the database spec`)
 	})
 }

--- a/server/internal/utils/utils.go
+++ b/server/internal/utils/utils.go
@@ -127,7 +127,7 @@ func BuildOptionArgs(options map[string]string) []string {
 }
 
 var idPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,34}[a-z0-9])?$`)
-var ErrInvalidIdentifier = errors.New(`valid IDs must be 1-36 characters long, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain two consecutive hyphens`)
+var ErrInvalidIdentifier = errors.New(`valid IDs must be 1-36 characters long, contain only lowercase letters, digits, and hyphens, start and end with a letter or digit, and not contain two consecutive hyphens`)
 
 func ValidateID(value string) error {
 	if !idPattern.MatchString(value) || strings.Contains(value, "--") {

--- a/server/internal/utils/utils.go
+++ b/server/internal/utils/utils.go
@@ -126,8 +126,8 @@ func BuildOptionArgs(options map[string]string) []string {
 	return res
 }
 
-var idPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$`)
-var ErrInvalidIdentifier = errors.New(`valid IDs must be 1-63 characters long, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain two consecutive hyphens`)
+var idPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,34}[a-z0-9])?$`)
+var ErrInvalidIdentifier = errors.New(`valid IDs must be 1-36 characters long, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain two consecutive hyphens`)
 
 func ValidateID(value string) error {
 	if !idPattern.MatchString(value) || strings.Contains(value, "--") {

--- a/server/internal/utils/utils_test.go
+++ b/server/internal/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -64,6 +65,45 @@ func TestBuildOptionArgs(t *testing.T) {
 			actual := BuildOptionArgs(tt.input)
 			if !reflect.DeepEqual(sortStrings(actual), sortStrings(tt.expected)) {
 				t.Errorf("got %v, want %v", actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateID(t *testing.T) {
+	valid := []string{
+		"a",                                    // single char
+		"ab",                                   // two chars
+		"my-db",                                // typical short ID
+		"production",                           // letters only
+		"db-1",                                 // trailing digit
+		"1-db",                                 // leading digit
+		"abcdefghijklmnopqrstuvwxyz1234567890", // 36 chars (max)
+		"76f9b8c0-4958-11f0-a489-3bb29577c696", // UUID (36 chars)
+	}
+	for _, id := range valid {
+		t.Run("valid/"+id, func(t *testing.T) {
+			if err := ValidateID(id); err != nil {
+				t.Errorf("ValidateID(%q) = %v, want nil", id, err)
+			}
+		})
+	}
+
+	invalid := []string{
+		"",                                      // empty
+		strings.Repeat("a", 37),                 // 37 chars (one over max)
+		"UPPERCASE",                             // uppercase letters
+		"-leading-hyphen",                       // leading hyphen
+		"trailing-hyphen-",                      // trailing hyphen
+		"double--hyphen",                        // consecutive hyphens
+		"has spaces",                            // spaces
+		"has.dot",                               // dots
+		"has_underscore",                        // underscores
+	}
+	for _, id := range invalid {
+		t.Run("invalid/"+id, func(t *testing.T) {
+			if err := ValidateID(id); err == nil {
+				t.Errorf("ValidateID(%q) = nil, want error", id)
 			}
 		})
 	}


### PR DESCRIPTION

Docker Swarm rejects service names longer than 63 characters.
`ServiceInstanceName` produces `{databaseID}-{serviceID}-{8charHash}`,
consuming 10 characters of that budget, leaving 53 for the two IDs
combined. Previously there was no guard — oversized IDs passed API
validation, entered the workflow, and failed deep in the orchestrator
with an opaque Docker error.

Two constraints are now enforced at the API validation layer:

- `Identifier` max length tightened from 63 → 36 characters (regex,
  Goa design, and error message all updated).
- Cross-field budget check added to `validateServiceSpec`:
  `len(databaseID) + len(serviceID)` must be ≤ 53. Applies to both
  `create-database` and `update-database`.

New tests: `TestValidateID` covers the 36-char boundary and all
invalid formats; `TestValidateServiceSpec_NameBudget` covers the
combined budget at, below, and above the limit.

[PLAT-562](https://pgedge.atlassian.net/browse/PLAT-562)

## Summary

Docker Swarm enforces a 63-character limit on service names. Because
service names are generated as `{databaseID}-{serviceID}-{8charHash}`,
the combined budget for the two IDs is 53 characters. This PR adds
validation that catches oversized IDs at the API layer before any
workflow starts, replacing a silent orchestrator failure with a clear
400 error.

## Changes

- `Identifier` max length tightened from 63 → 36 characters — regex
  pattern, Goa design type, and error message all updated; Goa code
  regenerated
- `validateServiceSpec` now receives `databaseID` and rejects requests
  where `len(databaseID) + len(serviceID) > 53`
- `validateDatabaseSpec` and `validateDatabaseUpdate` updated to pass
  the database ID through to `validateServiceSpec`

## Testing

```bash
# Unit tests
go test ./server/internal/api/apiv1/... -run TestValidateServiceSpec_NameBudget -v
go test ./server/internal/utils/... -run TestValidateID -v

**# Full suite
go test ./...**

```
- Test 1 — DB ID > 36 chars rejected → HTTP 400
- Test 2 — Service ID > 36 chars rejected → HTTP 400
- Test 3 — Combined > 53 rejected (each valid alone) → HTTP 400
- Test 4 — Combined exactly 53 accepted → HTTP 200
- Test 5 — Short IDs regression check → HTTP 200
- Test 6a — update-database budget overflow rejected → HTTP 400
- Test 6b — update-database within budget accepted → HTTP 200
- Test 7a — UUID DB ID + short service ID accepted → HTTP 200
- Test 7b — UUID DB ID + long service ID rejected → HTTP 400

[PLAT-562]: https://pgedge.atlassian.net/browse/PLAT-562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ