### PR TITLE
fix: embedded etcd should only connect to self

### DIFF
--- a/clustertest/add_remove_host_test.go
+++ b/clustertest/add_remove_host_test.go
@@ -3,6 +3,7 @@
 package clustertest
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -197,4 +198,26 @@ func TestForcedHostRemovalWithDatabase(t *testing.T) {
 	require.NoError(t, err, "database deletion task failed")
 
 	tLog(t, "test completed successfully")
+}
+
+func TestRollingAddRemove(t *testing.T) {
+	// Regression test for PLAT-581
+	t.Parallel()
+
+	// Initialize a four-host cluster, then remove host-1, and add another host.
+	// The order of adds is important because this bug originates in the
+	// endpoint list for host-2+, so we add each host individually.
+	cluster := NewCluster(t, ClusterConfig{
+		Hosts: []HostConfig{
+			{ID: "host-1"},
+		},
+	})
+	cluster.Init(t)
+	for i := 2; i <= 4; i++ {
+		cluster.Add(t, HostConfig{ID: fmt.Sprintf("host-%d", i)})
+		cluster.Init(t)
+	}
+	cluster.Remove(t, "host-1")
+	cluster.Add(t, HostConfig{ID: "host-5"})
+	cluster.Init(t)
 }

--- a/clustertest/cluster_test.go
+++ b/clustertest/cluster_test.go
@@ -101,6 +101,9 @@ func (c *Cluster) Add(t testing.TB, hostCfg HostConfig) {
 func (c *Cluster) Remove(t testing.TB, hostID string) {
 	t.Helper()
 
+	delete(c.hosts, hostID)
+	c.client = hostsClient(t, c.hosts)
+
 	resp, err := c.client.RemoveHost(t.Context(), &controlplane.RemoveHostPayload{
 		HostID: controlplane.Identifier(hostID),
 	})
@@ -114,9 +117,6 @@ func (c *Cluster) Remove(t testing.TB, hostID string) {
 		TaskID: resp.Task.TaskID,
 	})
 	require.NoError(t, err)
-
-	delete(c.hosts, hostID)
-	c.client = hostsClient(t, c.hosts)
 }
 
 // RefreshClient recreates the client with updated host configurations.

--- a/server/internal/etcd/embedded.go
+++ b/server/internal/etcd/embedded.go
@@ -409,7 +409,8 @@ func (e *EmbeddedEtcd) GetClient() (*clientv3.Client, error) {
 	}
 
 	cfg := e.cfg.Config()
-	clientCfg, err := clientConfig(cfg, e.logger, e.etcd.Server.Cluster().ClientURLs()...)
+	// We only want to connect to our own Etcd endpoint.
+	clientCfg, err := clientConfig(cfg, e.logger, e.ClientEndpoints()...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client config: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes a bug where the etcd clients in hosts with embedded etcd were configured to connect to all cluster members that existed when the client was initialized. The correct behavior is that hosts with embedded etcd should only connect to themselves. This was the original intent and functionality, but I changed it while implementing support for remote Etcd. I did a few different implementations of the remote Etcd feature before settling on the current one, and I think this was just an accidental inclusion from a different implementation of that feature.

PLAT-581

## Testing

This PR includes a cluster test for the issue:

```sh
# Using TEST_RERUN_FAILS in case the OS steals our ephemeral ports
make test-cluster TEST_RERUN_FAILS=2 CLUSTER_TEST_RUN=TestRollingAddRemove
```

To run the scenario by hand:

```sh
# start the servers in an uninitialized state
make dev-reset
make dev-watch

# join 4 hosts to the cluster
cp1-req init-cluster
cp2-req join-cluster $(cp1-req get-join-token)
cp3-req join-cluster $(cp1-req get-join-token)

# stop host-1
cp-docker-compose stop host-1

# remove host-1 - remember that this is asynchronous, so watch the logs for it to finish
cp2-req remove-host host-1

# add another host to the cluster
cp4-req join-cluster $(cp2-req get-join-token)
```

Note that our dev setup is slightly different than the scenario in the ticket and our cluster test because hosts 4-6 are in client mode. It still reproduces and validates the issue because the failure occurs in host-2.