### PR TITLE
fix: remove db_owner requirement for allow_writes on MCP

### DIFF
--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -414,15 +414,6 @@ func validateConnectAs(svc *api.ServiceSpec, dbUsers []*api.DatabaseUserSpec, pa
 
 	for _, u := range dbUsers {
 		if u.Username == svc.ConnectAs {
-			// For MCP with allow_writes, the connect_as user must be the db owner
-			if svc.ServiceType == "mcp" {
-				if allowWrites, ok := svc.Config["allow_writes"].(bool); ok && allowWrites {
-					if u.DbOwner == nil || !*u.DbOwner {
-						err := errors.New("allow_writes requires connect_as to reference a database_users entry with db_owner: true")
-						return []error{newValidationError(err, connectAsPath)}
-					}
-				}
-			}
 			return nil
 		}
 	}

--- a/server/internal/api/apiv1/validate_test.go
+++ b/server/internal/api/apiv1/validate_test.go
@@ -2100,8 +2100,7 @@ func TestValidateConnectAs(t *testing.T) {
 
 	t.Run("non-owner with allow_writes", func(t *testing.T) {
 		errs := validateConnectAs(baseSvc("app_read_only", true), dbUsers, nil)
-		assert.Len(t, errs, 1)
-		assert.ErrorContains(t, errs[0], "allow_writes requires connect_as to reference a database_users entry with db_owner: true")
+		assert.Empty(t, errs)
 	})
 
 	t.Run("empty connect_as", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR removes the validation that required `connect_as` to reference a `db_owner: true` user when `allow_writes: true` is set on an MCP service. PostgreSQL enforces write permissions at query time — the control plane check was redundant and blocked valid configurations.

## Changes

- Remove `db_owner` enforcement in `validateConnectAs()` for MCP `allow_writes`
- Update test to assert no validation error for non-owner with `allow_writes: true`

## Testing
Verification:
Before Fix:
```
curl -s -X POST http://localhost:3000/v1/databases \    
  -H "Content-Type: application/json" -d '{
  "id": "storefront",
  "spec": {
    "database_name": "storefront",
    "database_users": [
      {
        "username": "admin",
        "password": "password",
        "attributes": ["SUPERUSER", "LOGIN"]
      }
    ],
    "port": 0,
    "nodes": [
      { "name": "n1", "host_ids": ["host-1"] }
    ],
    "services": [
      {
        "service_id": "mcp-server",
        "service_type": "mcp",
        "version": "latest",
        "host_ids": ["host-1"],
        "port": 0,
        "connect_as": "admin",
        "config": {
          "allow_writes": true
        }
      }
    ]
  }
}'
```
```
{"name":"invalid_input","message":"services[0].connect_as: allow_writes requires connect_as to reference a database_users entry with db_owner: true"}
```

After Fix:
```
curl -s -X POST http://localhost:3000/v1/databases \
  -H "Content-Type: application/json" -d '{
  "id": "storefront",
  "spec": {
    "database_name": "storefront",
    "database_users": [
      {
        "username": "admin",
        "password": "password",
        "attributes": ["SUPERUSER", "LOGIN"]
      }
    ],
    "port": 0,
    "nodes": [
      { "name": "n1", "host_ids": ["host-1"] }
    ],
    "services": [
      {
        "service_id": "mcp-server",
        "service_type": "mcp",
        "version": "latest",
        "host_ids": ["host-1"],
        "port": 0,
        "connect_as": "admin",
        "config": {
          "allow_writes": true
        }
      }
    ]
  }
}'

```

```
{"task":{"scope":"database","entity_id":"storefront","database_id":"storefront","task_id":"019df438-da08-769a-a7e0-b30f14e28f2c","created_at":"2026-05-04T18:20:59Z","type":"create","status":"pending"},"database":{"id":"storefront","created_at":"2026-05-04T18:20:59Z","updated_at":"2026-05-04T18:20:59Z","state":"creating","spec":{"database_name":"storefront","postgres_version":"18.3","spock_version":"5","port":0,"nodes":[{"name":"n1","host_ids":["host-1"]}],"database_users":[{"username":"admin","db_owner":false,"attributes":["SUPERUSER","LOGIN"]}],"services":[{"service_id":"mcp-server","service_type":"mcp","version":"latest","host_ids":["host-1"],"port":0,"config":{"allow_writes":true},"connect_as":"admin"}]}}}
```
## Checklist

- [x] Tests added or updated 


[PLAT-587](https://pgedge.atlassian.net/browse/PLAT-587)


[PLAT-587]: https://pgedge.atlassian.net/browse/PLAT-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ