### PR TITLE
chore: added missing changelog entries

### DIFF
--- a/changes/unreleased/Added-20260611-090000.yaml
+++ b/changes/unreleased/Added-20260611-090000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added `pg_hba_conf` and `pg_ident_conf` fields to the database spec — Operators can now supply custom `pg_hba.conf` and `pg_ident.conf` entries at the database or per-node level, giving full control over client authentication rules and ident mappings. Per-node entries take first-match priority over database-level entries.
+time: 2026-06-11T09:00:00.000000-04:00

--- a/changes/unreleased/Added-20260611-090010.yaml
+++ b/changes/unreleased/Added-20260611-090010.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added Knowledge Base search support to the MCP service — Enable the `search_knowledgebase` tool via the `kb_enabled` option in the MCP service configuration, with support for OpenAI and Voyage AI embedding providers. The Knowledge Base file is loaded from a configurable host path and mounted read-only into the container.
+time: 2026-06-11T09:00:10.000000-04:00

--- a/changes/unreleased/Fixed-20260611-090000.yaml
+++ b/changes/unreleased/Fixed-20260611-090000.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed global Patroni parameters not being applied to running systemd-managed database clusters — Dynamic configuration changes are now patched directly via the Patroni API on the primary instance, ensuring parameters that cannot be changed via config file reload take effect immediately.
+time: 2026-06-11T09:00:00.000000-04:00

--- a/changes/unreleased/Fixed-20260611-090010.yaml
+++ b/changes/unreleased/Fixed-20260611-090010.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed valid instance IDs being incorrectly rejected by the API when the database ID was at its maximum allowed length — Instance IDs are an internal aggregate of the database ID, node name, and host hash, and are no longer subject to the same length limit as user-supplied identifiers.
+time: 2026-06-11T09:00:10.000000-04:00

--- a/changes/unreleased/Fixed-20260611-090020.yaml
+++ b/changes/unreleased/Fixed-20260611-090020.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed Postgres logging not being enabled by default on Debian-based systemd deployments — The default log configuration that was already applied to RPM-based deployments is now also applied to Debian-based ones.
+time: 2026-06-11T09:00:20.000000-04:00


### PR DESCRIPTION
Fixup missing changelog entries for the next release:

✗ changie batch minor --dry-run

## v0.9.0 - 2026-06-11
### Added
- Added `pg_hba_conf` and `pg_ident_conf` fields to the database spec — Operators can now supply custom `pg_hba.conf` and `pg_ident.conf` entries at the database or per-node level, giving full control over client authentication rules and ident mappings. Per-node entries take first-match priority over database-level entries. 
- Added Knowledge Base search support to the MCP service — Enable the `search_knowledgebase` tool via the `kb_enabled` option in the MCP service configuration, with support for OpenAI and Voyage AI embedding providers. The Knowledge Base file is loaded from a configurable host path and mounted read-only into the container.
### Fixed

- Fixed global Patroni parameters not being applied to running systemd-managed database clusters — Dynamic configuration changes are now patched directly via the Patroni API on the primary instance, ensuring parameters that cannot be changed via config file reload take effect immediately.
- Fixed valid instance IDs being incorrectly rejected by the API when the database ID was at its maximum allowed length — Instance IDs are an internal aggregate of the database ID, node name, and host hash, and are no longer subject to the same length limit as user-supplied identifiers.
- Fixed Postgres logging not being enabled by default on Debian-based systemd deployments — The default log configuration that was already applied to RPM-based deployments is now also applied to Debian-based ones.

[PLAT-642](https://pgedge.atlassian.net/browse/PLAT-642)

[PLAT-642]: https://pgedge.atlassian.net/browse/PLAT-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ