### PR TITLE
feat: update images to Spock 5.0.7

### DIFF
--- a/changes/unreleased/Added-20260509-000000.yaml
+++ b/changes/unreleased/Added-20260509-000000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added support for Spock 5.0.7 on Postgres 16.13, 17.9, and 18.3.
+time: 2026-05-09T00:00:00.000000-00:00

--- a/e2e/whole_cluster_test.go
+++ b/e2e/whole_cluster_test.go
@@ -81,32 +81,30 @@ func TestWholeCluster(t *testing.T) {
 				continue
 			}
 
-			for instance := range db.GetInstances(WithNode(read.Name)) {
-				t.Logf("validating table on node %s, instance %s with role %s", read.Name, instance.ID, *instance.Postgres.Role)
+			t.Logf("validating table on node %s", read.Name)
 
-				readOpts := ConnectionOptions{
-					Instance: instance,
-					Username: username,
-					Password: password,
-				}
-				db.WithConnection(ctx, readOpts, t, func(conn *pgx.Conn) {
-					t.Log("waiting for replication to finish")
-
-					var synced bool
-					row := conn.QueryRow(ctx, "CALL spock.wait_for_sync_event(true, $1, $2::pg_lsn, 30);", write.Name, syncLSN)
-
-					require.NoError(t, row.Scan(&synced))
-					require.True(t, synced)
-
-					t.Log("selecting test data")
-
-					var actual string
-					row = conn.QueryRow(ctx, fmt.Sprintf(`SELECT data FROM %s WHERE id = 1;`, write.Name))
-
-					require.NoError(t, row.Scan(&actual))
-					require.Equal(t, "test", actual)
-				})
+			readOpts := ConnectionOptions{
+				Matcher:  And(WithNode(read.Name), WithRole("primary")),
+				Username: username,
+				Password: password,
 			}
+			db.WithConnection(ctx, readOpts, t, func(conn *pgx.Conn) {
+				t.Log("waiting for replication to finish")
+
+				var synced bool
+				row := conn.QueryRow(ctx, "CALL spock.wait_for_sync_event(true, $1, $2::pg_lsn, 30);", write.Name, syncLSN)
+
+				require.NoError(t, row.Scan(&synced))
+				require.True(t, synced)
+
+				t.Log("selecting test data")
+
+				var actual string
+				row = conn.QueryRow(ctx, fmt.Sprintf(`SELECT data FROM %s WHERE id = 1;`, write.Name))
+
+				require.NoError(t, row.Scan(&actual))
+				require.Equal(t, "test", actual)
+			})
 		}
 	}
 }

--- a/server/internal/orchestrator/swarm/images.go
+++ b/server/internal/orchestrator/swarm/images.go
@@ -36,7 +36,7 @@ func NewVersions(cfg config.Config) *Versions {
 	})
 
 	versions.addImage(ds.MustPgEdgeVersion("16.13", "5"), &Images{
-		PgEdgeImage: imageTag(cfg, "16.13-spock5.0.6-standard-1"),
+		PgEdgeImage: imageTag(cfg, "16.13-spock5.0.7-standard-1"),
 	})
 
 	// pg17
@@ -50,7 +50,7 @@ func NewVersions(cfg config.Config) *Versions {
 		PgEdgeImage: imageTag(cfg, "17.8-spock5.0.5-standard-1"),
 	})
 	versions.addImage(ds.MustPgEdgeVersion("17.9", "5"), &Images{
-		PgEdgeImage: imageTag(cfg, "17.9-spock5.0.6-standard-1"),
+		PgEdgeImage: imageTag(cfg, "17.9-spock5.0.7-standard-1"),
 	})
 
 	// pg18
@@ -64,7 +64,7 @@ func NewVersions(cfg config.Config) *Versions {
 		PgEdgeImage: imageTag(cfg, "18.2-spock5.0.5-standard-1"),
 	})
 	versions.addImage(ds.MustPgEdgeVersion("18.3", "5"), &Images{
-		PgEdgeImage: imageTag(cfg, "18.3-spock5.0.6-standard-1"),
+		PgEdgeImage: imageTag(cfg, "18.3-spock5.0.7-standard-1"),
 	})
 
 	versions.defaultVersion = ds.MustPgEdgeVersion("18.3", "5")


### PR DESCRIPTION
## Summary

This PR updates the pgEdge image tags for Postgres 16.13, 17.9, and 18.3 to use Spock 5.0.7, which includes native PG17+ logical slot failover support.

## Changes

- Update image tags for PG 16.13, 17.9, and 18.3 from spock5.0.6-standard-1 to spock5.0.7-standard-1

- Updated TestWholeCluster to call spock.wait_for_sync_event only on Patroni primaries, not hot standbys — Spock 5.0.7 tightened this behavior and correctly returns false on standbys where no Spock subscription runs

## Testing

- Updated tests

## Checklist

- [x] Tests added or updated 

[PLAT-572](https://pgedge.atlassian.net/browse/PLAT-572)

[PLAT-572]: https://pgedge.atlassian.net/browse/PLAT-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ