### PR TITLE
fix: send SIGHUP to MCP container after initial deploy

### DIFF
--- a/server/internal/orchestrator/swarm/mcp_config_resource.go
+++ b/server/internal/orchestrator/swarm/mcp_config_resource.go
@@ -258,7 +258,15 @@ func (r *MCPConfigResource) writeUserFileIfNeeded(fs afero.Fs, usersPath string)
 // running. It sends SIGHUP to trigger a config reload, handling VirtioFS
 // bind-mount propagation delays on initial provisioning.
 func (r *MCPConfigResource) PostDeploy(ctx context.Context, rc *resource.Context) {
-	_ = r.signalConfigReload(ctx, rc)
+	logger, err := do.Invoke[zerolog.Logger](rc.Injector)
+	if err != nil {
+		return
+	}
+	if err := r.signalConfigReload(ctx, rc); err != nil {
+		logger.Warn().Err(err).
+			Str("service_instance_id", r.ServiceInstanceID).
+			Msg("post-deploy config reload signal failed")
+	}
 }
 
 func (r *MCPConfigResource) signalConfigReload(ctx context.Context, rc *resource.Context) error {

--- a/server/internal/orchestrator/swarm/mcp_config_resource.go
+++ b/server/internal/orchestrator/swarm/mcp_config_resource.go
@@ -254,6 +254,13 @@ func (r *MCPConfigResource) writeUserFileIfNeeded(fs afero.Fs, usersPath string)
 // return nil — the config file is already correct on disk and will be
 // picked up on the next container restart. Injector failures are returned
 // as errors since they indicate a systemic problem.
+// PostDeploy is called by ServiceInstanceResource after the container is confirmed
+// running. It sends SIGHUP to trigger a config reload, handling VirtioFS
+// bind-mount propagation delays on initial provisioning.
+func (r *MCPConfigResource) PostDeploy(ctx context.Context, rc *resource.Context) {
+	_ = r.signalConfigReload(ctx, rc)
+}
+
 func (r *MCPConfigResource) signalConfigReload(ctx context.Context, rc *resource.Context) error {
 	dockerClient, err := do.Invoke[*docker.Docker](rc.Injector)
 	if err != nil {

--- a/server/internal/orchestrator/swarm/service_instance.go
+++ b/server/internal/orchestrator/swarm/service_instance.go
@@ -203,6 +203,8 @@ func (s *ServiceInstanceResource) deploy(ctx context.Context, rc *resource.Conte
 		Str("service_id", res.ServiceID).
 		Msg("service instance started successfully")
 
+	spec.PostDeploy(ctx, rc)
+
 	// Transition state to "running" immediately after successful deployment.
 	// This mirrors the database instance pattern where state is set
 	// deterministically within the resource activity, not deferred to the monitor.

--- a/server/internal/orchestrator/swarm/service_instance_spec.go
+++ b/server/internal/orchestrator/swarm/service_instance_spec.go
@@ -95,9 +95,14 @@ func (s *ServiceInstanceSpecResource) TypeDependencies() []resource.Type {
 func (s *ServiceInstanceSpecResource) PostDeploy(ctx context.Context, rc *resource.Context) {
 	switch s.ServiceSpec.ServiceType {
 	case "mcp":
-		if mcpCfg, err := resource.FromContext[*MCPConfigResource](rc, MCPConfigResourceIdentifier(s.ServiceInstanceID)); err == nil {
-			mcpCfg.PostDeploy(ctx, rc)
+		mcpCfg, err := resource.FromContext[*MCPConfigResource](rc, MCPConfigResourceIdentifier(s.ServiceInstanceID))
+		if err != nil {
+			log.Warn().Err(err).
+				Str("service_instance_id", s.ServiceInstanceID).
+				Msg("skipping MCP post-deploy hook: MCP config resource unavailable")
+			return
 		}
+		mcpCfg.PostDeploy(ctx, rc)
 	}
 }
 

--- a/server/internal/orchestrator/swarm/service_instance_spec.go
+++ b/server/internal/orchestrator/swarm/service_instance_spec.go
@@ -90,6 +90,17 @@ func (s *ServiceInstanceSpecResource) TypeDependencies() []resource.Type {
 	return nil
 }
 
+// PostDeploy is called by ServiceInstanceResource after the container is confirmed
+// running. Each service type can trigger any necessary post-start actions here.
+func (s *ServiceInstanceSpecResource) PostDeploy(ctx context.Context, rc *resource.Context) {
+	switch s.ServiceSpec.ServiceType {
+	case "mcp":
+		if mcpCfg, err := resource.FromContext[*MCPConfigResource](rc, MCPConfigResourceIdentifier(s.ServiceInstanceID)); err == nil {
+			mcpCfg.PostDeploy(ctx, rc)
+		}
+	}
+}
+
 func (s *ServiceInstanceSpecResource) Refresh(ctx context.Context, rc *resource.Context) error {
 	network, err := resource.FromContext[*Network](rc, NetworkResourceIdentifier(s.DatabaseNetworkID))
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR ensures that once the MCP container is confirmed running during initial provisioning, a `SIGHUP` signal is sent to trigger a config reload.

## Changes

- `service_instance.go` — call `spec.PostDeploy()` after `WaitForService()` 
- `service_instance_spec.go` — add `PostDeploy()` with a service-type switch
- `mcp_config_resource.go` — add public `PostDeploy()` that calls the existing `signalConfigReload()`

## Testing
Verification:
- Created DB and MCP service using below config
```
curl -s -X POST http://localhost:3000/v1/databases \
  -H "Content-Type: application/json" -d '{
  "id": "test-mcp-embed",
  "spec": {
    "database_name": "test_mcp_embed",
    "database_users": [
      {
        "username": "admin",
        "password": "password",
        "db_owner": true,
        "attributes": ["LOGIN", "SUPERUSER"]
      }
    ],
    "port": 0,
    "nodes": [
      { "name": "n1", "host_ids": ["host-1"] }
    ],
    "services": [
      {
        "service_id": "mcp-server",
        "service_type": "mcp",
        "version": "latest",
        "host_ids": ["host-1"],
        "port": 0,
        "connect_as": "admin",
        "config": {
          "embedding_provider": "openai",
          "embedding_model": "text-embedding-3-small",
          "embedding_api_key": "sk-proj-1"
        }
      }
    ]
  }
}'

```
- Confirmed from config.yaml that embedding.enabled: true (Enabled)
```
embedding:
  enabled: true
  provider: openai
  model: text-embedding-3-small
```

From logs confirmed that config reloaded:
```
Database configured: admin@:0/test_mcp_embed (per-session connections)
Received SIGHUP, reloading configuration...
Updated database configurations: 1 database(s)
Configuration reloaded successfully from /app/data/config.yaml
```
## Checklist

- [x] Tests no change and no existing tests failure

[PLAT-588](https://pgedge.atlassian.net/browse/PLAT-588)

[PLAT-588]: https://pgedge.atlassian.net/browse/PLAT-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ