### PR TITLE
docs: promote Supporting Services to GA and fix mkdocs warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ dev-down:
 
 .PHONY: dev-reset
 dev-reset: dev-down
-	# remove postgres and supported services
+	# remove postgres and supporting services
 	ids=$$(docker service ls -q); \
 	if [ -n "$$ids" ]; then \
 		echo "$$ids" \

--- a/changes/unreleased/Changed-20260501-104640.yaml
+++ b/changes/unreleased/Changed-20260501-104640.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Promote Supporting Services from beta to generally available
+time: 2026-05-01T10:46:40.2527-05:00

--- a/docs/development/running-locally.md
+++ b/docs/development/running-locally.md
@@ -1,32 +1,5 @@
 # Running the Control Plane locally
 
-- [Running the Control Plane locally](#running-the-control-plane-locally)
-  - [Common prerequisites](#common-prerequisites)
-  - [Developing the Swarm orchestrator](#developing-the-swarm-orchestrator)
-    - [Prerequisites](#prerequisites)
-      - [Configuration](#configuration)
-    - [Running the Control Plane](#running-the-control-plane)
-    - [Interact with the Control Plane API](#interact-with-the-control-plane-api)
-    - [Resetting your Development Environment](#resetting-your-development-environment)
-    - [Development Workflow](#development-workflow)
-      - [Rebuilding the `pgedge-control-plane` binary](#rebuilding-the-pgedge-control-plane-binary)
-      - [Debugging](#debugging)
-    - [API Documentation](#api-documentation)
-  - [Optional Development Tools](#optional-development-tools)
-    - [Restish](#restish)
-    - [`dev-env.zsh` Script](#dev-envzsh-script)
-    - [Bruno](#bruno)
-      - [Bruno's `wait_for_task` Helper](#brunos-wait_for_task-helper)
-      - [When Should I Add to the Test Scenarios?](#when-should-i-add-to-the-test-scenarios)
-  - [Developing the SystemD orchestrator](#developing-the-systemd-orchestrator)
-    - [Prerequisites](#prerequisites-1)
-      - [`pipx`](#pipx)
-      - [Circus](#circus)
-      - [Ansible](#ansible)
-      - [Lima](#lima)
-    - [Running the Control Plane](#running-the-control-plane-1)
-    - [Resetting your Development Environment](#resetting-your-development-environment-1)
-
 ## Common prerequisites
 
 - Go >= 1.25

--- a/docs/development/supported-services.md
+++ b/docs/development/supported-services.md
@@ -1,6 +1,6 @@
-# Adding a Supported Service
+# Adding a Supporting Service
 
-This guide explains how to add a new supported service type to the control plane.
+This guide explains how to add a new supporting service type to the control plane.
 MCP is the reference implementation throughout. All touch points are summarized in
 the [checklist](#checklist-adding-a-new-service-type) at the end.
 
@@ -15,7 +15,7 @@ the [checklist](#checklist-adding-a-new-service-type) at the end.
 
 ## Overview
 
-A supported service is a containerized application deployed alongside a pgEdge
+A supporting service is a containerized application deployed alongside a pgEdge
 database. Services are declared in `DatabaseSpec.Services`, provisioned after
 the database is available, and deleted when the database is deleted.
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,10 +1,11 @@
-# Supporting Services (Beta)
+# Supporting Services
 
 The pgEdge Control Plane lets you run services alongside your databases.
 A supporting service is an application that attaches to a database,
 runs on any host in the cluster, and connects using a database user you
-specify with the `connect_as` field. The Control Plane supports the
-following service types:
+specify with the `connect_as` field.
+
+The Control Plane supports the following service types:
 
 - The [pgEdge Postgres MCP Server](mcp.md) connects AI agents and
   LLM-powered applications to your database.
@@ -14,6 +15,10 @@ following service types:
 - [PostgREST](postgrest.md) automatically generates a REST API from
   your PostgreSQL schema, making your data accessible over HTTP without
   writing backend code.
+
+> [!NOTE]
+> Supporting Services are not yet supported on systemd clusters; support is
+> coming in a subsequent release.
 
 ## Service Instances
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,10 +79,12 @@ nav:
       - Managing Database Instances: using/database-instances.md
       - Deleting a Database: using/delete-db.md
       - Migrating a Database: using/migrate-db.md
-  - Supporting Services (Beta):
+  - Supporting Services:
       - Overview: services/index.md
       - Managing Services: services/managing.md
       - pgEdge Postgres MCP Server: services/mcp.md
+      - pgEdge RAG Server: services/rag.md
+      - PostgREST: services/postgrest.md
   - Troubleshooting:
       - Recovering a Control Plane Cluster: disaster-recovery/disaster-recovery.md
   - API:
@@ -91,5 +93,7 @@ nav:
   - Development:
       - Development Process: development/development.md
       - Automated End-to-End tests: development/e2e-tests.md
+      - Cluster Integration Tests: development/cluster-tests.md
+      - Adding a Supporting Service: development/supported-services.md
       - Running Locally: development/running-locally.md
   - Control Plane Release Notes: changelog.md


### PR DESCRIPTION
## Summary

- Remove "(Beta)" label from Supporting Services nav and heading
- Add pgEdge RAG Server, PostgREST, cluster tests, and supporting
  service dev guide to mkdocs nav
- Remove manual TOC from running-locally.md that had broken anchors
- Add note that Supporting Services are not yet available on systemd
- Rename "supported service" to "supporting service" in dev guide
- Add changelog entry for Supporting Services promotion