### PR TITLE
chore: add option for staging repos to dev-lima

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ CLUSTER_TEST_SKIP_CLEANUP ?= 0
 CLUSTER_TEST_IMAGE_TAG ?=
 CLUSTER_TEST_DATA_DIR ?=
 DEV_LIMA_OS ?= rocky-9
+DEV_LIMA_USE_STAGING_PACKAGES ?= false
 
 ci_enabled=$(filter true,$(CI))
 docker_swarm_state=$(shell docker info --format '{{.Swarm.LocalNodeState}}')
@@ -413,7 +414,9 @@ api-docs:
 
 .PHONY: dev-lima-deploy
 dev-lima-deploy:
-	$(MAKE) -C lima deploy DEV_LIMA_OS=$(DEV_LIMA_OS)
+	$(MAKE) -C lima deploy \
+		DEV_LIMA_OS=$(DEV_LIMA_OS) \
+		DEV_LIMA_USE_STAGING_PACKAGES=$(DEV_LIMA_USE_STAGING_PACKAGES)
 
 .PHONY: dev-lima-build
 dev-lima-build:

--- a/docs/development/running-locally.md
+++ b/docs/development/running-locally.md
@@ -441,3 +441,28 @@ To reset this environment to its initial state, stop the servers by hitting `ctr
 ```sh
 make dev-lima-reset
 ```
+
+### Prerelease Package Testing
+
+You can deploy the staging package repositories to the `dev-lima` environment using the `DEV_LIMA_USE_STAGING_PACKAGES` environment variable:
+
+```sh
+# If you already have the dev-lima environment running, make sure to stop and
+# remove all databases:
+make dev-lima-reset
+
+# Set DEV_LIMA_USE_STAGING_PACKAGES=true to use the staging packages. If this
+# environment was already running, this will remove existing pgEdge packages and
+# reinstall them from the staging repository:
+make dev-lima-deploy DEV_LIMA_USE_STAGING_PACKAGES=true
+
+# To switch back to the release repositories:
+make dev-lima-reset
+make dev-lima-deploy
+
+# The same works with the debian environments, e.g.:
+make dev-lima-reset
+make dev-lima-deploy DEV_LIMA_OS=debian-13 DEV_LIMA_USE_STAGING_PACKAGES=true
+
+# Remember to run 'make dev-lima-teardown' when switching between distributions.
+```

--- a/lima/Makefile
+++ b/lima/Makefile
@@ -1,8 +1,10 @@
 DEV_LIMA_OS ?= rocky-9
+DEV_LIMA_USE_STAGING_PACKAGES ?= false
 
 ansible_playbook=ansible-playbook \
 	--extra-vars='@vars.yaml' \
-	--extra-vars='os=$(DEV_LIMA_OS)'
+	--extra-vars='os=$(DEV_LIMA_OS)' \
+	--extra-vars='use_staging_packages=$(DEV_LIMA_USE_STAGING_PACKAGES)'
 
 .PHONY: quit
 quit:

--- a/lima/ansible.cfg
+++ b/lima/ansible.cfg
@@ -4,3 +4,4 @@ host_key_checking = False
 inventory = inventory.yaml
 interpreter_python = auto_silent
 forks = 6
+display_skipped_hosts = False

--- a/lima/roles/deb_prerequisites/tasks/main.yaml
+++ b/lima/roles/deb_prerequisites/tasks/main.yaml
@@ -2,55 +2,62 @@
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: yes
-- name: Install pgEdge repository package prerequisites
+  changed_when: false
+- name: Install base prerequisites
   ansible.builtin.package:
     name: '{{ item }}'
     state: present
-  with_items:
+  loop:
     - curl
     - gnupg2
     - lsb-release
-- name: Install pgEdge repository
-  ansible.builtin.apt:
-    deb: https://apt.pgedge.com/repodeb/pgedge-release_latest_all.deb
-    state: present
-- name: Template control plane stack yaml
-  template:
-    src: pgedge-old.sources.tmpl
-    dest: /etc/apt/sources.list.d/pgedge-old.sources
-- name: Update apt cache again
-  ansible.builtin.apt:
-    update_cache: yes
-  become: true
-- name: Install control-plane prerequisites
-  ansible.builtin.package:
-    name: '{{ item }}'
-    state: present
-  with_items:
-    - pgedge-postgresql-18
-    - pgedge-postgresql-17
-    - pgedge-postgresql-16
-    - pgedge-postgresql-18-spock50
-    - pgedge-postgresql-17-spock50
-    - pgedge-postgresql-16-spock50
-    - pgedge-postgresql-18-snowflake
-    - pgedge-postgresql-17-snowflake
-    - pgedge-postgresql-16-snowflake
-    - pgedge-postgresql-18-lolor
-    - pgedge-postgresql-17-lolor
-    - pgedge-postgresql-16-lolor
-    - pgedge-patroni
-    - pgedge-pgbackrest
     - which
     - wget
     - git
     - chrony
+- name: Install pgEdge repository
+  ansible.builtin.apt:
+    deb: https://apt.pgedge.com/repodeb/pgedge-release_latest_all.deb
+    state: present
+- name: Install pgEdge old repository
+  template:
+    src: pgedge-old.sources.tmpl
+    dest: /etc/apt/sources.list.d/pgedge-old.sources
+- name: Reconfigure pgEdge repository for staging packages
+  ansible.builtin.replace:
+    path: /etc/apt/sources.list.d/pgedge.sources
+    regexp: release
+    replace: staging
+  when: use_staging_packages | bool
+  register: repo_reconfigured_to_staging
+- name: Reconfigure pgEdge repository for release packages
+  ansible.builtin.replace:
+    path: /etc/apt/sources.list.d/pgedge.sources
+    regexp: staging
+    replace: release
+  when: not (use_staging_packages | bool)
+  register: repo_reconfigured_to_release
+- name: Update apt cache again
+  ansible.builtin.apt:
+    update_cache: yes
+  changed_when: false
+- name: Remove pgEdge packages for reinstall
+  ansible.builtin.package:
+    name: '{{ item }}'
+    state: absent
+  loop: '{{ pgedge_packages }}'
+  when: repo_reconfigured_to_staging.changed or repo_reconfigured_to_release.changed
+- name: Install pgEdge packages
+  ansible.builtin.package:
+    name: '{{ item }}'
+    state: present
+  loop: '{{ pgedge_packages }}'
 - name: Disable default postgres units
   ansible.builtin.systemd_service:
     name: '{{ item }}'
     state: stopped
     enabled: false
-  with_items:
+  loop:
     - postgresql.service
     - postgresql@16-main.service
     - postgresql@17-main.service

--- a/lima/roles/deb_prerequisites/vars/main.yaml
+++ b/lima/roles/deb_prerequisites/vars/main.yaml
@@ -10,3 +10,18 @@ etcd_download_url: https://github.com/etcd-io/etcd/releases/download/{{ etcd_ver
 go_version: 1.25.5
 go_archive_name: go{{ go_version }}.linux-{{ _arch_transform[ansible_facts.architecture] }}.tar.gz
 go_download_url: https://dl.google.com/go/{{ go_archive_name }}
+pgedge_packages:
+  - pgedge-postgresql-18
+  - pgedge-postgresql-17
+  - pgedge-postgresql-16
+  - pgedge-postgresql-18-spock50
+  - pgedge-postgresql-17-spock50
+  - pgedge-postgresql-16-spock50
+  - pgedge-postgresql-18-snowflake
+  - pgedge-postgresql-17-snowflake
+  - pgedge-postgresql-16-snowflake
+  - pgedge-postgresql-18-lolor
+  - pgedge-postgresql-17-lolor
+  - pgedge-postgresql-16-lolor
+  - pgedge-patroni
+  - pgedge-pgbackrest

--- a/lima/roles/rhel_prerequisites/tasks/main.yaml
+++ b/lima/roles/rhel_prerequisites/tasks/main.yaml
@@ -1,11 +1,14 @@
 ---
-- name: Install epel-release
+- name: Install base prerequisites
   ansible.builtin.package:
     name: '{{ item }}'
     state: present
-  with_items:
+  loop:
     - epel-release
     - dnf
+    - which
+    - wget
+    - git
 - name: Enable crb
   community.general.dnf_config_manager:
     name: crb
@@ -33,31 +36,31 @@
     gpgcheck: no
     enabled: yes
     sslverify: yes
-- name: Install prerequisites
+- name: Reconfigure pgEdge repository for staging packages
+  ansible.builtin.replace:
+    path: /etc/yum.repos.d/pgedge.repo
+    regexp: release
+    replace: staging
+  when: use_staging_packages | bool
+  register: repo_reconfigured_to_staging
+- name: Reconfigure pgEdge repository for release packages
+  ansible.builtin.replace:
+    path: /etc/yum.repos.d/pgedge.repo
+    regexp: staging
+    replace: release
+  when: not (use_staging_packages | bool)
+  register: repo_reconfigured_to_release
+- name: Remove pgEdge packages for reinstall
+  ansible.builtin.package:
+    name: '{{ item }}'
+    state: absent
+  loop: '{{ pgedge_packages }}'
+  when: repo_reconfigured_to_staging.changed or repo_reconfigured_to_release.changed
+- name: Install pgEdge packages
   ansible.builtin.package:
     name: '{{ item }}'
     state: present
-  with_items:
-    - pgedge-postgresql18
-    - pgedge-postgresql17
-    - pgedge-postgresql16
-    - pgedge-spock50_18
-    - pgedge-spock50_17
-    - pgedge-spock50_16
-    - pgedge-snowflake_18
-    - pgedge-snowflake_17
-    - pgedge-snowflake_16
-    - pgedge-lolor_18
-    - pgedge-lolor_17
-    - pgedge-lolor_16
-    - pgedge-postgresql18-contrib
-    - pgedge-postgresql17-contrib
-    - pgedge-postgresql16-contrib
-    - pgedge-patroni
-    - pgedge-pgbackrest
-    - which
-    - wget
-    - git
+  loop: '{{ pgedge_packages }}'
 - name: Install etcdctl and etcdutl
   ansible.builtin.unarchive:
     src: "{{ etcd_download_url }}"

--- a/lima/roles/rhel_prerequisites/vars/main.yaml
+++ b/lima/roles/rhel_prerequisites/vars/main.yaml
@@ -10,3 +10,21 @@ etcd_download_url: https://github.com/etcd-io/etcd/releases/download/{{ etcd_ver
 go_version: 1.25.5
 go_archive_name: go{{ go_version }}.linux-{{ _arch_transform[ansible_facts.architecture] }}.tar.gz
 go_download_url: https://dl.google.com/go/{{ go_archive_name }}
+pgedge_packages:
+  - pgedge-postgresql18
+  - pgedge-postgresql17
+  - pgedge-postgresql16
+  - pgedge-spock50_18
+  - pgedge-spock50_17
+  - pgedge-spock50_16
+  - pgedge-snowflake_18
+  - pgedge-snowflake_17
+  - pgedge-snowflake_16
+  - pgedge-lolor_18
+  - pgedge-lolor_17
+  - pgedge-lolor_16
+  - pgedge-postgresql18-contrib
+  - pgedge-postgresql17-contrib
+  - pgedge-postgresql16-contrib
+  - pgedge-patroni
+  - pgedge-pgbackrest

--- a/lima/vars.yaml
+++ b/lima/vars.yaml
@@ -1,4 +1,5 @@
 ---
+use_staging_packages: false
 os: rocky-9
 machines:
   - name: control-plane-dev-1


### PR DESCRIPTION
Adds a new deploy option to enable the staging repository in the dev-lima environment:

```sh
make dev-lima-deploy DEV_LIMA_USE_STAGING_PACKAGES=true
```

See the doc updates included in this commit for further usage instructions.
