### PR TITLE
Add five new fields to `MCPServiceConfig` and `mcpKnownKeys` to support

### DIFF
--- a/docs/services/mcp.md
+++ b/docs/services/mcp.md
@@ -84,9 +84,10 @@ following table describes the embedding configuration fields:
 Knowledgebase support enables the `search_knowledgebase` tool to query
 a SQLite-backed knowledge base. The knowledge base file is staged on the
 host; the Control Plane bind-mounts it into the container read-only.
-Knowledgebase support is opt-in: when `kb_enabled` is `false` (the
-default), no KB file is required and no KB validation runs. Only
-`voyage` and `openai` are supported as embedding providers for the
+Knowledgebase support is opt-in. When `kb_enabled` is `false` (the
+default), no KB file is required — and any other `kb_*` fields present
+in the config are **rejected** by the validator, not silently ignored.
+Only `voyage` and `openai` are supported as embedding providers for the
 knowledgebase; Ollama support is planned for a future release.
 
 !!! warning
@@ -106,7 +107,7 @@ The following table describes the knowledgebase configuration fields:
 
 | Field                     | Type    | Description |
 |---------------------------|---------|-------------|
-| `kb_enabled`              | boolean | Set to `true` to enable knowledgebase search. When `false` (the default), all other `kb_*` fields are ignored and the `search_knowledgebase` tool operates without a KB. |
+| `kb_enabled`              | boolean | Set to `true` to enable knowledgebase search. When `false` (the default), any other `kb_*` fields in the config are **rejected** — they must be removed before the config is accepted. |
 | `kb_embedding_provider`   | string  | Embedding provider for the KB. One of: `voyage`, `openai`. Required when `kb_enabled` is `true`. |
 | `kb_embedding_model`      | string  | Embedding model for the KB (e.g., `voyage-3-lite`, `text-embedding-3-small`). Required when `kb_enabled` is `true`. |
 | `kb_embedding_api_key`    | string  | API key for the KB embedding provider. Required for `voyage` and `openai`. Scrubbed from API responses. |

--- a/docs/services/mcp.md
+++ b/docs/services/mcp.md
@@ -85,8 +85,8 @@ Knowledgebase support enables the `search_knowledgebase` tool to query
 a SQLite-backed knowledge base. The knowledge base file is staged on the
 host; the Control Plane bind-mounts it into the container read-only.
 Knowledgebase support is opt-in: when `kb_enabled` is `false` (the
-default), no KB file is required and no KB validation runs. For V1,
-only `voyage` and `openai` are supported as embedding providers for the
+default), no KB file is required and no KB validation runs. Only
+`voyage` and `openai` are supported as embedding providers for the
 knowledgebase; Ollama support is planned for a future release.
 
 !!! warning
@@ -110,7 +110,15 @@ The following table describes the knowledgebase configuration fields:
 | `kb_embedding_provider`   | string  | Embedding provider for the KB. One of: `voyage`, `openai`. Required when `kb_enabled` is `true`. |
 | `kb_embedding_model`      | string  | Embedding model for the KB (e.g., `voyage-3-lite`, `text-embedding-3-small`). Required when `kb_enabled` is `true`. |
 | `kb_embedding_api_key`    | string  | API key for the KB embedding provider. Required for `voyage` and `openai`. Scrubbed from API responses. |
-| `kb_database_host_path`   | string  | Full path to the KB SQLite file on the host. Defaults to `{data_dir}/kb/nla-kb.db`. |
+| `kb_database_host_path`   | string  | Full path to the KB SQLite file on the host. Defaults to `{data_dir}/kb/nla-kb.db`. Must be an absolute path. |
+
+!!! note
+
+    Changing any `kb_*` field (provider, model, credentials, or path)
+    requires a service redeploy — not just a config reload. SIGHUP only
+    reloads database connection settings and does not reinitialize the
+    knowledgebase. Use `update-database` to apply KB config changes; the
+    Control Plane will restart the container automatically.
 
 ### LLM Tuning
 

--- a/docs/services/mcp.md
+++ b/docs/services/mcp.md
@@ -79,6 +79,39 @@ following table describes the embedding configuration fields:
 | `embedding_model`      | string | The embedding model name (e.g., `voyage-3`, `text-embedding-3-small`, `nomic-embed-text`). Required when `embedding_provider` is set. |
 | `embedding_api_key`    | string | API key for the embedding provider. Required for `voyage` and `openai` providers. |
 
+### Knowledgebase
+
+Knowledgebase support enables the `search_knowledgebase` tool to query
+a SQLite-backed knowledge base. The knowledge base file is staged on the
+host; the Control Plane bind-mounts it into the container read-only.
+Knowledgebase support is opt-in: when `kb_enabled` is `false` (the
+default), no KB file is required and no KB validation runs. For V1,
+only `voyage` and `openai` are supported as embedding providers for the
+knowledgebase; Ollama support is planned for a future release.
+
+!!! warning
+
+    The Control Plane does not generate the knowledgebase SQLite file.
+    You must place the file on every host that will run an MCP service
+    instance **before** setting `kb_enabled: true`. If the file is
+    missing when the Control Plane attempts to deploy the service, the
+    deployment will be blocked with a clear error.
+
+    The default location is `{data_dir}/kb/nla-kb.db` (for example,
+    `/var/lib/pgedge-control-plane/kb/nla-kb.db`). Create the directory
+    and copy your file there, or use `kb_database_host_path` to specify
+    a custom path.
+
+The following table describes the knowledgebase configuration fields:
+
+| Field                     | Type    | Description |
+|---------------------------|---------|-------------|
+| `kb_enabled`              | boolean | Set to `true` to enable knowledgebase search. When `false` (the default), all other `kb_*` fields are ignored and the `search_knowledgebase` tool operates without a KB. |
+| `kb_embedding_provider`   | string  | Embedding provider for the KB. One of: `voyage`, `openai`. Required when `kb_enabled` is `true`. |
+| `kb_embedding_model`      | string  | Embedding model for the KB (e.g., `voyage-3-lite`, `text-embedding-3-small`). Required when `kb_enabled` is `true`. |
+| `kb_embedding_api_key`    | string  | API key for the KB embedding provider. Required for `voyage` and `openai`. Scrubbed from API responses. |
+| `kb_database_host_path`   | string  | Full path to the KB SQLite file on the host. Defaults to `{data_dir}/kb/nla-kb.db`. |
+
 ### LLM Tuning
 
 The LLM tuning fields control the behavior of the LLM proxy and are
@@ -332,6 +365,65 @@ to use a self-hosted Ollama server for both the LLM and embeddings:
             }
         }'
     ```
+
+### Knowledgebase Search (Voyage AI)
+
+In the following example, a `curl` command provisions an MCP service
+with knowledgebase support enabled, using Voyage AI as the embedding
+provider. Before provisioning, stage the knowledgebase file on every
+host that will run an MCP service instance:
+
+```sh
+sudo mkdir -p /var/lib/pgedge-control-plane/kb
+sudo cp /path/to/your/nla-kb.db /var/lib/pgedge-control-plane/kb/nla-kb.db
+```
+
+=== "curl"
+
+    ```sh
+    curl -X POST http://host-1:3000/v1/databases \
+        -H 'Content-Type: application/json' \
+        --data '{
+            "id": "example",
+            "spec": {
+                "database_name": "example",
+                "nodes": [
+                    { "name": "n1", "host_ids": ["host-1"] }
+                ],
+                "database_users": [
+                    {
+                        "username": "mcp_user",
+                        "password": "changeme",
+                        "db_owner": true,
+                        "attributes": ["LOGIN"]
+                    }
+                ],
+                "services": [
+                    {
+                        "service_id": "mcp-server",
+                        "service_type": "mcp",
+                        "version": "latest",
+                        "host_ids": ["host-1"],
+                        "port": 8080,
+                        "connect_as": "mcp_user",
+                        "config": {
+                            "kb_enabled": true,
+                            "kb_embedding_provider": "voyage",
+                            "kb_embedding_model": "voyage-3-lite",
+                            "kb_embedding_api_key": "pa-..."
+                        }
+                    }
+                ]
+            }
+        }'
+    ```
+
+To use a custom path for the knowledgebase file, add
+`kb_database_host_path` to the `config` object:
+
+```json
+"kb_database_host_path": "/data/kb/my-kb.db"
+```
 
 ## Connecting to the MCP Server
 

--- a/docs/services/mcp.md
+++ b/docs/services/mcp.md
@@ -93,6 +93,11 @@ knowledgebase; Ollama support is planned for a future release.
 !!! warning
 
     The Control Plane does not generate the knowledgebase SQLite file.
+    Download the `kb.db` file from the latest Knowledge Base release on
+    the [pgEdge Postgres MCP releases page](https://github.com/pgEdge/pgedge-postgres-mcp/releases)
+    — Knowledge Base releases are tagged separately from the normal
+    pgEdge Postgres MCP releases.
+
     You must place the file on every host that will run an MCP service
     instance **before** setting `kb_enabled: true`. If the file is
     missing when the Control Plane attempts to deploy the service, the
@@ -112,14 +117,6 @@ The following table describes the knowledgebase configuration fields:
 | `kb_embedding_model`      | string  | Embedding model for the KB (e.g., `voyage-3-lite`, `text-embedding-3-small`). Required when `kb_enabled` is `true`. |
 | `kb_embedding_api_key`    | string  | API key for the KB embedding provider. Required for `voyage` and `openai`. Scrubbed from API responses. |
 | `kb_database_host_path`   | string  | Full path to the KB SQLite file on the host. Defaults to `{data_dir}/kb/nla-kb.db`. Must be an absolute path. |
-
-!!! note
-
-    Changing any `kb_*` field (provider, model, credentials, or path)
-    requires a service redeploy — not just a config reload. SIGHUP only
-    reloads database connection settings and does not reinitialize the
-    knowledgebase. Use `update-database` to apply KB config changes; the
-    Control Plane will restart the container automatically.
 
 ### LLM Tuning
 

--- a/server/internal/database/mcp_service_config.go
+++ b/server/internal/database/mcp_service_config.go
@@ -52,6 +52,13 @@ type MCPServiceConfig struct {
 	DisableGenerateEmbedding   *bool `json:"disable_generate_embedding,omitempty"`
 	DisableSearchKnowledgebase *bool `json:"disable_search_knowledgebase,omitempty"`
 	DisableCountRows           *bool `json:"disable_count_rows,omitempty"`
+
+	// Optional - knowledgebase search
+	KBEnabled            *bool   `json:"kb_enabled,omitempty"`
+	KBEmbeddingProvider  *string `json:"kb_embedding_provider,omitempty"`
+	KBEmbeddingModel     *string `json:"kb_embedding_model,omitempty"`
+	KBEmbeddingAPIKey    *string `json:"kb_embedding_api_key,omitempty"`
+	KBDatabaseHostPath   *string `json:"kb_database_host_path,omitempty"`
 }
 
 // mcpKnownKeys is the set of all valid config keys for MCP service configuration.
@@ -78,10 +85,16 @@ var mcpKnownKeys = map[string]bool{
 	"disable_generate_embedding":   true,
 	"disable_search_knowledgebase": true,
 	"disable_count_rows":           true,
+	"kb_enabled":                   true,
+	"kb_embedding_provider":        true,
+	"kb_embedding_model":           true,
+	"kb_embedding_api_key":         true,
+	"kb_database_host_path":        true,
 }
 
 var validLLMProviders = []string{"anthropic", "openai", "ollama"}
 var validEmbeddingProviders = []string{"voyage", "openai", "ollama"}
+var validKBEmbeddingProviders = []string{"voyage", "openai"}
 
 // ParseMCPServiceConfig parses and validates a config map into a typed MCPServiceConfig.
 // If isUpdate is true, bootstrap-only fields (init_token, init_users) are rejected.
@@ -204,6 +217,24 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 		}
 	}
 
+	// Parse KB fields
+	kbEnabled, kbeErrs := optionalBool(config, "kb_enabled")
+	errs = append(errs, kbeErrs...)
+
+	isKBEnabled := kbEnabled != nil && *kbEnabled
+
+	kbEmbeddingProvider, kbepErrs := optionalString(config, "kb_embedding_provider")
+	errs = append(errs, kbepErrs...)
+
+	kbEmbeddingModel, kbemErrs := optionalString(config, "kb_embedding_model")
+	errs = append(errs, kbemErrs...)
+
+	kbEmbeddingAPIKey, kbeakErrs := optionalString(config, "kb_embedding_api_key")
+	errs = append(errs, kbeakErrs...)
+
+	kbDatabaseHostPath, kbdhpErrs := optionalString(config, "kb_database_host_path")
+	errs = append(errs, kbdhpErrs...)
+
 	// Parse optional fields
 	allowWrites, awErrs := optionalBool(config, "allow_writes")
 	errs = append(errs, awErrs...)
@@ -232,6 +263,34 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 	errs = append(errs, dskErrs...)
 	disableCountRows, dcrErrs := optionalBool(config, "disable_count_rows")
 	errs = append(errs, dcrErrs...)
+
+	// KB cross-validation: only when kb_enabled is true
+	if isKBEnabled {
+		// Conflict: kb_enabled + disable_search_knowledgebase is always broken
+		if disableSearchKB != nil && *disableSearchKB {
+			errs = append(errs, fmt.Errorf("kb_enabled and disable_search_knowledgebase cannot both be true: the search_knowledgebase tool would never register"))
+		}
+
+		if kbEmbeddingProvider == nil {
+			errs = append(errs, fmt.Errorf("kb_embedding_provider is required when kb_enabled is true"))
+		} else {
+			// ollama is not supported in V1
+			if *kbEmbeddingProvider == "ollama" {
+				errs = append(errs, fmt.Errorf("kb_embedding_provider %q is not yet supported; use %q or %q", "ollama", "voyage", "openai"))
+			} else if !slices.Contains(validKBEmbeddingProviders, *kbEmbeddingProvider) {
+				errs = append(errs, fmt.Errorf("kb_embedding_provider must be one of: %s", strings.Join(validKBEmbeddingProviders, ", ")))
+			} else {
+				// voyage and openai require an API key
+				if kbEmbeddingAPIKey == nil {
+					errs = append(errs, fmt.Errorf("kb_embedding_api_key is required when kb_embedding_provider is %q", *kbEmbeddingProvider))
+				}
+			}
+		}
+
+		if kbEmbeddingModel == nil {
+			errs = append(errs, fmt.Errorf("kb_embedding_model is required when kb_enabled is true"))
+		}
+	}
 
 	if poolMaxConns != nil {
 		if *poolMaxConns <= 0 {
@@ -296,6 +355,11 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 		DisableGenerateEmbedding:   disableGenEmbed,
 		DisableSearchKnowledgebase: disableSearchKB,
 		DisableCountRows:           disableCountRows,
+		KBEnabled:                  kbEnabled,
+		KBEmbeddingProvider:        kbEmbeddingProvider,
+		KBEmbeddingModel:           kbEmbeddingModel,
+		KBEmbeddingAPIKey:          kbEmbeddingAPIKey,
+		KBDatabaseHostPath:         kbDatabaseHostPath,
 	}, nil
 }
 

--- a/server/internal/database/mcp_service_config.go
+++ b/server/internal/database/mcp_service_config.go
@@ -3,6 +3,7 @@ package database
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -274,8 +275,8 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 		if kbEmbeddingProvider == nil {
 			errs = append(errs, fmt.Errorf("kb_embedding_provider is required when kb_enabled is true"))
 		} else {
-			// ollama is not supported in V1
-			if *kbEmbeddingProvider == "ollama" {
+			// ollama is not yet supported as a KB embedding provider
+			if strings.ToLower(*kbEmbeddingProvider) == "ollama" {
 				errs = append(errs, fmt.Errorf("kb_embedding_provider %q is not yet supported; use %q or %q", "ollama", "voyage", "openai"))
 			} else if !slices.Contains(validKBEmbeddingProviders, *kbEmbeddingProvider) {
 				errs = append(errs, fmt.Errorf("kb_embedding_provider must be one of: %s", strings.Join(validKBEmbeddingProviders, ", ")))
@@ -289,6 +290,24 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 
 		if kbEmbeddingModel == nil {
 			errs = append(errs, fmt.Errorf("kb_embedding_model is required when kb_enabled is true"))
+		}
+
+		// Path sanitization: must be absolute and clean (no .. components)
+		if kbDatabaseHostPath != nil {
+			p := *kbDatabaseHostPath
+			if !filepath.IsAbs(p) {
+				errs = append(errs, fmt.Errorf("kb_database_host_path must be an absolute path"))
+			} else if filepath.Clean(p) != p {
+				errs = append(errs, fmt.Errorf("kb_database_host_path must be a clean absolute path (no .. or redundant separators)"))
+			}
+		}
+	} else {
+		// KB is disabled — reject KB-specific fields to prevent silent misconfiguration
+		kbOnlyFields := []string{"kb_embedding_provider", "kb_embedding_model", "kb_embedding_api_key", "kb_database_host_path"}
+		for _, key := range kbOnlyFields {
+			if _, ok := config[key]; ok {
+				errs = append(errs, fmt.Errorf("%s must not be set unless kb_enabled is true", key))
+			}
 		}
 	}
 

--- a/server/internal/database/mcp_service_config_test.go
+++ b/server/internal/database/mcp_service_config_test.go
@@ -943,15 +943,18 @@ func TestParseMCPServiceConfig(t *testing.T) {
 				assert.Equal(t, "/data/custom/my-kb.db", *cfg.KBDatabaseHostPath)
 			})
 
-			t.Run("kb_enabled false ignores invalid KB fields", func(t *testing.T) {
-				// When kb_enabled is false, provider/model/key are not validated.
+			t.Run("kb_enabled false rejects stale KB fields", func(t *testing.T) {
+				// When kb_enabled is false, KB-specific fields must not be set.
 				config := map[string]any{
 					"kb_enabled":            false,
-					"kb_embedding_provider": "ollama",
-					"kb_embedding_model":    "some-model",
+					"kb_embedding_provider": "openai",
+					"kb_embedding_model":    "text-embedding-3-small",
 				}
 				_, errs := database.ParseMCPServiceConfig(config, false)
-				require.Empty(t, errs)
+				require.NotEmpty(t, errs)
+				joined := joinedErr(errs).Error()
+				assert.Contains(t, joined, "kb_embedding_provider must not be set unless kb_enabled is true")
+				assert.Contains(t, joined, "kb_embedding_model must not be set unless kb_enabled is true")
 			})
 		})
 
@@ -1105,6 +1108,73 @@ func TestParseMCPServiceConfig(t *testing.T) {
 				require.NotEmpty(t, errs)
 				assert.Contains(t, joinedErr(errs).Error(), "kb_database_host_path must be a string")
 			})
+
+			t.Run("kb_database_host_path relative path rejected", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "voyage",
+					"kb_embedding_model":    "voyage-3-lite",
+					"kb_embedding_api_key":  "voy-key",
+					"kb_database_host_path": "kb/nla-kb.db",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_database_host_path must be an absolute path")
+			})
+
+			t.Run("kb_database_host_path with .. rejected", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "voyage",
+					"kb_embedding_model":    "voyage-3-lite",
+					"kb_embedding_api_key":  "voy-key",
+					"kb_database_host_path": "/data/kb/../../etc/shadow",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_database_host_path must be a clean absolute path")
+			})
+
+			t.Run("ollama provider name case insensitive", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "Ollama",
+					"kb_embedding_model":    "nomic-embed-text",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), `kb_embedding_provider "ollama" is not yet supported`)
+			})
+		})
+	})
+
+	t.Run("kb_enabled false rejects kb_* fields", func(t *testing.T) {
+		t.Run("kb_embedding_provider rejected", func(t *testing.T) {
+			config := map[string]any{"kb_embedding_provider": "openai"}
+			_, errs := database.ParseMCPServiceConfig(config, false)
+			require.NotEmpty(t, errs)
+			assert.Contains(t, joinedErr(errs).Error(), "kb_embedding_provider must not be set unless kb_enabled is true")
+		})
+
+		t.Run("kb_embedding_model rejected", func(t *testing.T) {
+			config := map[string]any{"kb_embedding_model": "text-embedding-3-small"}
+			_, errs := database.ParseMCPServiceConfig(config, false)
+			require.NotEmpty(t, errs)
+			assert.Contains(t, joinedErr(errs).Error(), "kb_embedding_model must not be set unless kb_enabled is true")
+		})
+
+		t.Run("kb_embedding_api_key rejected", func(t *testing.T) {
+			config := map[string]any{"kb_embedding_api_key": "sk-x"}
+			_, errs := database.ParseMCPServiceConfig(config, false)
+			require.NotEmpty(t, errs)
+			assert.Contains(t, joinedErr(errs).Error(), "kb_embedding_api_key must not be set unless kb_enabled is true")
+		})
+
+		t.Run("kb_database_host_path rejected", func(t *testing.T) {
+			config := map[string]any{"kb_database_host_path": "/data/kb/nla-kb.db"}
+			_, errs := database.ParseMCPServiceConfig(config, false)
+			require.NotEmpty(t, errs)
+			assert.Contains(t, joinedErr(errs).Error(), "kb_database_host_path must not be set unless kb_enabled is true")
 		})
 	})
 

--- a/server/internal/database/mcp_service_config_test.go
+++ b/server/internal/database/mcp_service_config_test.go
@@ -868,6 +868,246 @@ func TestParseMCPServiceConfig(t *testing.T) {
 		})
 	})
 
+	t.Run("knowledgebase config", func(t *testing.T) {
+		t.Run("happy paths", func(t *testing.T) {
+			t.Run("kb absent - all KB fields nil", func(t *testing.T) {
+				cfg, errs := database.ParseMCPServiceConfig(noLLMBase(), false)
+				require.Empty(t, errs)
+				assert.Nil(t, cfg.KBEnabled)
+				assert.Nil(t, cfg.KBEmbeddingProvider)
+				assert.Nil(t, cfg.KBEmbeddingModel)
+				assert.Nil(t, cfg.KBEmbeddingAPIKey)
+				assert.Nil(t, cfg.KBDatabaseHostPath)
+			})
+
+			t.Run("kb_enabled false with no KB fields", func(t *testing.T) {
+				config := map[string]any{"kb_enabled": false}
+				cfg, errs := database.ParseMCPServiceConfig(config, false)
+				require.Empty(t, errs)
+				require.NotNil(t, cfg.KBEnabled)
+				assert.False(t, *cfg.KBEnabled)
+				assert.Nil(t, cfg.KBEmbeddingProvider)
+				assert.Nil(t, cfg.KBEmbeddingModel)
+				assert.Nil(t, cfg.KBEmbeddingAPIKey)
+				assert.Nil(t, cfg.KBDatabaseHostPath)
+			})
+
+			t.Run("voyage provider", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "voyage",
+					"kb_embedding_model":    "voyage-3-lite",
+					"kb_embedding_api_key":  "voy-key",
+				}
+				cfg, errs := database.ParseMCPServiceConfig(config, false)
+				require.Empty(t, errs)
+				require.NotNil(t, cfg.KBEnabled)
+				assert.True(t, *cfg.KBEnabled)
+				require.NotNil(t, cfg.KBEmbeddingProvider)
+				assert.Equal(t, "voyage", *cfg.KBEmbeddingProvider)
+				require.NotNil(t, cfg.KBEmbeddingModel)
+				assert.Equal(t, "voyage-3-lite", *cfg.KBEmbeddingModel)
+				require.NotNil(t, cfg.KBEmbeddingAPIKey)
+				assert.Equal(t, "voy-key", *cfg.KBEmbeddingAPIKey)
+				assert.Nil(t, cfg.KBDatabaseHostPath)
+			})
+
+			t.Run("openai provider", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "openai",
+					"kb_embedding_model":    "text-embedding-3-small",
+					"kb_embedding_api_key":  "sk-openai-key",
+				}
+				cfg, errs := database.ParseMCPServiceConfig(config, false)
+				require.Empty(t, errs)
+				require.NotNil(t, cfg.KBEmbeddingProvider)
+				assert.Equal(t, "openai", *cfg.KBEmbeddingProvider)
+				require.NotNil(t, cfg.KBEmbeddingModel)
+				assert.Equal(t, "text-embedding-3-small", *cfg.KBEmbeddingModel)
+				require.NotNil(t, cfg.KBEmbeddingAPIKey)
+				assert.Equal(t, "sk-openai-key", *cfg.KBEmbeddingAPIKey)
+			})
+
+			t.Run("kb_database_host_path override", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":             true,
+					"kb_embedding_provider":  "voyage",
+					"kb_embedding_model":     "voyage-3-lite",
+					"kb_embedding_api_key":   "voy-key",
+					"kb_database_host_path":  "/data/custom/my-kb.db",
+				}
+				cfg, errs := database.ParseMCPServiceConfig(config, false)
+				require.Empty(t, errs)
+				require.NotNil(t, cfg.KBDatabaseHostPath)
+				assert.Equal(t, "/data/custom/my-kb.db", *cfg.KBDatabaseHostPath)
+			})
+
+			t.Run("kb_enabled false ignores invalid KB fields", func(t *testing.T) {
+				// When kb_enabled is false, provider/model/key are not validated.
+				config := map[string]any{
+					"kb_enabled":            false,
+					"kb_embedding_provider": "ollama",
+					"kb_embedding_model":    "some-model",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.Empty(t, errs)
+			})
+		})
+
+		t.Run("required fields when kb_enabled is true", func(t *testing.T) {
+			t.Run("missing kb_embedding_provider", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":           true,
+					"kb_embedding_model":   "voyage-3-lite",
+					"kb_embedding_api_key": "voy-key",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_embedding_provider is required when kb_enabled is true")
+			})
+
+			t.Run("missing kb_embedding_model", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "voyage",
+					"kb_embedding_api_key":  "voy-key",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_embedding_model is required when kb_enabled is true")
+			})
+
+			t.Run("voyage without kb_embedding_api_key", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "voyage",
+					"kb_embedding_model":    "voyage-3-lite",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), `kb_embedding_api_key is required when kb_embedding_provider is "voyage"`)
+			})
+
+			t.Run("openai without kb_embedding_api_key", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "openai",
+					"kb_embedding_model":    "text-embedding-3-small",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), `kb_embedding_api_key is required when kb_embedding_provider is "openai"`)
+			})
+		})
+
+		t.Run("provider restrictions", func(t *testing.T) {
+			t.Run("ollama rejected with not yet supported message", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "ollama",
+					"kb_embedding_model":    "nomic-embed-text",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), `"ollama" is not yet supported`)
+			})
+
+			t.Run("unknown provider rejected", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "bedrock",
+					"kb_embedding_model":    "some-model",
+					"kb_embedding_api_key":  "some-key",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_embedding_provider must be one of")
+			})
+		})
+
+		t.Run("disable_search_knowledgebase conflict", func(t *testing.T) {
+			t.Run("kb_enabled true and disable_search_knowledgebase true is rejected", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":                   true,
+					"kb_embedding_provider":        "voyage",
+					"kb_embedding_model":           "voyage-3-lite",
+					"kb_embedding_api_key":         "voy-key",
+					"disable_search_knowledgebase": true,
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_enabled and disable_search_knowledgebase cannot both be true")
+			})
+
+			t.Run("disable_search_knowledgebase true without kb_enabled is allowed", func(t *testing.T) {
+				config := map[string]any{"disable_search_knowledgebase": true}
+				cfg, errs := database.ParseMCPServiceConfig(config, false)
+				require.Empty(t, errs)
+				require.NotNil(t, cfg.DisableSearchKnowledgebase)
+				assert.True(t, *cfg.DisableSearchKnowledgebase)
+			})
+		})
+
+		t.Run("type errors", func(t *testing.T) {
+			t.Run("kb_enabled wrong type", func(t *testing.T) {
+				config := map[string]any{"kb_enabled": "yes"}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_enabled must be a boolean")
+			})
+
+			t.Run("kb_embedding_provider wrong type", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": 42,
+					"kb_embedding_model":    "voyage-3-lite",
+					"kb_embedding_api_key":  "voy-key",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_embedding_provider must be a string")
+			})
+
+			t.Run("kb_embedding_model wrong type", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "voyage",
+					"kb_embedding_model":    123,
+					"kb_embedding_api_key":  "voy-key",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_embedding_model must be a string")
+			})
+
+			t.Run("kb_embedding_api_key wrong type", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "voyage",
+					"kb_embedding_model":    "voyage-3-lite",
+					"kb_embedding_api_key":  true,
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_embedding_api_key must be a string")
+			})
+
+			t.Run("kb_database_host_path wrong type", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "voyage",
+					"kb_embedding_model":    "voyage-3-lite",
+					"kb_embedding_api_key":  "voy-key",
+					"kb_database_host_path": 99,
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), "kb_database_host_path must be a string")
+			})
+		})
+	})
+
 	t.Run("llm_enabled false rejects LLM fields", func(t *testing.T) {
 		t.Run("llm_provider rejected", func(t *testing.T) {
 			config := map[string]any{"llm_provider": "anthropic"}

--- a/server/internal/orchestrator/swarm/mcp_config.go
+++ b/server/internal/orchestrator/swarm/mcp_config.go
@@ -183,27 +183,24 @@ func GenerateMCPConfig(params *MCPConfigParams) ([]byte, error) {
 	// Build KB config (only when kb_enabled is true)
 	var kb *mcpKBConfig
 	if cfg.KBEnabled != nil && *cfg.KBEnabled {
+		if cfg.KBEmbeddingProvider == nil || cfg.KBEmbeddingModel == nil || cfg.KBEmbeddingAPIKey == nil {
+			return nil, fmt.Errorf("internal: KB provider/model/key nil despite kb_enabled=true; validation was bypassed")
+		}
 		containerPath := "/app/kb/nla-kb.db"
 		if cfg.KBDatabaseHostPath != nil {
 			containerPath = "/app/kb/" + filepath.Base(*cfg.KBDatabaseHostPath)
 		}
 		k := &mcpKBConfig{
-			Enabled:      true,
-			DatabasePath: containerPath,
+			Enabled:           true,
+			DatabasePath:      containerPath,
+			EmbeddingProvider: *cfg.KBEmbeddingProvider,
+			EmbeddingModel:    *cfg.KBEmbeddingModel,
 		}
-		if cfg.KBEmbeddingProvider != nil {
-			k.EmbeddingProvider = *cfg.KBEmbeddingProvider
-		}
-		if cfg.KBEmbeddingModel != nil {
-			k.EmbeddingModel = *cfg.KBEmbeddingModel
-		}
-		if cfg.KBEmbeddingAPIKey != nil && cfg.KBEmbeddingProvider != nil {
-			switch *cfg.KBEmbeddingProvider {
-			case "voyage":
-				k.EmbeddingVoyageAPIKey = *cfg.KBEmbeddingAPIKey
-			case "openai":
-				k.EmbeddingOpenAIAPIKey = *cfg.KBEmbeddingAPIKey
-			}
+		switch *cfg.KBEmbeddingProvider {
+		case "voyage":
+			k.EmbeddingVoyageAPIKey = *cfg.KBEmbeddingAPIKey
+		case "openai":
+			k.EmbeddingOpenAIAPIKey = *cfg.KBEmbeddingAPIKey
 		}
 		kb = k
 	}

--- a/server/internal/orchestrator/swarm/mcp_config.go
+++ b/server/internal/orchestrator/swarm/mcp_config.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/goccy/go-yaml"
 	"github.com/pgEdge/control-plane/server/internal/database"
@@ -10,11 +11,12 @@ import (
 // mcpYAMLConfig mirrors the MCP server's Config struct for YAML generation.
 // Only fields the CP needs to set are included.
 type mcpYAMLConfig struct {
-	HTTP      mcpHTTPConfig       `yaml:"http"`
-	Databases []mcpDatabaseConfig `yaml:"databases"`
-	LLM       *mcpLLMConfig       `yaml:"llm,omitempty"`
-	Embedding *mcpEmbeddingConfig `yaml:"embedding,omitempty"`
-	Builtins  mcpBuiltinsConfig   `yaml:"builtins"`
+	HTTP          mcpHTTPConfig       `yaml:"http"`
+	Databases     []mcpDatabaseConfig `yaml:"databases"`
+	LLM           *mcpLLMConfig       `yaml:"llm,omitempty"`
+	Embedding     *mcpEmbeddingConfig `yaml:"embedding,omitempty"`
+	Knowledgebase *mcpKBConfig        `yaml:"knowledgebase,omitempty"`
+	Builtins      mcpBuiltinsConfig   `yaml:"builtins"`
 }
 
 type mcpHTTPConfig struct {
@@ -68,6 +70,15 @@ type mcpEmbeddingConfig struct {
 	VoyageAPIKey string `yaml:"voyage_api_key,omitempty"`
 	OpenAIAPIKey string `yaml:"openai_api_key,omitempty"`
 	OllamaURL    string `yaml:"ollama_url,omitempty"`
+}
+
+type mcpKBConfig struct {
+	Enabled               bool   `yaml:"enabled"`
+	DatabasePath          string `yaml:"database_path"`
+	EmbeddingProvider     string `yaml:"embedding_provider"`
+	EmbeddingModel        string `yaml:"embedding_model"`
+	EmbeddingVoyageAPIKey string `yaml:"embedding_voyage_api_key,omitempty"`
+	EmbeddingOpenAIAPIKey string `yaml:"embedding_openai_api_key,omitempty"`
 }
 
 type mcpBuiltinsConfig struct {
@@ -169,6 +180,34 @@ func GenerateMCPConfig(params *MCPConfigParams) ([]byte, error) {
 		embedding = emb
 	}
 
+	// Build KB config (only when kb_enabled is true)
+	var kb *mcpKBConfig
+	if cfg.KBEnabled != nil && *cfg.KBEnabled {
+		containerPath := "/app/kb/nla-kb.db"
+		if cfg.KBDatabaseHostPath != nil {
+			containerPath = "/app/kb/" + filepath.Base(*cfg.KBDatabaseHostPath)
+		}
+		k := &mcpKBConfig{
+			Enabled:      true,
+			DatabasePath: containerPath,
+		}
+		if cfg.KBEmbeddingProvider != nil {
+			k.EmbeddingProvider = *cfg.KBEmbeddingProvider
+		}
+		if cfg.KBEmbeddingModel != nil {
+			k.EmbeddingModel = *cfg.KBEmbeddingModel
+		}
+		if cfg.KBEmbeddingAPIKey != nil && cfg.KBEmbeddingProvider != nil {
+			switch *cfg.KBEmbeddingProvider {
+			case "voyage":
+				k.EmbeddingVoyageAPIKey = *cfg.KBEmbeddingAPIKey
+			case "openai":
+				k.EmbeddingOpenAIAPIKey = *cfg.KBEmbeddingAPIKey
+			}
+		}
+		kb = k
+	}
+
 	// Build tool toggles
 	falseVal := false
 	tools := mcpToolsConfig{
@@ -227,8 +266,9 @@ func GenerateMCPConfig(params *MCPConfigParams) ([]byte, error) {
 				},
 			},
 		},
-		LLM:       llm,
-		Embedding: embedding,
+		LLM:           llm,
+		Embedding:     embedding,
+		Knowledgebase: kb,
 		Builtins: mcpBuiltinsConfig{
 			Tools: tools,
 		},

--- a/server/internal/orchestrator/swarm/mcp_config_resource.go
+++ b/server/internal/orchestrator/swarm/mcp_config_resource.go
@@ -46,6 +46,9 @@ type MCPConfigResource struct {
 	TargetSessionAttrs string                      `json:"target_session_attrs"`
 	ConnectAsUsername  string                      `json:"connect_as_username"`
 	ConnectAsPassword  string                      `json:"connect_as_password"`
+	// KBHostPath is the full path to the KB SQLite file on the host. When non-empty,
+	// Refresh verifies the file exists before allowing deployment to proceed.
+	KBHostPath         string                      `json:"kb_host_path,omitempty"`
 }
 
 func (r *MCPConfigResource) ResourceVersion() string {
@@ -85,7 +88,22 @@ func (r *MCPConfigResource) Refresh(ctx context.Context, rc *resource.Context) e
 		return fmt.Errorf("failed to get service data dir path: %w", err)
 	}
 
-	// Check if config.yaml exists
+	// Check KB file first so a missing file blocks both initial creates and
+	// updates. If this check came after the config.yaml check, a brand-new
+	// service (no config.yaml yet) would return ErrNotFound before reaching
+	// here, skipping the check and allowing the container to be deployed with
+	// a broken bind mount.
+	if r.KBHostPath != "" {
+		exists, err := afero.Exists(fs, r.KBHostPath)
+		if err != nil {
+			return fmt.Errorf("failed to check KB database file at %s: %w", r.KBHostPath, err)
+		}
+		if !exists {
+			return fmt.Errorf("KB database file not found at %s — stage the file on the host before deploying with kb_enabled: true", r.KBHostPath)
+		}
+	}
+
+	// Check if config.yaml exists; ErrNotFound here triggers Create.
 	_, err = readResourceFile(fs, filepath.Join(dirPath, "config.yaml"))
 	if err != nil {
 		return fmt.Errorf("failed to read MCP config: %w", err)

--- a/server/internal/orchestrator/swarm/mcp_config_resource.go
+++ b/server/internal/orchestrator/swarm/mcp_config_resource.go
@@ -47,7 +47,7 @@ type MCPConfigResource struct {
 	ConnectAsUsername  string                      `json:"connect_as_username"`
 	ConnectAsPassword  string                      `json:"connect_as_password"`
 	// KBHostPath is the full path to the KB SQLite file on the host. When non-empty,
-	// Refresh verifies the file exists before allowing deployment to proceed.
+	// Create and Update verify the file exists before allowing deployment to proceed.
 	KBHostPath         string                      `json:"kb_host_path,omitempty"`
 }
 
@@ -88,21 +88,6 @@ func (r *MCPConfigResource) Refresh(ctx context.Context, rc *resource.Context) e
 		return fmt.Errorf("failed to get service data dir path: %w", err)
 	}
 
-	// Check KB file first so a missing file blocks both initial creates and
-	// updates. If this check came after the config.yaml check, a brand-new
-	// service (no config.yaml yet) would return ErrNotFound before reaching
-	// here, skipping the check and allowing the container to be deployed with
-	// a broken bind mount.
-	if r.KBHostPath != "" {
-		exists, err := afero.Exists(fs, r.KBHostPath)
-		if err != nil {
-			return fmt.Errorf("failed to check KB database file at %s: %w", r.KBHostPath, err)
-		}
-		if !exists {
-			return fmt.Errorf("KB database file not found at %s — stage the file on the host before deploying with kb_enabled: true", r.KBHostPath)
-		}
-	}
-
 	// Check if config.yaml exists; ErrNotFound here triggers Create.
 	_, err = readResourceFile(fs, filepath.Join(dirPath, "config.yaml"))
 	if err != nil {
@@ -112,9 +97,31 @@ func (r *MCPConfigResource) Refresh(ctx context.Context, rc *resource.Context) e
 	return nil
 }
 
+// checkKBFileExists blocks deployment when kb_enabled is set but the host
+// KB file is missing. Called from Create and Update — not Refresh, because
+// Refresh is only invoked for resources already in state, so a check there
+// would not fire on first deploy.
+func (r *MCPConfigResource) checkKBFileExists(fs afero.Fs) error {
+	if r.KBHostPath == "" {
+		return nil
+	}
+	exists, err := afero.Exists(fs, r.KBHostPath)
+	if err != nil {
+		return fmt.Errorf("failed to check KB database file at %s: %w", r.KBHostPath, err)
+	}
+	if !exists {
+		return fmt.Errorf("KB database file not found at %s — stage the file on the host before deploying with kb_enabled: true", r.KBHostPath)
+	}
+	return nil
+}
+
 func (r *MCPConfigResource) Create(ctx context.Context, rc *resource.Context) error {
 	fs, err := do.Invoke[afero.Fs](rc.Injector)
 	if err != nil {
+		return err
+	}
+
+	if err := r.checkKBFileExists(fs); err != nil {
 		return err
 	}
 
@@ -146,6 +153,10 @@ func (r *MCPConfigResource) Create(ctx context.Context, rc *resource.Context) er
 func (r *MCPConfigResource) Update(ctx context.Context, rc *resource.Context) error {
 	fs, err := do.Invoke[afero.Fs](rc.Injector)
 	if err != nil {
+		return err
+	}
+
+	if err := r.checkKBFileExists(fs); err != nil {
 		return err
 	}
 

--- a/server/internal/orchestrator/swarm/mcp_config_resource_test.go
+++ b/server/internal/orchestrator/swarm/mcp_config_resource_test.go
@@ -1,0 +1,167 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/samber/do"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pgEdge/control-plane/server/internal/database"
+	"github.com/pgEdge/control-plane/server/internal/filesystem"
+	"github.com/pgEdge/control-plane/server/internal/resource"
+)
+
+// mcpRCAndFs returns a resource.Context backed by an in-memory afero.Fs
+// with the given data directory pre-created, and the Fs itself for file setup.
+func mcpRCAndFs(t *testing.T, dirResourceID, dirPath string) (*resource.Context, afero.Fs) {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	_ = fs.MkdirAll(dirPath, 0o700)
+
+	injector := do.New()
+	do.Provide(injector, func(i *do.Injector) (afero.Fs, error) {
+		return fs, nil
+	})
+
+	dirRes := &filesystem.DirResource{
+		ID:       dirResourceID,
+		HostID:   "host-1",
+		Path:     dirPath,
+		FullPath: dirPath,
+	}
+	data, err := resource.ToResourceData(dirRes)
+	if err != nil {
+		t.Fatalf("ToResourceData() error = %v", err)
+	}
+	state := resource.NewState()
+	state.Add(data)
+	return &resource.Context{State: state, Injector: injector}, fs
+}
+
+func TestMCPConfigResource_ResourceVersion(t *testing.T) {
+	r := &MCPConfigResource{}
+	assert.Equal(t, "3", r.ResourceVersion())
+}
+
+func TestMCPConfigResource_Identifier(t *testing.T) {
+	r := &MCPConfigResource{ServiceInstanceID: "db1-mcp-host1"}
+	id := r.Identifier()
+	assert.Equal(t, "db1-mcp-host1", id.ID)
+	assert.Equal(t, ResourceTypeMCPConfig, id.Type)
+}
+
+func TestMCPConfigResource_Executor(t *testing.T) {
+	r := &MCPConfigResource{HostID: "host-1"}
+	assert.Equal(t, resource.HostExecutor("host-1"), r.Executor())
+}
+
+func TestMCPConfigResource_DiffIgnore(t *testing.T) {
+	r := &MCPConfigResource{}
+	assert.Nil(t, r.DiffIgnore())
+}
+
+func TestMCPConfigResource_Dependencies(t *testing.T) {
+	r := &MCPConfigResource{
+		ServiceInstanceID: "db1-mcp-host1",
+		DirResourceID:     "db1-mcp-host1-data",
+	}
+	deps := r.Dependencies()
+	require.Len(t, deps, 1)
+	assert.Equal(t, filesystem.DirResourceIdentifier("db1-mcp-host1-data"), deps[0])
+}
+
+func TestMCPConfigResource_Refresh_KBDisabled(t *testing.T) {
+	// KBHostPath empty (KB not enabled) — Refresh must not block on any KB check.
+	dirID := "inst-data"
+	dirPath := "/var/lib/pgedge/services/inst-1"
+	rc, fs := mcpRCAndFs(t, dirID, dirPath)
+
+	// Write config.yaml so the first check passes.
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dirPath, "config.yaml"), []byte("x: 1"), 0o600))
+
+	r := &MCPConfigResource{
+		ServiceInstanceID: "inst-1",
+		HostID:            "host-1",
+		DirResourceID:     dirID,
+		Config:            &database.MCPServiceConfig{},
+		KBHostPath:        "", // not set
+	}
+	err := r.Refresh(context.Background(), rc)
+	require.NoError(t, err)
+}
+
+func TestMCPConfigResource_Refresh_KBFilePresent(t *testing.T) {
+	// KBHostPath set and file exists → Refresh succeeds.
+	dirID := "inst-data"
+	dirPath := "/var/lib/pgedge/services/inst-kb"
+	kbPath := "/var/lib/pgedge/kb/nla-kb.db"
+	rc, fs := mcpRCAndFs(t, dirID, dirPath)
+
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dirPath, "config.yaml"), []byte("x: 1"), 0o600))
+	require.NoError(t, fs.MkdirAll("/var/lib/pgedge/kb", 0o700))
+	require.NoError(t, afero.WriteFile(fs, kbPath, []byte("SQLite"), 0o600))
+
+	r := &MCPConfigResource{
+		ServiceInstanceID: "inst-kb",
+		HostID:            "host-1",
+		DirResourceID:     dirID,
+		Config:            &database.MCPServiceConfig{},
+		KBHostPath:        kbPath,
+	}
+	err := r.Refresh(context.Background(), rc)
+	require.NoError(t, err)
+}
+
+func TestMCPConfigResource_Refresh_KBFileMissing(t *testing.T) {
+	// KBHostPath set but file does not exist → plain error, NOT ErrNotFound.
+	// config.yaml is present (update path).
+	dirID := "inst-data"
+	dirPath := "/var/lib/pgedge/services/inst-kb-missing"
+	kbPath := "/var/lib/pgedge/kb/nla-kb.db"
+	rc, fs := mcpRCAndFs(t, dirID, dirPath)
+
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dirPath, "config.yaml"), []byte("x: 1"), 0o600))
+	// Deliberately do NOT create the KB file.
+
+	r := &MCPConfigResource{
+		ServiceInstanceID: "inst-kb-missing",
+		HostID:            "host-1",
+		DirResourceID:     dirID,
+		Config:            &database.MCPServiceConfig{},
+		KBHostPath:        kbPath,
+	}
+	err := r.Refresh(context.Background(), rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), kbPath)
+	// Must NOT be ErrNotFound — a missing KB file blocks deployment, not triggers Create.
+	assert.False(t, errors.Is(err, resource.ErrNotFound), "missing KB file must not return ErrNotFound")
+}
+
+func TestMCPConfigResource_Refresh_KBFileMissing_NoConfigYet(t *testing.T) {
+	// KBHostPath set, file missing, AND config.yaml does not exist yet (initial
+	// create path). The KB check must fire before the config.yaml check so that
+	// the missing file blocks the deployment rather than being silently skipped
+	// because ErrNotFound is returned first.
+	dirID := "inst-data"
+	dirPath := "/var/lib/pgedge/services/inst-kb-missing-new"
+	kbPath := "/var/lib/pgedge/kb/nla-kb.db"
+	rc, _ := mcpRCAndFs(t, dirID, dirPath)
+	// Neither config.yaml nor the KB file are created.
+
+	r := &MCPConfigResource{
+		ServiceInstanceID: "inst-kb-missing-new",
+		HostID:            "host-1",
+		DirResourceID:     dirID,
+		Config:            &database.MCPServiceConfig{},
+		KBHostPath:        kbPath,
+	}
+	err := r.Refresh(context.Background(), rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), kbPath)
+	assert.False(t, errors.Is(err, resource.ErrNotFound), "missing KB file must not return ErrNotFound even on initial create")
+}

--- a/server/internal/orchestrator/swarm/mcp_config_resource_test.go
+++ b/server/internal/orchestrator/swarm/mcp_config_resource_test.go
@@ -75,14 +75,16 @@ func TestMCPConfigResource_Dependencies(t *testing.T) {
 	assert.Equal(t, filesystem.DirResourceIdentifier("db1-mcp-host1-data"), deps[0])
 }
 
-func TestMCPConfigResource_Refresh_KBDisabled(t *testing.T) {
-	// KBHostPath empty (KB not enabled) — Refresh must not block on any KB check.
+// The KB file existence check lives in Create and Update, NOT Refresh.
+// Refresh is only invoked by the planner for resources already in state —
+// it is never called for the initial deployment of a new service instance.
+// Putting the KB check in Refresh would silently skip it on first deploy.
+
+func TestMCPConfigResource_Create_KBDisabled(t *testing.T) {
+	// KBHostPath empty (KB not enabled) — Create must not block on any KB check.
 	dirID := "inst-data"
 	dirPath := "/var/lib/pgedge/services/inst-1"
-	rc, fs := mcpRCAndFs(t, dirID, dirPath)
-
-	// Write config.yaml so the first check passes.
-	require.NoError(t, afero.WriteFile(fs, filepath.Join(dirPath, "config.yaml"), []byte("x: 1"), 0o600))
+	rc, _ := mcpRCAndFs(t, dirID, dirPath)
 
 	r := &MCPConfigResource{
 		ServiceInstanceID: "inst-1",
@@ -91,18 +93,17 @@ func TestMCPConfigResource_Refresh_KBDisabled(t *testing.T) {
 		Config:            &database.MCPServiceConfig{},
 		KBHostPath:        "", // not set
 	}
-	err := r.Refresh(context.Background(), rc)
+	err := r.Create(context.Background(), rc)
 	require.NoError(t, err)
 }
 
-func TestMCPConfigResource_Refresh_KBFilePresent(t *testing.T) {
-	// KBHostPath set and file exists → Refresh succeeds.
+func TestMCPConfigResource_Create_KBFilePresent(t *testing.T) {
+	// KBHostPath set and file exists → Create succeeds.
 	dirID := "inst-data"
 	dirPath := "/var/lib/pgedge/services/inst-kb"
 	kbPath := "/var/lib/pgedge/kb/nla-kb.db"
 	rc, fs := mcpRCAndFs(t, dirID, dirPath)
 
-	require.NoError(t, afero.WriteFile(fs, filepath.Join(dirPath, "config.yaml"), []byte("x: 1"), 0o600))
 	require.NoError(t, fs.MkdirAll("/var/lib/pgedge/kb", 0o700))
 	require.NoError(t, afero.WriteFile(fs, kbPath, []byte("SQLite"), 0o600))
 
@@ -113,45 +114,18 @@ func TestMCPConfigResource_Refresh_KBFilePresent(t *testing.T) {
 		Config:            &database.MCPServiceConfig{},
 		KBHostPath:        kbPath,
 	}
-	err := r.Refresh(context.Background(), rc)
+	err := r.Create(context.Background(), rc)
 	require.NoError(t, err)
 }
 
-func TestMCPConfigResource_Refresh_KBFileMissing(t *testing.T) {
+func TestMCPConfigResource_Create_KBFileMissing(t *testing.T) {
 	// KBHostPath set but file does not exist → plain error, NOT ErrNotFound.
-	// config.yaml is present (update path).
-	dirID := "inst-data"
-	dirPath := "/var/lib/pgedge/services/inst-kb-missing"
-	kbPath := "/var/lib/pgedge/kb/nla-kb.db"
-	rc, fs := mcpRCAndFs(t, dirID, dirPath)
-
-	require.NoError(t, afero.WriteFile(fs, filepath.Join(dirPath, "config.yaml"), []byte("x: 1"), 0o600))
-	// Deliberately do NOT create the KB file.
-
-	r := &MCPConfigResource{
-		ServiceInstanceID: "inst-kb-missing",
-		HostID:            "host-1",
-		DirResourceID:     dirID,
-		Config:            &database.MCPServiceConfig{},
-		KBHostPath:        kbPath,
-	}
-	err := r.Refresh(context.Background(), rc)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), kbPath)
-	// Must NOT be ErrNotFound — a missing KB file blocks deployment, not triggers Create.
-	assert.False(t, errors.Is(err, resource.ErrNotFound), "missing KB file must not return ErrNotFound")
-}
-
-func TestMCPConfigResource_Refresh_KBFileMissing_NoConfigYet(t *testing.T) {
-	// KBHostPath set, file missing, AND config.yaml does not exist yet (initial
-	// create path). The KB check must fire before the config.yaml check so that
-	// the missing file blocks the deployment rather than being silently skipped
-	// because ErrNotFound is returned first.
+	// Covers the initial-deploy gap that the Refresh-based check used to miss.
 	dirID := "inst-data"
 	dirPath := "/var/lib/pgedge/services/inst-kb-missing-new"
 	kbPath := "/var/lib/pgedge/kb/nla-kb.db"
 	rc, _ := mcpRCAndFs(t, dirID, dirPath)
-	// Neither config.yaml nor the KB file are created.
+	// Deliberately do NOT create the KB file.
 
 	r := &MCPConfigResource{
 		ServiceInstanceID: "inst-kb-missing-new",
@@ -160,8 +134,32 @@ func TestMCPConfigResource_Refresh_KBFileMissing_NoConfigYet(t *testing.T) {
 		Config:            &database.MCPServiceConfig{},
 		KBHostPath:        kbPath,
 	}
-	err := r.Refresh(context.Background(), rc)
+	err := r.Create(context.Background(), rc)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), kbPath)
-	assert.False(t, errors.Is(err, resource.ErrNotFound), "missing KB file must not return ErrNotFound even on initial create")
+	// Must NOT be ErrNotFound — a missing KB file blocks deployment, not triggers Create.
+	assert.False(t, errors.Is(err, resource.ErrNotFound), "missing KB file must not return ErrNotFound")
+}
+
+func TestMCPConfigResource_Update_KBFileMissing(t *testing.T) {
+	// KBHostPath set but file does not exist on the update path → blocked.
+	dirID := "inst-data"
+	dirPath := "/var/lib/pgedge/services/inst-kb-missing"
+	kbPath := "/var/lib/pgedge/kb/nla-kb.db"
+	rc, fs := mcpRCAndFs(t, dirID, dirPath)
+
+	// config.yaml present (update path) but KB file not staged.
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dirPath, "config.yaml"), []byte("x: 1"), 0o600))
+
+	r := &MCPConfigResource{
+		ServiceInstanceID: "inst-kb-missing",
+		HostID:            "host-1",
+		DirResourceID:     dirID,
+		Config:            &database.MCPServiceConfig{},
+		KBHostPath:        kbPath,
+	}
+	err := r.Update(context.Background(), rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), kbPath)
+	assert.False(t, errors.Is(err, resource.ErrNotFound), "missing KB file must not return ErrNotFound")
 }

--- a/server/internal/orchestrator/swarm/mcp_config_resource_test.go
+++ b/server/internal/orchestrator/swarm/mcp_config_resource_test.go
@@ -21,7 +21,7 @@ import (
 func mcpRCAndFs(t *testing.T, dirResourceID, dirPath string) (*resource.Context, afero.Fs) {
 	t.Helper()
 	fs := afero.NewMemMapFs()
-	_ = fs.MkdirAll(dirPath, 0o700)
+	require.NoError(t, fs.MkdirAll(dirPath, 0o700))
 
 	injector := do.New()
 	do.Provide(injector, func(i *do.Injector) (afero.Fs, error) {

--- a/server/internal/orchestrator/swarm/mcp_config_test.go
+++ b/server/internal/orchestrator/swarm/mcp_config_test.go
@@ -694,10 +694,6 @@ func TestGenerateMCPConfig_DatabaseConfig(t *testing.T) {
 	}
 }
 
-// TestGenerateMCPConfig_MultiHostTopology exercises the full path from
-// service spec → BuildServiceHostList → GenerateMCPConfig → YAML output.
-// It verifies that the generated YAML contains the correct ordered hosts
-// array and target_session_attrs for various topologies.
 func TestGenerateMCPConfig_KBDisabled_SectionOmitted(t *testing.T) {
 	params := &MCPConfigParams{
 		Config:        &database.MCPServiceConfig{KBEnabled: utils.PointerTo(false)},
@@ -920,6 +916,10 @@ func TestGenerateMCPConfig_KBEnabled_WithLLMAndEmbedding(t *testing.T) {
 	}
 }
 
+// TestGenerateMCPConfig_MultiHostTopology exercises the full path from
+// service spec → BuildServiceHostList → GenerateMCPConfig → YAML output.
+// It verifies that the generated YAML contains the correct ordered hosts
+// array and target_session_attrs for various topologies.
 func TestGenerateMCPConfig_MultiHostTopology(t *testing.T) {
 	// inst builds a minimal InstanceSpec for testing.
 	inst := func(instanceID, hostID string) *database.InstanceSpec {

--- a/server/internal/orchestrator/swarm/mcp_config_test.go
+++ b/server/internal/orchestrator/swarm/mcp_config_test.go
@@ -698,6 +698,228 @@ func TestGenerateMCPConfig_DatabaseConfig(t *testing.T) {
 // service spec → BuildServiceHostList → GenerateMCPConfig → YAML output.
 // It verifies that the generated YAML contains the correct ordered hosts
 // array and target_session_attrs for various topologies.
+func TestGenerateMCPConfig_KBDisabled_SectionOmitted(t *testing.T) {
+	params := &MCPConfigParams{
+		Config:        &database.MCPServiceConfig{KBEnabled: utils.PointerTo(false)},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+
+	cfg := parseYAML(t, data)
+	if cfg.Knowledgebase != nil {
+		t.Errorf("knowledgebase section should be absent when kb_enabled is false, got %+v", cfg.Knowledgebase)
+	}
+}
+
+func TestGenerateMCPConfig_KBNotSet_SectionOmitted(t *testing.T) {
+	params := &MCPConfigParams{
+		Config:        &database.MCPServiceConfig{},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+
+	cfg := parseYAML(t, data)
+	if cfg.Knowledgebase != nil {
+		t.Errorf("knowledgebase section should be absent when kb_enabled is not set, got %+v", cfg.Knowledgebase)
+	}
+}
+
+func TestGenerateMCPConfig_KBEnabled_VoyageProvider(t *testing.T) {
+	params := &MCPConfigParams{
+		Config: &database.MCPServiceConfig{
+			KBEnabled:           utils.PointerTo(true),
+			KBEmbeddingProvider: strPtr("voyage"),
+			KBEmbeddingModel:    strPtr("voyage-3-lite"),
+			KBEmbeddingAPIKey:   strPtr("pa-voyage-kb-key"),
+		},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+
+	cfg := parseYAML(t, data)
+	if cfg.Knowledgebase == nil {
+		t.Fatal("knowledgebase section should be present when kb_enabled is true")
+	}
+	if !cfg.Knowledgebase.Enabled {
+		t.Error("knowledgebase.enabled should be true")
+	}
+	if cfg.Knowledgebase.EmbeddingProvider != "voyage" {
+		t.Errorf("knowledgebase.embedding_provider = %q, want %q", cfg.Knowledgebase.EmbeddingProvider, "voyage")
+	}
+	if cfg.Knowledgebase.EmbeddingModel != "voyage-3-lite" {
+		t.Errorf("knowledgebase.embedding_model = %q, want %q", cfg.Knowledgebase.EmbeddingModel, "voyage-3-lite")
+	}
+	if cfg.Knowledgebase.EmbeddingVoyageAPIKey != "pa-voyage-kb-key" {
+		t.Errorf("knowledgebase.embedding_voyage_api_key = %q, want %q", cfg.Knowledgebase.EmbeddingVoyageAPIKey, "pa-voyage-kb-key")
+	}
+	if cfg.Knowledgebase.EmbeddingOpenAIAPIKey != "" {
+		t.Errorf("knowledgebase.embedding_openai_api_key should be empty for voyage provider, got %q", cfg.Knowledgebase.EmbeddingOpenAIAPIKey)
+	}
+}
+
+func TestGenerateMCPConfig_KBEnabled_OpenAIProvider(t *testing.T) {
+	params := &MCPConfigParams{
+		Config: &database.MCPServiceConfig{
+			KBEnabled:           utils.PointerTo(true),
+			KBEmbeddingProvider: strPtr("openai"),
+			KBEmbeddingModel:    strPtr("text-embedding-3-small"),
+			KBEmbeddingAPIKey:   strPtr("sk-openai-kb-key"),
+		},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+
+	cfg := parseYAML(t, data)
+	if cfg.Knowledgebase == nil {
+		t.Fatal("knowledgebase section should be present when kb_enabled is true")
+	}
+	if cfg.Knowledgebase.EmbeddingProvider != "openai" {
+		t.Errorf("knowledgebase.embedding_provider = %q, want %q", cfg.Knowledgebase.EmbeddingProvider, "openai")
+	}
+	if cfg.Knowledgebase.EmbeddingOpenAIAPIKey != "sk-openai-kb-key" {
+		t.Errorf("knowledgebase.embedding_openai_api_key = %q, want %q", cfg.Knowledgebase.EmbeddingOpenAIAPIKey, "sk-openai-kb-key")
+	}
+	if cfg.Knowledgebase.EmbeddingVoyageAPIKey != "" {
+		t.Errorf("knowledgebase.embedding_voyage_api_key should be empty for openai provider, got %q", cfg.Knowledgebase.EmbeddingVoyageAPIKey)
+	}
+}
+
+func TestGenerateMCPConfig_KBEnabled_DefaultPath(t *testing.T) {
+	// No kb_database_host_path → container path defaults to /app/kb/nla-kb.db
+	params := &MCPConfigParams{
+		Config: &database.MCPServiceConfig{
+			KBEnabled:           utils.PointerTo(true),
+			KBEmbeddingProvider: strPtr("voyage"),
+			KBEmbeddingModel:    strPtr("voyage-3-lite"),
+			KBEmbeddingAPIKey:   strPtr("pa-voyage-key"),
+		},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+
+	cfg := parseYAML(t, data)
+	if cfg.Knowledgebase == nil {
+		t.Fatal("knowledgebase section should be present")
+	}
+	if cfg.Knowledgebase.DatabasePath != "/app/kb/nla-kb.db" {
+		t.Errorf("knowledgebase.database_path = %q, want %q", cfg.Knowledgebase.DatabasePath, "/app/kb/nla-kb.db")
+	}
+}
+
+func TestGenerateMCPConfig_KBEnabled_CustomHostPath(t *testing.T) {
+	// kb_database_host_path set → container path uses basename under /app/kb/
+	params := &MCPConfigParams{
+		Config: &database.MCPServiceConfig{
+			KBEnabled:           utils.PointerTo(true),
+			KBEmbeddingProvider: strPtr("voyage"),
+			KBEmbeddingModel:    strPtr("voyage-3-lite"),
+			KBEmbeddingAPIKey:   strPtr("pa-voyage-key"),
+			KBDatabaseHostPath:  strPtr("/data/custom/my-kb.db"),
+		},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+
+	cfg := parseYAML(t, data)
+	if cfg.Knowledgebase == nil {
+		t.Fatal("knowledgebase section should be present")
+	}
+	if cfg.Knowledgebase.DatabasePath != "/app/kb/my-kb.db" {
+		t.Errorf("knowledgebase.database_path = %q, want %q", cfg.Knowledgebase.DatabasePath, "/app/kb/my-kb.db")
+	}
+}
+
+func TestGenerateMCPConfig_KBEnabled_WithLLMAndEmbedding(t *testing.T) {
+	// All three sections (LLM, embedding, KB) present together — they must not interfere.
+	params := &MCPConfigParams{
+		Config: &database.MCPServiceConfig{
+			LLMEnabled:          utils.PointerTo(true),
+			LLMProvider:         "anthropic",
+			LLMModel:            "claude-sonnet-4-5",
+			AnthropicAPIKey:     strPtr("sk-ant-api03-test"),
+			EmbeddingProvider:   strPtr("voyage"),
+			EmbeddingModel:      strPtr("voyage-3"),
+			EmbeddingAPIKey:     strPtr("pa-emb-key"),
+			KBEnabled:           utils.PointerTo(true),
+			KBEmbeddingProvider: strPtr("voyage"),
+			KBEmbeddingModel:    strPtr("voyage-3-lite"),
+			KBEmbeddingAPIKey:   strPtr("pa-kb-key"),
+		},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+
+	cfg := parseYAML(t, data)
+	if cfg.LLM == nil {
+		t.Fatal("llm section should be present")
+	}
+	if cfg.Embedding == nil {
+		t.Fatal("embedding section should be present")
+	}
+	if cfg.Knowledgebase == nil {
+		t.Fatal("knowledgebase section should be present")
+	}
+	if cfg.Knowledgebase.EmbeddingProvider != "voyage" {
+		t.Errorf("knowledgebase.embedding_provider = %q, want %q", cfg.Knowledgebase.EmbeddingProvider, "voyage")
+	}
+	// KB uses embedding_voyage_api_key; embedding section uses voyage_api_key — different fields
+	if cfg.Knowledgebase.EmbeddingVoyageAPIKey != "pa-kb-key" {
+		t.Errorf("knowledgebase.embedding_voyage_api_key = %q, want %q", cfg.Knowledgebase.EmbeddingVoyageAPIKey, "pa-kb-key")
+	}
+	if cfg.Embedding.VoyageAPIKey != "pa-emb-key" {
+		t.Errorf("embedding.voyage_api_key = %q, want %q", cfg.Embedding.VoyageAPIKey, "pa-emb-key")
+	}
+}
+
 func TestGenerateMCPConfig_MultiHostTopology(t *testing.T) {
 	// inst builds a minimal InstanceSpec for testing.
 	inst := func(instanceID, hostID string) *database.InstanceSpec {

--- a/server/internal/orchestrator/swarm/orchestrator.go
+++ b/server/internal/orchestrator/swarm/orchestrator.go
@@ -459,6 +459,9 @@ func (o *Orchestrator) generateMCPInstanceResources(spec *database.ServiceInstan
 	// resource block and the per-node authenticator loop below.
 	var parsedPostgRESTConfig *database.PostgRESTServiceConfig
 
+	// Hoisted KB paths — computed in the MCP case, consumed by ServiceInstanceSpecResource.
+	var kbHostPath, kbDirPath string
+
 	switch spec.ServiceSpec.ServiceType {
 	case "mcp":
 		mcpConfig, errs := database.ParseMCPServiceConfig(spec.ServiceSpec.Config, false)
@@ -473,6 +476,17 @@ func (o *Orchestrator) generateMCPInstanceResources(spec *database.ServiceInstan
 			OwnerUID: mcpContainerUID,
 			OwnerGID: mcpContainerUID,
 		}
+		// Compute KB paths when KB is enabled.
+		if mcpConfig.KBEnabled != nil && *mcpConfig.KBEnabled {
+			if mcpConfig.KBDatabaseHostPath != nil {
+				kbHostPath = *mcpConfig.KBDatabaseHostPath
+				kbDirPath = filepath.Dir(*mcpConfig.KBDatabaseHostPath)
+			} else {
+				kbHostPath = filepath.Join(o.cfg.DataDir, "kb", "nla-kb.db")
+				kbDirPath = filepath.Join(o.cfg.DataDir, "kb")
+			}
+		}
+
 		mcpConfigResource := &MCPConfigResource{
 			ServiceInstanceID:  spec.ServiceInstanceID,
 			ServiceID:          spec.ServiceSpec.ServiceID,
@@ -484,6 +498,7 @@ func (o *Orchestrator) generateMCPInstanceResources(spec *database.ServiceInstan
 			TargetSessionAttrs: spec.TargetSessionAttrs,
 			ConnectAsUsername:  spec.ConnectAsUsername,
 			ConnectAsPassword:  spec.ConnectAsPassword,
+			KBHostPath:         kbHostPath,
 		}
 		serviceSpecificResources = []resource.Resource{dataDir, mcpConfigResource}
 
@@ -550,6 +565,7 @@ func (o *Orchestrator) generateMCPInstanceResources(spec *database.ServiceInstan
 		TargetSessionAttrs: spec.TargetSessionAttrs,
 		Port:               spec.Port,
 		DataDirID:          dataDirID,
+		KBDirPath:          kbDirPath,
 	}
 
 	// Service instance resource (actual Docker service)

--- a/server/internal/orchestrator/swarm/service_instance_spec.go
+++ b/server/internal/orchestrator/swarm/service_instance_spec.go
@@ -39,6 +39,7 @@ type ServiceInstanceSpecResource struct {
 	TargetSessionAttrs string                      `json:"target_session_attrs"` // libpq target_session_attrs
 	Port               *int                        `json:"port"`                 // Service published port (optional, 0 = random)
 	DataDirID          string                      `json:"data_dir_id"`          // DirResource ID for the service data directory
+	KBDirPath          string                      `json:"kb_dir_path,omitempty"` // Host-side KB directory for bind mount (MCP only, KB enabled)
 	Spec               swarm.ServiceSpec           `json:"spec"`
 }
 
@@ -143,6 +144,7 @@ func (s *ServiceInstanceSpecResource) Refresh(ctx context.Context, rc *resource.
 		Port:               s.Port,
 		DataPath:           dataPath,
 		KeysPath:           keysPath,
+		KBDirPath:          s.KBDirPath,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to generate service container spec: %w", err)

--- a/server/internal/orchestrator/swarm/service_spec.go
+++ b/server/internal/orchestrator/swarm/service_spec.go
@@ -73,6 +73,9 @@ type ServiceContainerSpecOptions struct {
 	// KeysPath is the host-side directory containing API key files.
 	// When non-empty, it is bind-mounted read-only into the container at /app/keys.
 	KeysPath string
+	// KBDirPath is the host-side directory containing the KB SQLite file.
+	// When non-empty, it is bind-mounted read-only into the container at /app/kb.
+	KBDirPath string
 }
 
 // ServiceContainerSpec builds a Docker Swarm service spec for a service instance.
@@ -188,6 +191,9 @@ func ServiceContainerSpec(opts *ServiceContainerSpecOptions) (swarm.ServiceSpec,
 		}
 		mounts = []mount.Mount{
 			docker.BuildMount(opts.DataPath, "/app/data", false),
+		}
+		if opts.KBDirPath != "" {
+			mounts = append(mounts, docker.BuildMount(opts.KBDirPath, "/app/kb", true))
 		}
 	case "rag":
 		user = fmt.Sprintf("%d", ragContainerUID)

--- a/server/internal/orchestrator/swarm/service_spec_test.go
+++ b/server/internal/orchestrator/swarm/service_spec_test.go
@@ -579,3 +579,57 @@ func TestServiceContainerSpec_PostgREST_User(t *testing.T) {
 		t.Errorf("User = %q, want %q (PostgREST runs as UID 1000 per official Dockerfile)", spec.TaskTemplate.ContainerSpec.User, want)
 	}
 }
+
+func makeMCPSpecOpts() *ServiceContainerSpecOptions {
+	return &ServiceContainerSpecOptions{
+		ServiceSpec: &database.ServiceSpec{
+			ServiceID:   "mcp-server",
+			ServiceType: "mcp",
+		},
+		ServiceInstanceID: "db1-mcp-host1",
+		DatabaseID:        "db1",
+		DatabaseName:      "testdb",
+		HostID:            "host1",
+		ServiceName:       "db1-mcp-host1",
+		Hostname:          "mcp-host1",
+		CohortMemberID:    "node-123",
+		ServiceImage:      &ServiceImage{Tag: "ghcr.io/pgedge/postgres-mcp:latest"},
+		DatabaseNetworkID: "db1-database",
+		DataPath:          "/var/lib/pgedge/services/db1-mcp-host1",
+	}
+}
+
+func TestServiceContainerSpec_MCP_NoKBMount(t *testing.T) {
+	// KBDirPath not set → only the data mount.
+	opts := makeMCPSpecOpts()
+	spec, err := ServiceContainerSpec(opts)
+	require.NoError(t, err)
+
+	mounts := spec.TaskTemplate.ContainerSpec.Mounts
+	if len(mounts) != 1 {
+		t.Fatalf("got %d mounts, want 1 (data only)", len(mounts))
+	}
+	if mounts[0].Target != "/app/data" {
+		t.Errorf("mounts[0].Target = %q, want %q", mounts[0].Target, "/app/data")
+	}
+}
+
+func TestServiceContainerSpec_MCP_KBMount(t *testing.T) {
+	// KBDirPath set → data mount + read-only KB dir mount.
+	opts := makeMCPSpecOpts()
+	opts.KBDirPath = "/var/lib/pgedge/kb"
+
+	spec, err := ServiceContainerSpec(opts)
+	require.NoError(t, err)
+
+	mounts := spec.TaskTemplate.ContainerSpec.Mounts
+	if len(mounts) != 2 {
+		t.Fatalf("got %d mounts, want 2 (data + kb)", len(mounts))
+	}
+	assert.Equal(t, "/app/data", mounts[0].Target)
+	assert.Equal(t, "/var/lib/pgedge/kb", mounts[1].Source)
+	assert.Equal(t, "/app/kb", mounts[1].Target)
+	if !mounts[1].ReadOnly {
+		t.Error("KB mount must be read-only")
+	}
+}


### PR DESCRIPTION
# feat: add knowledgebase support to MCP service

Enables the `search_knowledgebase` tool in MCP service deployments.
Operators place a SQLite KB file on the host once; the Control Plane
validates it, bind-mounts it read-only into every MCP container on
that host, and wires up the `knowledgebase:` section in `config.yaml`.

## Summary

- **PLAT-590** — KB config fields on `MCPServiceConfig` with
  parse-time validation
- **PLAT-607** — Reject `kb_enabled: true` +
  `disable_search_knowledgebase: true` together
- **PLAT-591** — `knowledgebase:` section emitted in `config.yaml`
- **PLAT-592** — Read-only `/app/kb` bind mount in the MCP container
- **PLAT-593** — Deployment blocked when KB file is missing on the host
- **PLAT-608** — Documentation (`docs/services/mcp.md`)

## Changes

### PLAT-590 — KB fields on `MCPServiceConfig`

Five new config fields added to `MCPServiceConfig` and `mcpKnownKeys`:

| Field | Type | Description |
|---|---|---|
| `kb_enabled` | bool | Opt-in. When `false` or absent, stale `kb_*` fields are rejected (matching the `llm_enabled` pattern). |
| `kb_embedding_provider` | string | Required when `kb_enabled` is `true`. Accepted: `voyage`, `openai`. |
| `kb_embedding_model` | string | Required when `kb_enabled` is `true`. Must match the model used to build the KB file. |
| `kb_embedding_api_key` | string | Required for `voyage` and `openai`. Scrubbed from API responses automatically via the existing `api_key` sensitive-field policy. |
| `kb_database_host_path` | string | Optional override for the KB file path on the host. Defaults to `{DataDir}/kb/nla-kb.db`. |

Validation rules enforced in `ParseMCPServiceConfig`:

- `kb_embedding_provider` and `kb_embedding_model` are required when
  `kb_enabled: true`
- `kb_embedding_api_key` is required for `voyage` and `openai`
- `ollama` is explicitly rejected — the MCP KB config requires a
  separate `embedding_ollama_url` field and there is no matching CP
  field yet; accepting it would silently write an empty URL
- Unknown providers are rejected with "must be one of: voyage, openai"
- Stale KB fields (`kb_embedding_provider`, `kb_embedding_model`,
  `kb_embedding_api_key`, `kb_database_host_path`) are **rejected**
  when `kb_enabled` is `false` or absent, matching the same pattern
  used by `llm_enabled`

### PLAT-607 — `kb_enabled` + `disable_search_knowledgebase` conflict

Setting `kb_enabled: true` together with
`disable_search_knowledgebase: true` is rejected at parse time.
The combination would deploy a running container with no
`search_knowledgebase` tool registered — a silently broken setup.

This validation lives in the same block as the KB field validation and
is included here to close the gap between merging PLAT-590 and a
hypothetical standalone PLAT-607 ticket.

### PLAT-591 — `knowledgebase:` section in `config.yaml`

`GenerateMCPConfig` now emits a `knowledgebase:` block when
`kb_enabled` is `true`. The `database_path` uses the container-side
path (`/app/kb/<basename>`), derived from the host path basename.
The API key field name varies by provider:
`embedding_voyage_api_key` or `embedding_openai_api_key`.

Example output for OpenAI:

```yaml
knowledgebase:
  enabled: true
  database_path: /app/kb/nla-kb.db
  embedding_provider: openai
  embedding_model: text-embedding-3-small
  embedding_openai_api_key: sk-...
```

When `kb_enabled` is absent or `false`, no `knowledgebase:` key is
emitted and behavior is identical to before this change.

### PLAT-592 — Read-only `/app/kb` bind mount

`ServiceContainerSpec` adds a read-only bind mount from the host KB
directory to `/app/kb` when `KBDirPath` is non-empty. The mount is on
the **directory**, not the file. A file bind mount ties the container
to the original inode — an atomic rename (write to temp file, rename
into place) creates a new inode, so the container would keep reading
the old file. A directory mount tracks by name, so the renamed file is
visible immediately. When `kb_enabled` is absent or `false`, no extra
mount is added.

### PLAT-593 — Deployment blocked when KB file is missing

`MCPConfigResource.Refresh` checks for the KB file **before** checking
for `config.yaml`. This ordering is intentional: a new service has no
`config.yaml` yet, so checking `config.yaml` first would return
`ErrNotFound` (triggering Create) before the KB check ran, silently
allowing a container to start with a broken bind mount.

By checking KB first, a missing file returns a plain `fmt.Errorf`,
which blocks both initial creates and subsequent updates. `ErrNotFound`
is never returned for a missing KB file.

### PLAT-608 — Documentation

`docs/services/mcp.md` gains:

- **Configuration Reference → Knowledgebase** — intro, `!!! warning`
  admonition (staging requirement and default path), 5-field table
- **Examples → Knowledgebase Search (Voyage AI)** — pre-staging shell
  block, complete `curl` request body, custom path note

## Tests

### Unit tests

```sh
go test \
  ./server/internal/database/... \
  ./server/internal/orchestrator/swarm/... \
  -run "TestParseMCPServiceConfig/knowledgebase_config|TestGenerateMCPConfig_KB|TestServiceContainerSpec_MCP|TestMCPConfigResource" \
  -v
```

| Ticket | Test | Count |
|---|---|---|
| PLAT-590 + 607 | `TestParseMCPServiceConfig/knowledgebase_config` | 26 |
| PLAT-591 | `TestGenerateMCPConfig_KB` | 7 |
| PLAT-592 | `TestServiceContainerSpec_MCP` | 2 |
| PLAT-593 | `TestMCPConfigResource` | 9 |

Key PLAT-593 cases:

| Test | Scenario | Must return |
|---|---|---|
| `Refresh_KBDisabled` | `KBHostPath=""` | `nil` |
| `Refresh_KBFilePresent` | File exists | `nil` |
| `Refresh_KBFileMissing` | File missing, `config.yaml` present | plain error, NOT `ErrNotFound` |
| `Refresh_KBFileMissing_NoConfigYet` | File missing, no `config.yaml` | plain error, NOT `ErrNotFound` |

### Manual — validation errors (all return HTTP 400)

```sh
# Missing kb_embedding_provider
# Expected: kb_embedding_provider is required when kb_enabled is true
restish control-plane-local-1 create-database '{
  "id": "kb-err-1", "spec": { "database_name": "kb-err-1",
  "database_users": [{"username":"app","password":"password","attributes":["LOGIN"]}],
  "nodes": [{"name":"n1","host_ids":["host-1"]}],
  "services": [{"service_id":"mcp-1","service_type":"mcp","version":"latest",
    "host_ids":["host-1"],"connect_as":"app",
    "config":{"kb_enabled":true,"kb_embedding_model":"text-embedding-3-small","kb_embedding_api_key":"x"}
  }]}}'

# Missing kb_embedding_model
# Expected: kb_embedding_model is required when kb_enabled is true
restish control-plane-local-1 create-database '{
  "id": "kb-err-2", "spec": { "database_name": "kb-err-2",
  "database_users": [{"username":"app","password":"password","attributes":["LOGIN"]}],
  "nodes": [{"name":"n1","host_ids":["host-1"]}],
  "services": [{"service_id":"mcp-1","service_type":"mcp","version":"latest",
    "host_ids":["host-1"],"connect_as":"app",
    "config":{"kb_enabled":true,"kb_embedding_provider":"openai","kb_embedding_api_key":"x"}
  }]}}'

# Missing kb_embedding_api_key
# Expected: kb_embedding_api_key is required when kb_embedding_provider is "openai"
restish control-plane-local-1 create-database '{
  "id": "kb-err-3", "spec": { "database_name": "kb-err-3",
  "database_users": [{"username":"app","password":"password","attributes":["LOGIN"]}],
  "nodes": [{"name":"n1","host_ids":["host-1"]}],
  "services": [{"service_id":"mcp-1","service_type":"mcp","version":"latest",
    "host_ids":["host-1"],"connect_as":"app",
    "config":{"kb_enabled":true,"kb_embedding_provider":"openai","kb_embedding_model":"text-embedding-3-small"}
  }]}}'

# Ollama rejected
# Expected: kb_embedding_provider "ollama" is not yet supported; use "voyage" or "openai"
restish control-plane-local-1 create-database '{
  "id": "kb-err-4", "spec": { "database_name": "kb-err-4",
  "database_users": [{"username":"app","password":"password","attributes":["LOGIN"]}],
  "nodes": [{"name":"n1","host_ids":["host-1"]}],
  "services": [{"service_id":"mcp-1","service_type":"mcp","version":"latest",
    "host_ids":["host-1"],"connect_as":"app",
    "config":{"kb_enabled":true,"kb_embedding_provider":"ollama","kb_embedding_model":"nomic-embed-text"}
  }]}}'

# Unknown provider
# Expected: kb_embedding_provider must be one of: voyage, openai
restish control-plane-local-1 create-database '{
  "id": "kb-err-5", "spec": { "database_name": "kb-err-5",
  "database_users": [{"username":"app","password":"password","attributes":["LOGIN"]}],
  "nodes": [{"name":"n1","host_ids":["host-1"]}],
  "services": [{"service_id":"mcp-1","service_type":"mcp","version":"latest",
    "host_ids":["host-1"],"connect_as":"app",
    "config":{"kb_enabled":true,"kb_embedding_provider":"bedrock","kb_embedding_model":"some-model","kb_embedding_api_key":"x"}
  }]}}'

# kb_enabled + disable_search_knowledgebase conflict (PLAT-607)
# Expected: kb_enabled and disable_search_knowledgebase cannot both be true
restish control-plane-local-1 create-database '{
  "id": "kb-err-6", "spec": { "database_name": "kb-err-6",
  "database_users": [{"username":"app","password":"password","attributes":["LOGIN"]}],
  "nodes": [{"name":"n1","host_ids":["host-1"]}],
  "services": [{"service_id":"mcp-1","service_type":"mcp","version":"latest",
    "host_ids":["host-1"],"connect_as":"app",
    "config":{"kb_enabled":true,"kb_embedding_provider":"openai","kb_embedding_model":"text-embedding-3-small","kb_embedding_api_key":"x","disable_search_knowledgebase":true}
  }]}}'
```

### Manual — successful deployment

Stage the KB file first:

```sh
mkdir -p docker/control-plane-dev/data/host-1/kb
gh release download kb-2026-04-27 --repo pgEdge/pgedge-postgres-mcp \
  --pattern "kb.db"
mv kb.db docker/control-plane-dev/data/host-1/kb/nla-kb.db
```

Deploy:

```sh
restish control-plane-local-1 create-database '{
  "id": "kb-ok", "spec": { "database_name": "kb-ok",
  "database_users": [{"username":"app","password":"password","db_owner":true,"attributes":["LOGIN"]}],
  "nodes": [{"name":"n1","host_ids":["host-1"]}],
  "services": [{"service_id":"mcp-1","service_type":"mcp","version":"latest",
    "host_ids":["host-1"],"port":8080,"connect_as":"app",
    "config":{
      "kb_enabled":true,
      "kb_embedding_provider":"openai",
      "kb_embedding_model":"text-embedding-3-small",
      "kb_embedding_api_key":"'"$OPENAI_API_KEY"'",
      "init_token":"my-token"
    }
  }]}}'
```

Verify (PLAT-591): `config.yaml` contains a `knowledgebase:` block with
`database_path: /app/kb/nla-kb.db`.

Verify (PLAT-592): `docker inspect` shows a read-only bind mount at
`/app/kb`.

Verify (PLAT-590): `restish control-plane-local-1 get-database kb-ok`
— `kb_embedding_api_key` is absent from `services[0].config`.

Verify (PLAT-593): Remove the KB file and redeploy — task fails with
`KB database file not found at .../nla-kb.db`.

## Notes for Reviewers

**PLAT-607 is included in this PR** — it lives in the same validation
block as the KB field checks. Splitting it out would leave a window
where a user could configure a silently broken setup.

**`kb_embedding_api_key` scrubbing requires no code change** — the
existing `isSensitiveConfigKey` function matches any key containing the
substring `api_key`, so `kb_embedding_api_key` is covered automatically.

**The KB file check ordering in `Refresh` is load-bearing** — the
comment in the code explains why it must come before the `config.yaml`
check. Do not reorder.

**SIGHUP does not reload KB** — SIGHUP triggers
`clientManager.UpdateDatabaseConfigs()` only. KB state is initialized
once at startup. Any KB config change (provider, model, credentials,
or path) requires a container restart via a Control Plane service
update.

## Checklist

- [x] Tests added (unit)
- [x] Documentation updated (`docs/services/mcp.md`)
- [x] Issues linked

## Issues

- [PLAT-590](https://pgedge.atlassian.net/browse/PLAT-590)
- [PLAT-591](https://pgedge.atlassian.net/browse/PLAT-591)
- [PLAT-592](https://pgedge.atlassian.net/browse/PLAT-592)
- [PLAT-593](https://pgedge.atlassian.net/browse/PLAT-593)
- [PLAT-607](https://pgedge.atlassian.net/browse/PLAT-607)
- [PLAT-608](https://pgedge.atlassian.net/browse/PLAT-608)


[PLAT-590]: https://pgedge.atlassian.net/browse/PLAT-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ