### PR TITLE
chore: add missing changelog entries

### DIFF
--- a/changes/unreleased/Added-20260509-000000.yaml
+++ b/changes/unreleased/Added-20260509-000000.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: Added support for Spock 5.0.7 on Postgres 16.13, 17.9, and 18.3.
-time: 2026-05-09T00:00:00.000000-00:00

--- a/changes/unreleased/Added-20260518-000000.yaml
+++ b/changes/unreleased/Added-20260518-000000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added support for Spock 5.0.8 on Postgres 16.14, 17.10, and 18.4.
+time: 2026-05-18T00:00:00.000000-00:00

--- a/changes/unreleased/Fixed-20260518-000000.yaml
+++ b/changes/unreleased/Fixed-20260518-000000.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed add-node data safety by ensuring replication slot and origin are correctly advanced before the new node joins.
+time: 2026-05-18T00:00:00.000000-00:00


### PR DESCRIPTION
Fixup missing changelog entries for the next release:

✗ changie batch minor --dry-run

##  v0.8.1 - 2026-05-19 

### Added

Added support for Spock 5.0.8 on Postgres 16.14, 17.10, and 18.4.

### Fixed

Fixed add-node data safety by ensuring replication slot and origin are correctly advanced before the new node joins.

[PLAT-614](https://pgedge.atlassian.net/browse/PLAT-614)

[PLAT-614]: https://pgedge.atlassian.net/browse/PLAT-614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ