### PR TITLE
fix: correct usage in server cmd

### DIFF
--- a/server/cmd/root.go
+++ b/server/cmd/root.go
@@ -41,7 +41,7 @@ var (
 
 func newRootCmd(i *do.Injector) *cobra.Command {
 	return &cobra.Command{
-		Use:   "control-plane",
+		Use:   "pgedge-control-plane",
 		Short: "pgEdge control plane server",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true


### PR DESCRIPTION
## Summary

We've renamed the control plane server binary to `pgedge-control-plane`. This commit fixes the usage information that you get from the server's inline help.

## Testing

```sh
# this changes the 'Usage' section in the inline help to say pgedge-control-plane:
go run ./server --help
```
