### PR TITLE
fix: allow longer instance ids in api

### DIFF
--- a/api/apiv1/design/api.go
+++ b/api/apiv1/design/api.go
@@ -382,6 +382,8 @@ var _ = g.Service("control-plane", func() {
 			g.Attribute("candidate_instance_id", g.String, func() {
 				g.Description("Optional instance_id for the replica candidate.")
 				g.Example("68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi")
+				g.MinLength(1)
+				g.MaxLength(63)
 			})
 			g.Attribute("scheduled_at", g.String, func() {
 				g.Description("Optional scheduled time (ISO8601) for the switchover. If absent switchover happens immediately.")
@@ -733,9 +735,11 @@ var _ = g.Service("control-plane", func() {
 				g.Description("The ID of the database that owns the instance.")
 				g.Example("68f50878-44d2-4524-a823-e31bd478706d")
 			})
-			g.Attribute("instance_id", Identifier, func() {
+			g.Attribute("instance_id", g.String, func() {
 				g.Description("The ID of the instance to restart.")
 				g.Example("68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi")
+				g.MinLength(1)
+				g.MaxLength(63)
 			})
 			g.Attribute("scheduled_at", g.String, func() {
 				g.Format(g.FormatDateTime)
@@ -791,9 +795,11 @@ var _ = g.Service("control-plane", func() {
 				g.Description("The ID of the database that owns the instance.")
 				g.Example("68f50878-44d2-4524-a823-e31bd478706d")
 			})
-			g.Attribute("instance_id", Identifier, func() {
+			g.Attribute("instance_id", g.String, func() {
 				g.Description("The ID of the instance to stop.")
 				g.Example("68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi")
+				g.MinLength(1)
+				g.MaxLength(63)
 			})
 			g.Attribute("force", g.Boolean, func() {
 				g.Description("Force stopping an instance even if database in an unmodifiable state")
@@ -846,9 +852,11 @@ var _ = g.Service("control-plane", func() {
 				g.Description("The ID of the database that owns the instance.")
 				g.Example("68f50878-44d2-4524-a823-e31bd478706d")
 			})
-			g.Attribute("instance_id", Identifier, func() {
+			g.Attribute("instance_id", g.String, func() {
 				g.Description("The ID of the instance to start.")
 				g.Example("68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi")
+				g.MinLength(1)
+				g.MaxLength(63)
 			})
 			g.Attribute("force", g.Boolean, func() {
 				g.Description("Force starting an instance even if database in an unmodifiable state")

--- a/api/apiv1/gen/control_plane/service.go
+++ b/api/apiv1/gen/control_plane/service.go
@@ -848,7 +848,7 @@ type RestartInstancePayload struct {
 	// The ID of the database that owns the instance.
 	DatabaseID Identifier
 	// The ID of the instance to restart.
-	InstanceID Identifier
+	InstanceID string
 	// The time at which the restart is scheduled.
 	ScheduledAt *string
 }
@@ -1027,7 +1027,7 @@ type StartInstancePayload struct {
 	// The ID of the database that owns the instance.
 	DatabaseID Identifier
 	// The ID of the instance to start.
-	InstanceID Identifier
+	InstanceID string
 	// Force starting an instance even if database in an unmodifiable state
 	Force bool
 }
@@ -1044,7 +1044,7 @@ type StopInstancePayload struct {
 	// The ID of the database that owns the instance.
 	DatabaseID Identifier
 	// The ID of the instance to stop.
-	InstanceID Identifier
+	InstanceID string
 	// Force stopping an instance even if database in an unmodifiable state
 	Force bool
 }

--- a/api/apiv1/gen/http/cli/control_plane/cli.go
+++ b/api/apiv1/gen/http/cli/control_plane/cli.go
@@ -997,7 +997,7 @@ func controlPlaneRestartInstanceUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane restart-instance --body '{\n      \"scheduled_at\": \"2025-06-18T16:52:05Z\"\n   }' --database-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --instance-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane restart-instance --body '{\n      \"scheduled_at\": \"2025-06-18T16:52:05Z\"\n   }' --database-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --instance-id \"68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi\"")
 }
 
 func controlPlaneStopInstanceUsage() {
@@ -1019,7 +1019,7 @@ func controlPlaneStopInstanceUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane stop-instance --database-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --instance-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --force true")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane stop-instance --database-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --instance-id \"68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi\" --force true")
 }
 
 func controlPlaneStartInstanceUsage() {
@@ -1041,7 +1041,7 @@ func controlPlaneStartInstanceUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane start-instance --database-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --instance-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --force true")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane start-instance --database-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --instance-id \"68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi\" --force true")
 }
 
 func controlPlaneCancelDatabaseTaskUsage() {

--- a/api/apiv1/gen/http/control_plane/client/cli.go
+++ b/api/apiv1/gen/http/control_plane/client/cli.go
@@ -463,6 +463,16 @@ func BuildSwitchoverDatabaseNodePayload(controlPlaneSwitchoverDatabaseNodeBody s
 		if err != nil {
 			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"candidate_instance_id\": \"68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi\",\n      \"scheduled_at\": \"2025-09-20T22:00:00+05:30\"\n   }'")
 		}
+		if body.CandidateInstanceID != nil {
+			if utf8.RuneCountInString(*body.CandidateInstanceID) < 1 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("body.candidate_instance_id", *body.CandidateInstanceID, utf8.RuneCountInString(*body.CandidateInstanceID), 1, true))
+			}
+		}
+		if body.CandidateInstanceID != nil {
+			if utf8.RuneCountInString(*body.CandidateInstanceID) > 63 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("body.candidate_instance_id", *body.CandidateInstanceID, utf8.RuneCountInString(*body.CandidateInstanceID), 63, false))
+			}
+		}
 		if body.ScheduledAt != nil {
 			err = goa.MergeErrors(err, goa.ValidateFormat("body.scheduled_at", *body.ScheduledAt, goa.FormatDateTime))
 		}
@@ -1022,8 +1032,8 @@ func BuildRestartInstancePayload(controlPlaneRestartInstanceBody string, control
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 36 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
+		if utf8.RuneCountInString(instanceID) > 63 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1033,7 +1043,7 @@ func BuildRestartInstancePayload(controlPlaneRestartInstanceBody string, control
 		ScheduledAt: body.ScheduledAt,
 	}
 	v.DatabaseID = controlplane.Identifier(databaseID)
-	v.InstanceID = controlplane.Identifier(instanceID)
+	v.InstanceID = instanceID
 
 	return v, nil
 }
@@ -1061,8 +1071,8 @@ func BuildStopInstancePayload(controlPlaneStopInstanceDatabaseID string, control
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 36 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
+		if utf8.RuneCountInString(instanceID) > 63 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1079,7 +1089,7 @@ func BuildStopInstancePayload(controlPlaneStopInstanceDatabaseID string, control
 	}
 	v := &controlplane.StopInstancePayload{}
 	v.DatabaseID = controlplane.Identifier(databaseID)
-	v.InstanceID = controlplane.Identifier(instanceID)
+	v.InstanceID = instanceID
 	v.Force = force
 
 	return v, nil
@@ -1108,8 +1118,8 @@ func BuildStartInstancePayload(controlPlaneStartInstanceDatabaseID string, contr
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 36 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
+		if utf8.RuneCountInString(instanceID) > 63 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
 		}
 		if err != nil {
 			return nil, err
@@ -1126,7 +1136,7 @@ func BuildStartInstancePayload(controlPlaneStartInstanceDatabaseID string, contr
 	}
 	v := &controlplane.StartInstancePayload{}
 	v.DatabaseID = controlplane.Identifier(databaseID)
-	v.InstanceID = controlplane.Identifier(instanceID)
+	v.InstanceID = instanceID
 	v.Force = force
 
 	return v, nil

--- a/api/apiv1/gen/http/control_plane/client/encode_decode.go
+++ b/api/apiv1/gen/http/control_plane/client/encode_decode.go
@@ -3464,7 +3464,7 @@ func (c *Client) BuildRestartInstanceRequest(ctx context.Context, v any) (*http.
 			return nil, goahttp.ErrInvalidType("control-plane", "restart-instance", "*controlplane.RestartInstancePayload", v)
 		}
 		databaseID = string(p.DatabaseID)
-		instanceID = string(p.InstanceID)
+		instanceID = p.InstanceID
 	}
 	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: RestartInstanceControlPlanePath(databaseID, instanceID)}
 	req, err := http.NewRequest("POST", u.String(), nil)
@@ -3609,7 +3609,7 @@ func (c *Client) BuildStopInstanceRequest(ctx context.Context, v any) (*http.Req
 			return nil, goahttp.ErrInvalidType("control-plane", "stop-instance", "*controlplane.StopInstancePayload", v)
 		}
 		databaseID = string(p.DatabaseID)
-		instanceID = string(p.InstanceID)
+		instanceID = p.InstanceID
 	}
 	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: StopInstanceControlPlanePath(databaseID, instanceID)}
 	req, err := http.NewRequest("POST", u.String(), nil)
@@ -3753,7 +3753,7 @@ func (c *Client) BuildStartInstanceRequest(ctx context.Context, v any) (*http.Re
 			return nil, goahttp.ErrInvalidType("control-plane", "start-instance", "*controlplane.StartInstancePayload", v)
 		}
 		databaseID = string(p.DatabaseID)
-		instanceID = string(p.InstanceID)
+		instanceID = p.InstanceID
 	}
 	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: StartInstanceControlPlanePath(databaseID, instanceID)}
 	req, err := http.NewRequest("POST", u.String(), nil)

--- a/api/apiv1/gen/http/control_plane/server/encode_decode.go
+++ b/api/apiv1/gen/http/control_plane/server/encode_decode.go
@@ -2929,8 +2929,8 @@ func DecodeRestartInstanceRequest(mux goahttp.Muxer, decoder func(*http.Request)
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 36 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
+		if utf8.RuneCountInString(instanceID) > 63 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
 		}
 		if err != nil {
 			return nil, err
@@ -3044,8 +3044,8 @@ func DecodeStopInstanceRequest(mux goahttp.Muxer, decoder func(*http.Request) go
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 36 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
+		if utf8.RuneCountInString(instanceID) > 63 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
 		}
 		{
 			forceRaw := r.URL.Query().Get("force")
@@ -3169,8 +3169,8 @@ func DecodeStartInstanceRequest(mux goahttp.Muxer, decoder func(*http.Request) g
 		if utf8.RuneCountInString(instanceID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 1, true))
 		}
-		if utf8.RuneCountInString(instanceID) > 36 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 36, false))
+		if utf8.RuneCountInString(instanceID) > 63 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("instance_id", instanceID, utf8.RuneCountInString(instanceID), 63, false))
 		}
 		{
 			forceRaw := r.URL.Query().Get("force")

--- a/api/apiv1/gen/http/control_plane/server/types.go
+++ b/api/apiv1/gen/http/control_plane/server/types.go
@@ -4966,7 +4966,7 @@ func NewRestartInstancePayload(body struct {
 		ScheduledAt: body.ScheduledAt,
 	}
 	v.DatabaseID = controlplane.Identifier(databaseID)
-	v.InstanceID = controlplane.Identifier(instanceID)
+	v.InstanceID = instanceID
 
 	return v
 }
@@ -4976,7 +4976,7 @@ func NewRestartInstancePayload(body struct {
 func NewStopInstancePayload(databaseID string, instanceID string, force bool) *controlplane.StopInstancePayload {
 	v := &controlplane.StopInstancePayload{}
 	v.DatabaseID = controlplane.Identifier(databaseID)
-	v.InstanceID = controlplane.Identifier(instanceID)
+	v.InstanceID = instanceID
 	v.Force = force
 
 	return v
@@ -4987,7 +4987,7 @@ func NewStopInstancePayload(databaseID string, instanceID string, force bool) *c
 func NewStartInstancePayload(databaseID string, instanceID string, force bool) *controlplane.StartInstancePayload {
 	v := &controlplane.StartInstancePayload{}
 	v.DatabaseID = controlplane.Identifier(databaseID)
-	v.InstanceID = controlplane.Identifier(instanceID)
+	v.InstanceID = instanceID
 	v.Force = force
 
 	return v
@@ -5129,6 +5129,16 @@ func ValidateBackupDatabaseNodeRequestBody(body *BackupDatabaseNodeRequestBody) 
 // ValidateSwitchoverDatabaseNodeRequestBody runs the validations defined on
 // Switchover-Database-NodeRequestBody
 func ValidateSwitchoverDatabaseNodeRequestBody(body *SwitchoverDatabaseNodeRequestBody) (err error) {
+	if body.CandidateInstanceID != nil {
+		if utf8.RuneCountInString(*body.CandidateInstanceID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.candidate_instance_id", *body.CandidateInstanceID, utf8.RuneCountInString(*body.CandidateInstanceID), 1, true))
+		}
+	}
+	if body.CandidateInstanceID != nil {
+		if utf8.RuneCountInString(*body.CandidateInstanceID) > 63 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.candidate_instance_id", *body.CandidateInstanceID, utf8.RuneCountInString(*body.CandidateInstanceID), 63, false))
+		}
+	}
 	if body.ScheduledAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.scheduled_at", *body.ScheduledAt, goa.FormatDateTime))
 	}

--- a/api/apiv1/gen/http/openapi.json
+++ b/api/apiv1/gen/http/openapi.json
@@ -681,9 +681,11 @@
           {
             "name": "instance_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "The ID of the instance to restart.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "minLength": 1
           },
           {
             "name": "object",
@@ -791,9 +793,11 @@
           {
             "name": "instance_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "The ID of the instance to start.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "minLength": 1
           }
         ],
         "responses": {
@@ -885,9 +889,11 @@
           {
             "name": "instance_id",
             "in": "path",
-            "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
+            "description": "The ID of the instance to stop.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "minLength": 1
           }
         ],
         "responses": {
@@ -3273,7 +3279,9 @@
         "candidate_instance_id": {
           "type": "string",
           "description": "Optional instance_id for the replica candidate.",
-          "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi"
+          "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi",
+          "minLength": 1,
+          "maxLength": 63
         },
         "scheduled_at": {
           "type": "string",

--- a/api/apiv1/gen/http/openapi.yaml
+++ b/api/apiv1/gen/http/openapi.yaml
@@ -472,9 +472,11 @@ paths:
           type: string
         - name: instance_id
           in: path
-          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: The ID of the instance to restart.
           required: true
           type: string
+          maxLength: 63
+          minLength: 1
         - name: object
           in: body
           required: true
@@ -548,9 +550,11 @@ paths:
           type: string
         - name: instance_id
           in: path
-          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: The ID of the instance to start.
           required: true
           type: string
+          maxLength: 63
+          minLength: 1
       responses:
         "200":
           description: OK response.
@@ -613,9 +617,11 @@ paths:
           type: string
         - name: instance_id
           in: path
-          description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
+          description: The ID of the instance to stop.
           required: true
           type: string
+          maxLength: 63
+          minLength: 1
       responses:
         "200":
           description: OK response.
@@ -2322,6 +2328,8 @@ definitions:
         type: string
         description: Optional instance_id for the replica candidate.
         example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
+        minLength: 1
+        maxLength: 63
       scheduled_at:
         type: string
         description: Optional scheduled time (ISO8601) for the switchover. If absent switchover happens immediately.

--- a/api/apiv1/gen/http/openapi3.json
+++ b/api/apiv1/gen/http/openapi3.json
@@ -2183,10 +2183,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
-              "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "description": "The ID of the instance to restart.",
+              "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi",
               "minLength": 1,
-              "maxLength": 36
+              "maxLength": 63
             },
             "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi"
           }
@@ -2357,10 +2357,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
-              "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "description": "The ID of the instance to start.",
+              "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi",
               "minLength": 1,
-              "maxLength": 36
+              "maxLength": 63
             },
             "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi"
           }
@@ -2507,10 +2507,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.",
-              "example": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "description": "The ID of the instance to stop.",
+              "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi",
               "minLength": 1,
-              "maxLength": 36
+              "maxLength": 63
             },
             "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi"
           }
@@ -26973,7 +26973,9 @@
           "candidate_instance_id": {
             "type": "string",
             "description": "Optional instance_id for the replica candidate.",
-            "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi"
+            "example": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi",
+            "minLength": 1,
+            "maxLength": 63
           },
           "scheduled_at": {
             "type": "string",

--- a/api/apiv1/gen/http/openapi3.yaml
+++ b/api/apiv1/gen/http/openapi3.yaml
@@ -1424,10 +1424,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
-            example: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            description: The ID of the instance to restart.
+            example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
             minLength: 1
-            maxLength: 36
+            maxLength: 63
           example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
       requestBody:
         required: true
@@ -1543,10 +1543,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
-            example: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            description: The ID of the instance to start.
+            example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
             minLength: 1
-            maxLength: 36
+            maxLength: 63
           example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
       responses:
         "200":
@@ -1646,10 +1646,10 @@ paths:
           required: true
           schema:
             type: string
-            description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
-            example: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            description: The ID of the instance to stop.
+            example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
             minLength: 1
-            maxLength: 36
+            maxLength: 63
           example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
       responses:
         "200":
@@ -19057,6 +19057,8 @@ components:
           type: string
           description: Optional instance_id for the replica candidate.
           example: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
+          minLength: 1
+          maxLength: 63
         scheduled_at:
           type: string
           description: Optional scheduled time (ISO8601) for the switchover. If absent switchover happens immediately.

--- a/e2e/database_test.go
+++ b/e2e/database_test.go
@@ -177,7 +177,7 @@ type RestartInstanceOptions struct {
 func (d *DatabaseFixture) RestartInstance(ctx context.Context, options RestartInstanceOptions) error {
 	resp, err := d.client.RestartInstance(ctx, &controlplane.RestartInstancePayload{
 		DatabaseID: d.ID,
-		InstanceID: controlplane.Identifier(options.InstanceID),
+		InstanceID: options.InstanceID,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to restart instance: %w", err)


### PR DESCRIPTION
## Summary

Fixes an issue where valid instance IDs are rejected by our API validation. Instance IDs are an aggregate that includes database ID, node name, and a hash of the host ID. When the database ID is the maximum allowable length for an Identifier, its instance IDs will exceed the maximum length for an Identifier. This commit switches to using strings with longer limits to avoid this issue.

## Testing

This PR fixes this test case:

```sh
# create a database with a max length id
cp1-req create-database <<EOF | cp-follow-task             
{
  "id": "a37e2ed1-bb81-49cb-872b-2bdb7fff3bbc",
  "spec": {
    "database_name": "storefront",
    "database_users": [
      {
        "username": "admin",
        "password": "password",
        "db_owner": true,
        "attributes": ["SUPERUSER", "LOGIN"]
      }
    ],
    "port": 0,
    "nodes": [
      { "name": "n1", "host_ids": ["host-1"] }
    ]
  }
}
EOF

# attempt to stop the n1 instance
# on main, this would return a validation error
cp1-req stop-instance a37e2ed1-bb81-49cb-872b-2bdb7fff3bbc \
    a37e2ed1-bb81-49cb-872b-2bdb7fff3bbc-n1-689qacsi
```
