### PR TITLE
refactor(clustertest): call init in add

### DIFF
--- a/clustertest/add_remove_host_test.go
+++ b/clustertest/add_remove_host_test.go
@@ -68,12 +68,10 @@ func TestJoin(t *testing.T) {
 	tLog(t, "adding an etcd server host")
 
 	cluster.Add(t, HostConfig{ID: "host-2"})
-	cluster.Init(t)
 
 	tLog(t, "adding an etcd client host")
 
 	cluster.Add(t, HostConfig{ID: "host-3", EtcdMode: EtcdModeClient})
-	cluster.Init(t)
 }
 
 func TestRemove(t *testing.T) {
@@ -215,9 +213,7 @@ func TestRollingAddRemove(t *testing.T) {
 	cluster.Init(t)
 	for i := 2; i <= 4; i++ {
 		cluster.Add(t, HostConfig{ID: fmt.Sprintf("host-%d", i)})
-		cluster.Init(t)
 	}
 	cluster.Remove(t, "host-1")
 	cluster.Add(t, HostConfig{ID: "host-5"})
-	cluster.Init(t)
 }

--- a/clustertest/cluster_test.go
+++ b/clustertest/cluster_test.go
@@ -96,6 +96,7 @@ func (c *Cluster) Add(t testing.TB, hostCfg HostConfig) {
 	host := NewHost(t, hostCfg)
 	c.hosts[host.id] = host
 	c.client = hostsClient(t, c.hosts)
+	c.Init(t)
 }
 
 func (c *Cluster) Remove(t testing.TB, hostID string) {


### PR DESCRIPTION
## Summary

Refactors these tests so that `Add` also calls `Init` after creating the new host. These are always called together, and it was confusing that `Add` didn't modify the cluster membership, given that `Remove` does modify it.
