### PR TITLE
chore: resolve ansible facts deprecation notice

### DIFF
--- a/e2e/fixtures/deploy_control_plane.yaml
+++ b/e2e/fixtures/deploy_control_plane.yaml
@@ -22,7 +22,7 @@
       file:
         path: /data/control-plane
         state: directory
-        owner: '{{ ansible_env.SUDO_USER }}'
+        owner: '{{ ansible_facts.env.SUDO_USER }}'
 
 - name: Build and deploy control-plane
   hosts: "{{ hostvars['localhost'].first_manager_host }}"

--- a/e2e/fixtures/roles/ec2_deploy/tasks/main.yaml
+++ b/e2e/fixtures/roles/ec2_deploy/tasks/main.yaml
@@ -8,7 +8,7 @@
 # Get the current region using the default credential chain
 - name: Get current region
   ansible.builtin.command: |
-    {{ ansible_playbook_python | default(ansible_python.executable) }}
+    {{ ansible_playbook_python | default(ansible_facts.python.executable) }}
     -c "import boto3; print(boto3.session.Session().region_name or '')"
   register: boto3_region
   changed_when: false

--- a/e2e/fixtures/roles/install_prerequisites/tasks/main.yaml
+++ b/e2e/fixtures/roles/install_prerequisites/tasks/main.yaml
@@ -34,7 +34,7 @@
     dest: /etc/systemd/system/docker.socket.d/override.conf
     content: |
       [Socket]
-      SocketUser={{ ansible_env.SUDO_USER }}
+      SocketUser={{ ansible_facts.env.SUDO_USER }}
 - name: Start and enable Docker
   systemd_service:
     name: docker

--- a/e2e/fixtures/setup_new_host.yaml
+++ b/e2e/fixtures/setup_new_host.yaml
@@ -25,12 +25,12 @@
       add_host:
         name: "{{ target_host }}"
         groups: new_host
-        ansible_ssh_common_args: "-F {{ ansible_env.HOME }}/.lima/{{ target_host }}/ssh.config"
+        ansible_ssh_common_args: "-F {{ ansible_facts.env.HOME }}/.lima/{{ target_host }}/ssh.config"
         ansible_host: "lima-{{ target_host }}"
       when: provider == 'lima'
 
     - name: Wait for SSH to be available
-      command: ssh -F {{ ansible_env.HOME }}/.lima/{{ target_host }}/ssh.config lima-{{ target_host }} echo ok
+      command: ssh -F {{ ansible_facts.env.HOME }}/.lima/{{ target_host }}/ssh.config lima-{{ target_host }} echo ok
       register: ssh_result
       until: ssh_result.rc == 0
       retries: 24

--- a/e2e/fixtures/teardown_control_plane.yaml
+++ b/e2e/fixtures/teardown_control_plane.yaml
@@ -27,7 +27,7 @@
       file:
         path: /data/control-plane
         state: absent
-        owner: '{{ ansible_env.SUDO_USER }}'
+        owner: '{{ ansible_facts.env.SUDO_USER }}'
 
 - name: Remove S3 repository data
   hosts: "{{ hostvars['localhost'].first_manager_host }}"

--- a/lima/roles/install_prerequisites/vars/main.yaml
+++ b/lima/roles/install_prerequisites/vars/main.yaml
@@ -5,8 +5,8 @@ _arch_transform:
   aarch64: arm64
   arm64: arm64
 etcd_version: v3.6.5
-etcd_archive_name: etcd-{{ etcd_version }}-linux-{{ _arch_transform[ansible_architecture] }}
+etcd_archive_name: etcd-{{ etcd_version }}-linux-{{ _arch_transform[ansible_facts.architecture] }}
 etcd_download_url: https://github.com/etcd-io/etcd/releases/download/{{ etcd_version }}/{{ etcd_archive_name }}.tar.gz
 go_version: 1.25.5
-go_archive_name: go{{ go_version }}.linux-{{ _arch_transform[ansible_architecture] }}.tar.gz
+go_archive_name: go{{ go_version }}.linux-{{ _arch_transform[ansible_facts.architecture] }}.tar.gz
 go_download_url: https://dl.google.com/go/{{ go_archive_name }}


### PR DESCRIPTION
## Summary

Ansible is deprecating the default setting that populates some ansible facts into top-level `ansible_` variables, such as `ansible_architecture`. This commit replaces our use of these variables with the `ansible_facts` equivalent.

## Testing

This no longer produces a deprecation notice on the latest versions of ansible:

```sh
make dev-lima-deploy
```
