### PR TITLE
docs: remove changelog entry for debian logging

### DIFF
--- a/changes/unreleased/Fixed-20260611-090020.yaml
+++ b/changes/unreleased/Fixed-20260611-090020.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: Fixed Postgres logging not being enabled by default on Debian-based systemd deployments — The default log configuration that was already applied to RPM-based deployments is now also applied to Debian-based ones.
-time: 2026-06-11T09:00:20.000000-04:00


### PR DESCRIPTION
Debian support didn't exist in the previous release, so no user would be affected by this issue. Issues that are created and fixed between releases should be omitted from the changelog.
