### PR TITLE
test(e2e): fix TestAddNodeOriginAdvanced flakiness and improve observability

### DIFF
--- a/e2e/add_node_data_safety_test.go
+++ b/e2e/add_node_data_safety_test.go
@@ -19,8 +19,11 @@ import (
 // causes the apply worker to start from the beginning of WAL, producing
 // duplicate-key errors or silently overwriting rows.
 //
-// Covers: Change 1 — EnsureReplicationOriginExists + AdvanceReplicationOrigin
-// wired into ReplicationSlotAdvanceFromCTSResource.
+// Covers: ReplicationOriginAdvanceResource which ensures the replication
+// origin exists and is advanced to the same LSN as the replication slot.
+// This resource depends on ReplicationSlotAdvanceFromCTSResource which runs
+// on the provider's host, while origin advancement runs on the subscriber's
+// host (since cross-host connections are not allowed).
 func TestAddNodeOriginAdvanced(t *testing.T) {
 	t.Parallel()
 
@@ -30,10 +33,11 @@ func TestAddNodeOriginAdvanced(t *testing.T) {
 		dbName   = "origin_adv_db"
 	)
 
-	ctx, cancel := context.WithTimeout(t.Context(), 7*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
 	defer cancel()
 
 	hostIDs := fixture.HostIDs()
+	t.Log("Step 1: Creating 2-node database fixture")
 	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
 		Spec: &controlplane.DatabaseSpec{
 			DatabaseName: dbName,
@@ -51,9 +55,11 @@ func TestAddNodeOriginAdvanced(t *testing.T) {
 			},
 		},
 	})
+	t.Logf("Database created: %s", db.ID)
 
 	// Write rows on n2 so its WAL position is meaningfully ahead of the slot's
 	// consistent_point. This gives the origin advancement a non-trivial LSN.
+	t.Log("Step 2: Writing 100 test rows to n2")
 	n2Opts := ConnectionOptions{
 		Matcher:  And(WithNode("n2"), WithRole("primary")),
 		Username: username,
@@ -68,18 +74,27 @@ func TestAddNodeOriginAdvanced(t *testing.T) {
 			require.NoError(t, err)
 		}
 	})
+	t.Log("Test data written successfully")
 
 	// Add n3 with n1 as source.
+	t.Log("Step 3: Adding n3 node with n1 as source")
 	db.Spec.Nodes = append(db.Spec.Nodes, &controlplane.DatabaseNodeSpec{
 		Name:       "n3",
 		HostIds:    []controlplane.Identifier{controlplane.Identifier(hostIDs[2])},
 		SourceNode: pointerTo("n1"),
 	})
+	t.Log("Starting database update to add n3 (this may take several minutes)")
 	require.NoError(t, db.Update(ctx, UpdateOptions{Spec: db.Spec}))
+	t.Log("Database update completed, n3 node added successfully")
+
+	t.Log("Step 3b: Waiting for replication to complete across all nodes")
+	db.WaitForReplication(ctx, t, username, password)
+	t.Log("Replication complete")
 
 	// The replication slot spk_<db>_n2_sub_n2_n3 lives on n2.
 	// The origin with the same name lives on n3 (subscriber side).
 	slotName := e2eReplicationSlotName(dbName, "n2", "n3")
+	t.Logf("Step 4: Checking replication origin on n3 (slot name: %s)", slotName)
 
 	n3Opts := ConnectionOptions{
 		Matcher:  And(WithNode("n3"), WithRole("primary")),
@@ -98,12 +113,14 @@ func TestAddNodeOriginAdvanced(t *testing.T) {
 			)`, slotName,
 		).Scan(&lsn)
 		require.NoError(t, err)
+		t.Logf("Replication origin LSN: %s (expected: not 0/0)", lsn)
 
 		assert.NotEqual(t, "0/0", lsn,
 			"replication origin %q on n3 should be advanced past 0/0 (got %s); "+
 				"a zeroed origin risks the apply worker replaying historical WAL",
 			slotName, lsn)
 	})
+	t.Log("Test completed successfully")
 }
 
 // e2eReplicationSlotName mirrors postgres.ReplicationSlotName without


### PR DESCRIPTION
## Summary
This PR enhance TestAddNodeOriginAdvanced E2E test reliability and observability by increasing context timeout to 10 minutes and adding comprehensive step-by-step logging. 

## Changes
- Add comprehensive step-by-step logging at each operation:
  - Step 1: Database creation with ID logging
  - Step 2: Test data insertion confirmation
  - Step 3: Node addition with expected duration note
  - Step 3b: Replication completion wait
  - Step 4: Replication origin verification with actual LSN value
- Add `WaitForReplication()` call after node update to ensure sync completes before assertion


## Testing
make test-e2e E2E_FIXTURE=lima E2E_RUN=TestAddNodeOriginAdvanced
/Users/sivat/go/bin/gotestsum  \
		--format-hide-empty-pkg \
		--format standard-verbose \
		--rerun-fails=0 \
		--rerun-fails-max-failures=4 \
		--packages='./e2e/...' \
		-- \
		-tags=e2e_test -count=1 -timeout=45m -parallel 4 -run TestAddNodeOriginAdvanced -args -fixture lima   
2026/05/20 15:16:18 initializing cluster
2026/05/20 15:16:18 cluster initialized
=== RUN   TestAddNodeOriginAdvanced
=== PAUSE TestAddNodeOriginAdvanced
=== CONT  TestAddNodeOriginAdvanced
    add_node_data_safety_test.go:40: Step 1: Creating 2-node database fixture
    add_node_data_safety_test.go:58: Database created: 65567e2d-c4cb-484b-b54f-b8e034b7a781
    add_node_data_safety_test.go:62: Step 2: Writing 100 test rows to n2
    add_node_data_safety_test.go:77: Test data written successfully
    add_node_data_safety_test.go:80: Step 3: Adding n3 node with n1 as source
    add_node_data_safety_test.go:86: Starting database update to add n3 (this may take several minutes)
    add_node_data_safety_test.go:88: Database update completed, n3 node added successfully
    add_node_data_safety_test.go:90: Step 3b: Waiting for replication to complete across all nodes
    database_test.go:357: [TestAddNodeOriginAdvanced] waiting for replication to catch up on all nodes
    add_node_data_safety_test.go:92: Replication complete
    add_node_data_safety_test.go:97: Step 4: Checking replication origin on n3 (slot name: spk_origin_adv_db_n2_sub_n2_n3)
    add_node_data_safety_test.go:116: Replication origin LSN: 0/1D569A0 (expected: not 0/0)
    add_node_data_safety_test.go:123: Test completed successfully
    fixture_test.go:200: cleaning up database 65567e2d-c4cb-484b-b54f-b8e034b7a781
--- PASS: TestAddNodeOriginAdvanced (543.14s)
PASS
ok  	github.com/pgEdge/control-plane/e2e	543.641s

DONE 1 tests in 543.611s

## Checklist

- [x] Tests added or updated (unit and/or e2e, as needed)

[PLAT-617](https://pgedge.atlassian.net/browse/PLAT-617)

[PLAT-617]: https://pgedge.atlassian.net/browse/PLAT-617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ