### PR TITLE
feat: enable failsafe mode for single-host nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - **Breaking:** Database, host, cluster, and service identifiers are now validated to comply with RFC 1035 name requirements — IDs must be 1–36 characters, contain only lowercase letters, digits, and hyphens, and start and end with a letter or digit. The combined length of a database ID and service ID may not exceed 53 characters.
 - Removed the `pgedge_application` and `pgedge_application_read_only` built-in database roles — These roles are no longer created for new databases. The names are no longer reserved and may be used freely for custom database users.
 - Promote Supporting Services from beta to generally available
+- Enable Patroni's failsafe mode in single-host nodes to improve resilience in some Etcd outages. Failsafe mode is not enabled in nodes with more than one host.
 
 ### Fixed
 

--- a/changes/v0.8.0.md
+++ b/changes/v0.8.0.md
@@ -17,6 +17,7 @@
 - **Breaking:** Database, host, cluster, and service identifiers are now validated to comply with RFC 1035 name requirements — IDs must be 1–36 characters, contain only lowercase letters, digits, and hyphens, and start and end with a letter or digit. The combined length of a database ID and service ID may not exceed 53 characters.
 - Removed the `pgedge_application` and `pgedge_application_read_only` built-in database roles — These roles are no longer created for new databases. The names are no longer reserved and may be used freely for custom database users.
 - Promote Supporting Services from beta to generally available
+- Enable Patroni's failsafe mode in single-host nodes to improve resilience in some Etcd outages. Failsafe mode is not enabled in nodes with more than one host.
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@
 - **Breaking:** Database, host, cluster, and service identifiers are now validated to comply with RFC 1035 name requirements — IDs must be 1–36 characters, contain only lowercase letters, digits, and hyphens, and start and end with a letter or digit. The combined length of a database ID and service ID may not exceed 53 characters.
 - Removed the `pgedge_application` and `pgedge_application_read_only` built-in database roles — These roles are no longer created for new databases. The names are no longer reserved and may be used freely for custom database users.
 - Promote Supporting Services from beta to generally available
+- Enable Patroni's failsafe mode in single-host nodes to improve resilience in some Etcd outages. Failsafe mode is not enabled in nodes with more than one host.
 
 ### Fixed
 

--- a/server/internal/database/instance_resource.go
+++ b/server/internal/database/instance_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pgEdge/control-plane/server/internal/patroni"
 	"github.com/pgEdge/control-plane/server/internal/postgres"
 	"github.com/pgEdge/control-plane/server/internal/resource"
+	"github.com/pgEdge/control-plane/server/internal/utils"
 )
 
 var _ resource.Resource = (*InstanceResource)(nil)
@@ -190,7 +191,8 @@ func (r *InstanceResource) Paths(orchestrator Orchestrator) (InstancePaths, erro
 }
 
 func (r *InstanceResource) initializeInstance(ctx context.Context, rc *resource.Context) error {
-	primaryInstanceID, err := GetPrimaryInstanceID(ctx, r.patroniClient(), time.Minute)
+	patroniClient := r.patroniClient()
+	primaryInstanceID, err := GetPrimaryInstanceID(ctx, patroniClient, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -203,6 +205,15 @@ func (r *InstanceResource) initializeInstance(ctx context.Context, rc *resource.
 		}
 		// no other initialization needed on non-primary instances
 		return nil
+	}
+
+	// Enable failsafe mode if this instance is the only one in the node.
+	// Otherwise, disable it.
+	_, err = patroniClient.PatchDynamicConfig(ctx, &patroni.DynamicConfig{
+		FailsafeMode: utils.PointerTo(r.Spec.NodeSize == 1),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to configure failsafe mode: %w", err)
 	}
 
 	conn, err := r.Connection(ctx, rc, "postgres")

--- a/server/internal/database/spec.go
+++ b/server/internal/database/spec.go
@@ -541,6 +541,7 @@ type InstanceSpec struct {
 	RestoreConfig    *RestoreConfig    `json:"restore_config"`
 	PostgreSQLConf   map[string]any    `json:"postgresql_conf"`
 	ClusterSize      int               `json:"cluster_size"`
+	NodeSize         int               `json:"node_size"`
 	OrchestratorOpts *OrchestratorOpts `json:"orchestrator_opts,omitempty"`
 	InPlaceRestore   bool              `json:"in_place_restore,omitempty"`
 	AllHostIDs       []string          `json:"all_host_ids"` // All host IDs in the database
@@ -594,6 +595,7 @@ func (s *InstanceSpec) Clone() *InstanceSpec {
 		RestoreConfig:    s.RestoreConfig.Clone(),
 		PostgreSQLConf:   maps.Clone(s.PostgreSQLConf),
 		ClusterSize:      s.ClusterSize,
+		NodeSize:         s.NodeSize,
 		OrchestratorOpts: s.OrchestratorOpts.Clone(),
 		AllHostIDs:       slices.Clone(s.AllHostIDs),
 	}
@@ -648,6 +650,7 @@ func (s *Spec) NodeInstances() ([]*NodeInstances, error) {
 	clusterSize := len(s.Nodes)
 	nodes := make([]*NodeInstances, clusterSize)
 	for nodeIdx, node := range s.Nodes {
+		nodeSize := len(node.HostIDs)
 		nodeOrdinal, err := extractOrdinal(node.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract ordinal from node name: %w", err)
@@ -690,6 +693,7 @@ func (s *Spec) NodeInstances() ([]*NodeInstances, error) {
 				RestoreConfig:    effectiveRestore,
 				PostgreSQLConf:   overridableMapValue(s.PostgreSQLConf, node.PostgreSQLConf),
 				ClusterSize:      clusterSize,
+				NodeSize:         nodeSize,
 				OrchestratorOpts: overridableValue(s.OrchestratorOpts, node.OrchestratorOpts),
 				AllHostIDs:       allHostIDs,
 			}


### PR DESCRIPTION
## Summary

Patroni's failsafe mode prevents instances from entering read-only mode when they lose their connection to the DCS, as long as they can contact all other Patroni instances in the cluster. There could be edge cases to this behavior when there's more than one instance in the Patroni cluster; however, it's known to be safe if there's only one host in the cluster.

This commit enables failsafe mode when there's only a single host in the node (meaning the Patroni cluster only has a single instance) and disables it otherwise.

This change is backward-compatible and does not need a migration.

## Testing

```sh
# run the compose dev environment
make dev-watch

# then in another terminal, create a database with two nodes: one with two
# hosts and another with one host
cp1-req create-database <<EOF | cp-follow-task
{
  "id": "storefront",
  "spec": {
    "database_name": "storefront",
    "database_users": [
      {
        "username": "admin",
        "password": "password",
        "db_owner": true,
        "attributes": ["SUPERUSER", "LOGIN"]
      }
    ],
    "port": 0,
    "nodes": [
      { "name": "n1", "host_ids": ["host-1", "host-3"] },
      { "name": "n2", "host_ids": ["host-2"] }
    ]
  }
}
EOF

# in separate terminals, start connections to n1's primary and n2's instance using
# using the interactive prompts
cp-psql

# then, stop the control plane servers with ctrl+c

# wait a few seconds for Patroni to notice that it's lost its connection to Etcd
# then in your psql windows, query pg_is_in_recovery()
select pg_is_in_recovery();

# what you should see is that n1's primary entered recovery mode because it's
# configured with failsafe_mode: false
# n2's primary should _not_ have entered recovery mode and should still be
# writable because it only has a single host.
```

PLAT-545