### PR TITLE
test(e2e): add WaitForReplication after first switchover/failover

### DIFF
--- a/e2e/database_test.go
+++ b/e2e/database_test.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"iter"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	controlplane "github.com/pgEdge/control-plane/api/apiv1/gen/control_plane"
 	"github.com/pgEdge/control-plane/client"
@@ -355,85 +356,49 @@ func (d *DatabaseFixture) waitForTask(ctx context.Context, task *controlplane.Ta
 func (f *DatabaseFixture) WaitForReplication(ctx context.Context, t testing.TB, username, password string) {
 	tLog(t, "waiting for replication to catch up on all nodes")
 
-	// After a primary change (switchover/failover), Spock subscriptions need
-	// time to reconnect to the new primary.  Retry with fresh sync markers
-	// until all nodes are in sync or the 10-minute deadline is exceeded.
-	// The 10-minute budget accommodates Spock's reconnect delay when the
-	// provider node's primary changes (the logical replication slot must be
-	// re-created on the new primary, which takes additional time in CI).
-	// Each iteration calls wait_for_sync_event (30s timeout) plus a 15s
-	// sleep, so roughly 77s per retry; 10 minutes allows ~7 retries.
-	deadline := time.Now().Add(10 * time.Minute)
-	for {
-		if err := f.Refresh(ctx); err != nil {
-			t.Errorf("failed to refresh database state while waiting for replication: %v", err)
-			return
-		}
-		ok, reason := f.pollReplication(ctx, username, password)
-		if ok {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Errorf("replication did not catch up on all nodes within 10 minutes (last failure: %s)", reason)
-			return
-		}
-		tLogf(t, "replication not yet in sync, retrying in 15s... (%s)", reason)
-		select {
-		case <-ctx.Done():
-			t.Errorf("replication wait aborted: %v", ctx.Err())
-			return
-		case <-time.After(15 * time.Second):
-		}
-	}
-}
-
-// pollReplication inserts a sync marker on every primary, then checks that
-// each marker has been delivered to every other node's primary.  Returns
-// (true, "") only when all cross-node checks pass.  On failure it returns
-// (false, reason) where reason identifies the failing pair so callers can
-// log it.  Never calls t.Fatal/t.Error so it can be used safely in a retry loop.
-func (f *DatabaseFixture) pollReplication(ctx context.Context, username, password string) (bool, string) {
+	// Execute sync_event on all primary nodes
 	nodeSyncMap := make(map[string]string)
 	for _, node := range f.Spec.Nodes {
-		conn, err := f.ConnectToInstance(ctx, ConnectionOptions{
+		primaryOpts := ConnectionOptions{
 			Matcher:  And(WithNode(node.Name), WithRole("primary")),
 			Username: username,
 			Password: password,
+		}
+
+		f.WithConnection(ctx, primaryOpts, t, func(conn *pgx.Conn) {
+			var syncLSN string
+
+			row := conn.QueryRow(ctx, "SELECT spock.sync_event();")
+			require.NoError(t, row.Scan(&syncLSN))
+
+			assert.NotEmpty(t, syncLSN)
+
+			nodeSyncMap[node.Name] = syncLSN
 		})
-		if err != nil {
-			return false, fmt.Sprintf("connect to %s primary: %v", node.Name, err)
-		}
-		var syncLSN string
-		err = conn.QueryRow(ctx, "SELECT spock.sync_event();").Scan(&syncLSN)
-		conn.Close(ctx)
-		if err != nil || syncLSN == "" {
-			return false, fmt.Sprintf("sync_event on %s: %v", node.Name, err)
-		}
-		nodeSyncMap[node.Name] = syncLSN
 	}
 
+	// Verify wait_for_sync_event on all other nodes
 	for _, node := range f.Spec.Nodes {
+		primaryOpts := ConnectionOptions{
+			Matcher:  And(WithNode(node.Name), WithRole("primary")),
+			Username: username,
+			Password: password,
+		}
+
 		for peerNode, lsn := range nodeSyncMap {
 			if peerNode == node.Name {
 				continue
 			}
-			conn, err := f.ConnectToInstance(ctx, ConnectionOptions{
-				Matcher:  And(WithNode(node.Name), WithRole("primary")),
-				Username: username,
-				Password: password,
+
+			f.WithConnection(ctx, primaryOpts, t, func(conn *pgx.Conn) {
+				var synced bool
+
+				row := conn.QueryRow(ctx, "CALL spock.wait_for_sync_event(true, $1, $2::pg_lsn, 30);", peerNode, lsn)
+				require.NoError(t, row.Scan(&synced))
+				assert.True(t, synced)
 			})
-			if err != nil {
-				return false, fmt.Sprintf("connect to %s primary for peer check: %v", node.Name, err)
-			}
-			var synced bool
-			err = conn.QueryRow(ctx, "CALL spock.wait_for_sync_event(true, $1, $2::pg_lsn, 30);", peerNode, lsn).Scan(&synced)
-			conn.Close(ctx)
-			if err != nil || !synced {
-				return false, fmt.Sprintf("%s waiting for %s events (LSN %s): synced=%v err=%v", node.Name, peerNode, lsn, synced, err)
-			}
 		}
 	}
-	return true, ""
 }
 
 func (d *DatabaseFixture) SwitchoverDatabaseNode(ctx context.Context, req *controlplane.SwitchoverDatabaseNodePayload) error {

--- a/e2e/database_test.go
+++ b/e2e/database_test.go
@@ -8,10 +8,9 @@ import (
 	"fmt"
 	"iter"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	controlplane "github.com/pgEdge/control-plane/api/apiv1/gen/control_plane"
 	"github.com/pgEdge/control-plane/client"
@@ -356,49 +355,85 @@ func (d *DatabaseFixture) waitForTask(ctx context.Context, task *controlplane.Ta
 func (f *DatabaseFixture) WaitForReplication(ctx context.Context, t testing.TB, username, password string) {
 	tLog(t, "waiting for replication to catch up on all nodes")
 
-	// Execute sync_event on all primary nodes
+	// After a primary change (switchover/failover), Spock subscriptions need
+	// time to reconnect to the new primary.  Retry with fresh sync markers
+	// until all nodes are in sync or the 10-minute deadline is exceeded.
+	// The 10-minute budget accommodates Spock's reconnect delay when the
+	// provider node's primary changes (the logical replication slot must be
+	// re-created on the new primary, which takes additional time in CI).
+	// Each iteration calls wait_for_sync_event (30s timeout) plus a 15s
+	// sleep, so roughly 77s per retry; 10 minutes allows ~7 retries.
+	deadline := time.Now().Add(10 * time.Minute)
+	for {
+		if err := f.Refresh(ctx); err != nil {
+			t.Errorf("failed to refresh database state while waiting for replication: %v", err)
+			return
+		}
+		ok, reason := f.pollReplication(ctx, username, password)
+		if ok {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Errorf("replication did not catch up on all nodes within 10 minutes (last failure: %s)", reason)
+			return
+		}
+		tLogf(t, "replication not yet in sync, retrying in 15s... (%s)", reason)
+		select {
+		case <-ctx.Done():
+			t.Errorf("replication wait aborted: %v", ctx.Err())
+			return
+		case <-time.After(15 * time.Second):
+		}
+	}
+}
+
+// pollReplication inserts a sync marker on every primary, then checks that
+// each marker has been delivered to every other node's primary.  Returns
+// (true, "") only when all cross-node checks pass.  On failure it returns
+// (false, reason) where reason identifies the failing pair so callers can
+// log it.  Never calls t.Fatal/t.Error so it can be used safely in a retry loop.
+func (f *DatabaseFixture) pollReplication(ctx context.Context, username, password string) (bool, string) {
 	nodeSyncMap := make(map[string]string)
 	for _, node := range f.Spec.Nodes {
-		primaryOpts := ConnectionOptions{
+		conn, err := f.ConnectToInstance(ctx, ConnectionOptions{
 			Matcher:  And(WithNode(node.Name), WithRole("primary")),
 			Username: username,
 			Password: password,
-		}
-
-		f.WithConnection(ctx, primaryOpts, t, func(conn *pgx.Conn) {
-			var syncLSN string
-
-			row := conn.QueryRow(ctx, "SELECT spock.sync_event();")
-			require.NoError(t, row.Scan(&syncLSN))
-
-			assert.NotEmpty(t, syncLSN)
-
-			nodeSyncMap[node.Name] = syncLSN
 		})
+		if err != nil {
+			return false, fmt.Sprintf("connect to %s primary: %v", node.Name, err)
+		}
+		var syncLSN string
+		err = conn.QueryRow(ctx, "SELECT spock.sync_event();").Scan(&syncLSN)
+		conn.Close(ctx)
+		if err != nil || syncLSN == "" {
+			return false, fmt.Sprintf("sync_event on %s: %v", node.Name, err)
+		}
+		nodeSyncMap[node.Name] = syncLSN
 	}
 
-	// Verify wait_for_sync_event on all other nodes
 	for _, node := range f.Spec.Nodes {
-		primaryOpts := ConnectionOptions{
-			Matcher:  And(WithNode(node.Name), WithRole("primary")),
-			Username: username,
-			Password: password,
-		}
-
 		for peerNode, lsn := range nodeSyncMap {
 			if peerNode == node.Name {
 				continue
 			}
-
-			f.WithConnection(ctx, primaryOpts, t, func(conn *pgx.Conn) {
-				var synced bool
-
-				row := conn.QueryRow(ctx, "CALL spock.wait_for_sync_event(true, $1, $2::pg_lsn, 30);", peerNode, lsn)
-				require.NoError(t, row.Scan(&synced))
-				assert.True(t, synced)
+			conn, err := f.ConnectToInstance(ctx, ConnectionOptions{
+				Matcher:  And(WithNode(node.Name), WithRole("primary")),
+				Username: username,
+				Password: password,
 			})
+			if err != nil {
+				return false, fmt.Sprintf("connect to %s primary for peer check: %v", node.Name, err)
+			}
+			var synced bool
+			err = conn.QueryRow(ctx, "CALL spock.wait_for_sync_event(true, $1, $2::pg_lsn, 30);", peerNode, lsn).Scan(&synced)
+			conn.Close(ctx)
+			if err != nil || !synced {
+				return false, fmt.Sprintf("%s waiting for %s events (LSN %s): synced=%v err=%v", node.Name, peerNode, lsn, synced, err)
+			}
 		}
 	}
+	return true, ""
 }
 
 func (d *DatabaseFixture) SwitchoverDatabaseNode(ctx context.Context, req *controlplane.SwitchoverDatabaseNodePayload) error {

--- a/e2e/failover_test.go
+++ b/e2e/failover_test.go
@@ -23,7 +23,7 @@ func TestFailoverScenarios(t *testing.T) {
 	host2 := hostIDs[1]
 	host3 := hostIDs[2]
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
 	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{

--- a/e2e/failover_test.go
+++ b/e2e/failover_test.go
@@ -17,11 +17,13 @@ import (
 func TestFailoverScenarios(t *testing.T) {
 	t.Parallel()
 
-	host1 := fixture.HostIDs()[0]
-	host2 := fixture.HostIDs()[1]
-	host3 := fixture.HostIDs()[2]
+	hostIDs := fixture.HostIDs()
+	require.GreaterOrEqual(t, len(hostIDs), 3, "fixture must provide at least 3 hosts")
+	host1 := hostIDs[0]
+	host2 := hostIDs[1]
+	host3 := hostIDs[2]
 
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
 	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
@@ -42,6 +44,10 @@ func TestFailoverScenarios(t *testing.T) {
 					Name:    "n1",
 					HostIds: []controlplane.Identifier{controlplane.Identifier(host1), controlplane.Identifier(host2), controlplane.Identifier(host3)},
 				},
+				{
+					Name:    "n2",
+					HostIds: []controlplane.Identifier{controlplane.Identifier(host1)},
+				},
 			},
 		},
 	})
@@ -56,15 +62,17 @@ func TestFailoverScenarios(t *testing.T) {
 		return inst.ID
 	}
 
-	waitFor(func() bool {
-		db.Refresh(ctx)
+	require.True(t, waitFor(func() bool {
+		require.NoError(t, db.Refresh(ctx))
 		for _, inst := range db.Instances {
 			if inst.NodeName == "n1" && (inst.State == "modifying" || inst.State == "creating") {
 				return false
 			}
 		}
 		return true
-	}, 60*time.Second)
+	}, 60*time.Second))
+
+	waitForFailoverSlots(ctx, t, db)
 
 	// Returns a non-primary instance that's ready/available, or "" if none found within timeout.
 	waitForReadyReplica := func(timeout time.Duration) string {
@@ -138,6 +146,7 @@ func TestFailoverScenarios(t *testing.T) {
 			"[auto] primary did not change within timeout (still %s)", origPrimary)
 		newPrimary := getPrimaryInstanceID()
 		t.Logf("[auto] new primary: %s", newPrimary)
+		db.WaitForReplication(ctx, t, "admin", "password")
 	})
 
 	t.Run("failover to a specific candidate", func(t *testing.T) {

--- a/e2e/switchover_test.go
+++ b/e2e/switchover_test.go
@@ -25,7 +25,7 @@ func TestSwitchoverScenarios(t *testing.T) {
 	host2 := hostIDs[1]
 	host3 := hostIDs[2]
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
 	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{

--- a/e2e/switchover_test.go
+++ b/e2e/switchover_test.go
@@ -9,19 +9,23 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
 	controlplane "github.com/pgEdge/control-plane/api/apiv1/gen/control_plane"
+	"github.com/pgEdge/control-plane/client"
 )
 
 func TestSwitchoverScenarios(t *testing.T) {
 	t.Parallel()
 
-	host1 := fixture.HostIDs()[0]
-	host2 := fixture.HostIDs()[1]
-	host3 := fixture.HostIDs()[2]
+	hostIDs := fixture.HostIDs()
+	require.GreaterOrEqual(t, len(hostIDs), 3, "fixture must provide at least 3 hosts")
+	host1 := hostIDs[0]
+	host2 := hostIDs[1]
+	host3 := hostIDs[2]
 
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
 	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
@@ -42,6 +46,10 @@ func TestSwitchoverScenarios(t *testing.T) {
 					Name:    "n1",
 					HostIds: []controlplane.Identifier{controlplane.Identifier(host1), controlplane.Identifier(host2), controlplane.Identifier(host3)},
 				},
+				{
+					Name:    "n2",
+					HostIds: []controlplane.Identifier{controlplane.Identifier(host1)},
+				},
 			},
 		},
 	})
@@ -60,15 +68,17 @@ func TestSwitchoverScenarios(t *testing.T) {
 		return inst.ID
 	}
 
-	waitFor(func() bool {
-		db.Refresh(ctx)
+	require.True(t, waitFor(func() bool {
+		require.NoError(t, db.Refresh(ctx))
 		for _, inst := range db.Instances {
 			if inst.NodeName == "n1" && (inst.State == "modifying" || inst.State == "creating") {
 				return false
 			}
 		}
 		return true
-	}, 60*time.Second)
+	}, 60*time.Second))
+
+	waitForFailoverSlots(ctx, t, db)
 
 	// Returns a non-primary instance that's ready/available, or "" if none found within timeout.
 	waitForReadyReplica := func(curPrimary string, timeout time.Duration) string {
@@ -140,6 +150,7 @@ func TestSwitchoverScenarios(t *testing.T) {
 			"[auto] primary did not change within timeout (still %s)", origPrimary)
 		newPrimary := getPrimaryInstanceID()
 		t.Logf("[auto] new primary: %s", newPrimary)
+		db.WaitForReplication(ctx, t, "admin", "password")
 	})
 
 	t.Run("switchover to a specific candidate", func(t *testing.T) {
@@ -259,6 +270,32 @@ func waitFor(cond func() bool, timeout time.Duration) bool {
 		time.Sleep(1 * time.Second)
 	}
 	return false
+}
+
+func waitForFailoverSlots(ctx context.Context, t *testing.T, db *DatabaseFixture) {
+	require.NoError(t, db.Refresh(ctx))
+	replicas := db.GetInstances(And(WithRole(client.RoleReplica)))
+	require.NotEmpty(t, replicas)
+	for replica := range replicas {
+		opts := ConnectionOptions{
+			Username: "admin",
+			Password: "password",
+			Instance: replica,
+		}
+		db.WithConnection(ctx, opts, t, func(conn *pgx.Conn) {
+			tLogf(t, "waiting for failover slot to exist on replica instance %s", replica.ID)
+			start := time.Now()
+
+			require.True(t, waitFor(func() bool {
+				var failoverSlotExists bool
+				row := conn.QueryRow(ctx, `select exists (select 1 from pg_replication_slots where plugin = 'spock_output')`)
+				require.NoError(t, row.Scan(&failoverSlotExists))
+				return failoverSlotExists
+			}, 60*time.Second))
+
+			tLogf(t, "failover slot exists in replica instance %s after %.2f seconds", replica.ID, time.Since(start).Seconds())
+		})
+	}
 }
 
 func serverNowUTC(t *testing.T, baseURL string) time.Time {


### PR DESCRIPTION
## Summary
This PR adds a `db.WaitForReplication` call after the first automatic switchover in `TestSwitchoverScenarios` to verify replication recovery after a topology change, and also adds the same check after the first automatic failover in `TestFailoverScenarios`.

## Changes

- Add `db.WaitForReplication `after the first automatic switchover in `TestSwitchoverScenarios`
- Add `db.WaitForReplication` after the first automatic failover in `TestFailoverScenarios`
## Testing
Verification:

```
make test-e2e E2E_FIXTURE=lima E2E_RUN=TestSwitchoverScenarios                      
/Users/sivat/go/bin/gotestsum  \
		--format-hide-empty-pkg \
		--format standard-verbose \
		--rerun-fails=0 \
		--rerun-fails-max-failures=4 \
		--packages='./e2e/...' \
		-- \
		-tags=e2e_test -count=1 -timeout=45m -parallel 4 -run TestSwitchoverScenarios -args -fixture lima   
2026/05/25 11:28:35 initializing cluster
2026/05/25 11:28:35 cluster initialized
=== RUN   TestSwitchoverScenarios
=== PAUSE TestSwitchoverScenarios
=== CONT  TestSwitchoverScenarios
=== RUN   TestSwitchoverScenarios/automatic_candidate_selection_(no_candidate_specified)
    switchover_test.go:130: [auto] original primary: df0c6351-b081-444a-85d8-54600366e28a-n1-689qacsi
    switchover_test.go:142: [auto] new primary: df0c6351-b081-444a-85d8-54600366e28a-n1-9ptayhma
    database_test.go:357: [TestSwitchoverScenarios/automatic_candidate_selection_(no_candidate_specified)] waiting for replication to catch up on all nodes
--- PASS: TestSwitchoverScenarios/automatic_candidate_selection_(no_candidate_specified) (26.03s)
=== RUN   TestSwitchoverScenarios/switchover_to_a_specific_candidate
    switchover_test.go:153: [specific] current primary: df0c6351-b081-444a-85d8-54600366e28a-n1-9ptayhma, candidate (ready): df0c6351-b081-444a-85d8-54600366e28a-n1-689qacsi
    switchover_test.go:165: [specific] new primary confirmed: df0c6351-b081-444a-85d8-54600366e28a-n1-689qacsi
--- PASS: TestSwitchoverScenarios/switchover_to_a_specific_candidate (26.03s)
=== RUN   TestSwitchoverScenarios/scheduled_switchover
    switchover_test.go:188: [scheduled] hostNow=2026-05-25T06:00:29Z serverNow=2026-05-25T05:57:38Z skew=-2m51s scheduled_at=2026-05-25T05:59:38Z (delta=-51s)
    switchover_test.go:211: [scheduled] new primary confirmed: df0c6351-b081-444a-85d8-54600366e28a-n1-9ptayhma
--- PASS: TestSwitchoverScenarios/scheduled_switchover (136.38s)
=== RUN   TestSwitchoverScenarios/invalid_candidate_instance
    switchover_test.go:222: [invalid] got expected error: failed to call switchover api: not_found: instance not found
--- PASS: TestSwitchoverScenarios/invalid_candidate_instance (0.00s)
=== RUN   TestSwitchoverScenarios/concurrent_switchover_requests
    switchover_test.go:247: [concurrent] second request returned expected error: failed to call switchover api: server_error: switchover already in progress for database df0c6351-b081-444a-85d8-54600366e28a node n1
--- PASS: TestSwitchoverScenarios/concurrent_switchover_requests (25.03s)
    fixture_test.go:200: cleaning up database df0c6351-b081-444a-85d8-54600366e28a
--- PASS: TestSwitchoverScenarios (289.91s)
PASS
ok  	github.com/pgEdge/control-plane/e2e	290.413s

DONE 6 tests in 290.413s
```

```
make test-e2e E2E_FIXTURE=lima E2E_RUN=TestFailoverScenarios
/Users/sivat/go/bin/gotestsum  \
		--format-hide-empty-pkg \
		--format standard-verbose \
		--rerun-fails=0 \
		--rerun-fails-max-failures=4 \
		--packages='./e2e/...' \
		-- \
		-tags=e2e_test -count=1 -timeout=45m -parallel 4 -run TestFailoverScenarios -args -fixture lima   
2026/05/25 11:36:21 initializing cluster
2026/05/25 11:36:21 cluster initialized
=== RUN   TestFailoverScenarios
=== PAUSE TestFailoverScenarios
=== CONT  TestFailoverScenarios
=== RUN   TestFailoverScenarios/automatic_candidate_selection_(no_candidate_specified)
    failover_test.go:125: [auto] original primary: 1e06bf4a-8222-4631-8607-8ba0c20d4ea9-n1-689qacsi
    failover_test.go:140: [auto] new primary: 1e06bf4a-8222-4631-8607-8ba0c20d4ea9-n1-9ptayhma
    database_test.go:357: [TestFailoverScenarios/automatic_candidate_selection_(no_candidate_specified)] waiting for replication to catch up on all nodes
--- PASS: TestFailoverScenarios/automatic_candidate_selection_(no_candidate_specified) (26.03s)
=== RUN   TestFailoverScenarios/failover_to_a_specific_candidate
    failover_test.go:150: [specific] current primary: 1e06bf4a-8222-4631-8607-8ba0c20d4ea9-n1-9ptayhma, candidate (ready): 1e06bf4a-8222-4631-8607-8ba0c20d4ea9-n1-689qacsi
    failover_test.go:165: [specific] new primary confirmed: 1e06bf4a-8222-4631-8607-8ba0c20d4ea9-n1-689qacsi
--- PASS: TestFailoverScenarios/failover_to_a_specific_candidate (25.03s)
=== RUN   TestFailoverScenarios/invalid_candidate_instance
    failover_test.go:176: [invalid] got expected error: failed to call failover api: not_found: instance not found
--- PASS: TestFailoverScenarios/invalid_candidate_instance (0.01s)
=== RUN   TestFailoverScenarios/concurrent_failover_requests
    failover_test.go:201: [concurrent] second request returned expected error: failed to call failover api: server_error: failover already in progress for database 1e06bf4a-8222-4631-8607-8ba0c20d4ea9 node n1
--- PASS: TestFailoverScenarios/concurrent_failover_requests (6.52s)
=== RUN   TestFailoverScenarios/skip_validation_behavior
    failover_test.go:211: [skip-validation] original primary: 1e06bf4a-8222-4631-8607-8ba0c20d4ea9-n1-689qacsi
    failover_test.go:230: [skip-validation] got expected rejection without skip_validation: task status is 'failed' instead of 'completed', error=cluster is healthy; refuse failover unless skip_validation is true
--- PASS: TestFailoverScenarios/skip_validation_behavior (32.04s)
    fixture_test.go:200: cleaning up database 1e06bf4a-8222-4631-8607-8ba0c20d4ea9
--- PASS: TestFailoverScenarios (165.12s)
PASS
ok  	github.com/pgEdge/control-plane/e2e	165.615s

DONE 6 tests in 165.615s
```

## Checklist

- [x] Tests added or updated (unit and/or e2e, as needed)

[PLAT-612](https://pgedge.atlassian.net/browse/PLAT-612)

[PLAT-612]: https://pgedge.atlassian.net/browse/PLAT-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ