### PR TITLE
feat: validate conf libraries contain spock

### DIFF
--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -42,17 +42,24 @@ func validateAuthFileGUCs(conf map[string]any, path validation.Path) []error {
 }
 
 func validateConfLibraries(conf map[string]any, path validation.Path) []error {
-	val, ok := utils.TypedFromMap[string](conf, "shared_preload_libraries")
-	if !ok {
-		return nil // defaults will be applied, including spock
-	}
-	for _, lib := range strings.Split(val, ",") {
-		if strings.TrimSpace(lib) == "spock" {
-			return nil
+	for key, val := range conf {
+		if strings.ToLower(strings.TrimSpace(key)) != "shared_preload_libraries" {
+			continue
 		}
+		strVal, ok := val.(string)
+		if !ok {
+			err := fmt.Errorf("%q must be a string", key)
+			return []error{validation.NewError(err, path.AppendMapKey(key))}
+		}
+		for _, lib := range strings.Split(strVal, ",") {
+			if strings.TrimSpace(lib) == "spock" {
+				return nil
+			}
+		}
+		err := errors.New(`"spock" must be included in shared_preload_libraries`)
+		return []error{validation.NewError(err, path.AppendMapKey(key))}
 	}
-	err := errors.New(`"spock" must be included in shared_preload_libraries`)
-	return []error{validation.NewError(err, path.AppendMapKey("shared_preload_libraries"))}
+	return nil // key absent; defaults will be applied, including spock
 }
 
 // validatePgHbaConf checks that every non-comment pg_hba_conf entry parses.

--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -43,19 +43,16 @@ func validateAuthFileGUCs(conf map[string]any, path validation.Path) []error {
 
 func validateConfLibraries(conf map[string]any, path validation.Path) []error {
 	val, ok := utils.TypedFromMap[string](conf, "shared_preload_libraries")
-
 	if !ok {
-		return nil //defaults will be applied, including spock
+		return nil // defaults will be applied, including spock
 	}
 	for _, lib := range strings.Split(val, ",") {
 		if strings.TrimSpace(lib) == "spock" {
 			return nil
 		}
 	}
-
 	err := errors.New(`"spock" must be included in shared_preload_libraries`)
 	return []error{validation.NewError(err, path.AppendMapKey("shared_preload_libraries"))}
-
 }
 
 // validatePgHbaConf checks that every non-comment pg_hba_conf entry parses.
@@ -151,7 +148,7 @@ func validateDatabaseSpec(orchestrator config.Orchestrator, databaseID string, s
 	}
 
 	// Reject postgresql_conf GUCs that would make user-supplied pg_hba/pg_ident
-	// entries ineffective, check spock is present, then validate the entries themselves.
+	// entries ineffective or remove spock, then validate the entries themselves.
 	errs = append(errs, validateAuthFileGUCs(spec.PostgresqlConf, validation.NewPath("postgresql_conf"))...)
 	errs = append(errs, validateConfLibraries(spec.PostgresqlConf, validation.NewPath("postgresql_conf"))...)
 	errs = append(errs, validatePgHbaConf(spec.PgHbaConf, validation.NewPath("pg_hba_conf"))...)
@@ -299,7 +296,7 @@ func validateNode(
 	}
 
 	errs = append(errs, validateAuthFileGUCs(node.PostgresqlConf, path.Append("postgresql_conf"))...)
-	errs = append(errs, validateConfLibraries(node.PostgresqlConf, validation.NewPath("postgresql_conf"))...)
+	errs = append(errs, validateConfLibraries(node.PostgresqlConf, path.Append("postgresql_conf"))...)
 	errs = append(errs, validatePgHbaConf(node.PgHbaConf, path.Append("pg_hba_conf"))...)
 	errs = append(errs, validatePgIdentConf(node.PgIdentConf, path.Append("pg_ident_conf"))...)
 

--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -42,6 +42,7 @@ func validateAuthFileGUCs(conf map[string]any, path validation.Path) []error {
 }
 
 func validateConfLibraries(conf map[string]any, path validation.Path) []error {
+	// param names are case-insensitive, so comparison is done after casting to lowercase
 	for key, val := range conf {
 		if strings.ToLower(strings.TrimSpace(key)) != "shared_preload_libraries" {
 			continue
@@ -254,6 +255,14 @@ func validateDatabaseUpdate(old *database.Spec, new *api.DatabaseSpec) error {
 		isExistingService := existingServiceIDs.Has(string(svc.ServiceID))
 
 		errs = append(errs, validateServiceSpec(svc, svcPath, isExistingService, old.DatabaseID, new.DatabaseUsers, newNodeNames)...)
+	}
+
+	// Validate that shared_preload_libraries, if explicitly set, still includes
+	// "spock" — both at the spec level and on individual nodes.
+	errs = append(errs, validateConfLibraries(new.PostgresqlConf, validation.NewPath("postgresql_conf"))...)
+	for i, n := range new.Nodes {
+		nodePath := validation.NewPath("nodes", validation.ArrayIndexElement(i))
+		errs = append(errs, validateConfLibraries(n.PostgresqlConf, nodePath.Append("postgresql_conf"))...)
 	}
 
 	return errors.Join(errs...)

--- a/server/internal/api/apiv1/validate.go
+++ b/server/internal/api/apiv1/validate.go
@@ -41,6 +41,23 @@ func validateAuthFileGUCs(conf map[string]any, path validation.Path) []error {
 	return errs
 }
 
+func validateConfLibraries(conf map[string]any, path validation.Path) []error {
+	val, ok := utils.TypedFromMap[string](conf, "shared_preload_libraries")
+
+	if !ok {
+		return nil //defaults will be applied, including spock
+	}
+	for _, lib := range strings.Split(val, ",") {
+		if strings.TrimSpace(lib) == "spock" {
+			return nil
+		}
+	}
+
+	err := errors.New(`"spock" must be included in shared_preload_libraries`)
+	return []error{validation.NewError(err, path.AppendMapKey("shared_preload_libraries"))}
+
+}
+
 // validatePgHbaConf checks that every non-comment pg_hba_conf entry parses.
 // Blank and comment lines are allowed and skipped. Validation is intentionally
 // minimal — see server/internal/postgres/hba/parse.go.
@@ -134,8 +151,9 @@ func validateDatabaseSpec(orchestrator config.Orchestrator, databaseID string, s
 	}
 
 	// Reject postgresql_conf GUCs that would make user-supplied pg_hba/pg_ident
-	// entries ineffective, then validate the entries themselves.
+	// entries ineffective, check spock is present, then validate the entries themselves.
 	errs = append(errs, validateAuthFileGUCs(spec.PostgresqlConf, validation.NewPath("postgresql_conf"))...)
+	errs = append(errs, validateConfLibraries(spec.PostgresqlConf, validation.NewPath("postgresql_conf"))...)
 	errs = append(errs, validatePgHbaConf(spec.PgHbaConf, validation.NewPath("pg_hba_conf"))...)
 	errs = append(errs, validatePgIdentConf(spec.PgIdentConf, validation.NewPath("pg_ident_conf"))...)
 
@@ -281,6 +299,7 @@ func validateNode(
 	}
 
 	errs = append(errs, validateAuthFileGUCs(node.PostgresqlConf, path.Append("postgresql_conf"))...)
+	errs = append(errs, validateConfLibraries(node.PostgresqlConf, validation.NewPath("postgresql_conf"))...)
 	errs = append(errs, validatePgHbaConf(node.PgHbaConf, path.Append("pg_hba_conf"))...)
 	errs = append(errs, validatePgIdentConf(node.PgIdentConf, path.Append("pg_ident_conf"))...)
 

--- a/server/internal/api/apiv1/validate_test.go
+++ b/server/internal/api/apiv1/validate_test.go
@@ -451,6 +451,92 @@ func TestValidateBackupConfig(t *testing.T) {
 	}
 }
 
+func TestValidateDatabaseUpdate_LibraryConf(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		old      *database.Spec
+		new      *api.DatabaseSpec
+		expected []string
+	}{
+		{
+			name: "absent valid",
+			old:  &database.Spec{},
+			new:  &api.DatabaseSpec{},
+		},
+		{
+			name: "invalid spec-level conf missing spock",
+			old:  &database.Spec{},
+			new: &api.DatabaseSpec{
+				PostgresqlConf: map[string]any{"shared_preload_libraries": "pg_stat_statements"},
+			},
+			expected: []string{`"spock" must be included in shared_preload_libraries`},
+		},
+		{
+			name: "invalid node-level conf missing spock",
+			old:  &database.Spec{},
+			new: &api.DatabaseSpec{
+				Nodes: []*api.DatabaseNodeSpec{
+					{PostgresqlConf: map[string]any{"shared_preload_libraries": "pg_stat_statements"}},
+				},
+			},
+			expected: []string{`"spock" must be included in shared_preload_libraries`},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDatabaseUpdate(tc.old, tc.new)
+			if len(tc.expected) < 1 {
+				assert.NoError(t, err)
+			} else {
+				for _, expected := range tc.expected {
+					assert.ErrorContains(t, err, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateConfLibraries(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		conf     map[string]any
+		expected []string
+	}{
+		{
+			name: "absent valid",
+		},
+		{
+			name: "valid spock conf",
+			conf: map[string]any{"shared_preload_libraries": "snowflake, spock"},
+		},
+		{
+			name: "valid uppercase param name",
+			conf: map[string]any{"SHARED_PRELOAD_LIBRARIES": "snowflake, spock"},
+		},
+		{
+			name: "valid conf spock and custom",
+			conf: map[string]any{"shared_preload_libraries": "snowflake, spock, custom_lib"},
+		},
+		{
+			name: "invalid conf missing spock",
+			conf: map[string]any{"shared_preload_libraries": "snowflake"},
+			expected: []string{
+				`"spock" must be included in shared_preload_libraries`,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errors.Join(validateConfLibraries(tc.conf, nil)...)
+			if len(tc.expected) < 1 {
+				assert.NoError(t, err)
+			} else {
+				for _, expected := range tc.expected {
+					assert.ErrorContains(t, err, expected)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateNode(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
@@ -572,6 +658,20 @@ func TestValidateNode(t *testing.T) {
 				"host_ids[3]: host IDs must be unique within a node",
 				"backup_config.repositories[0].base_path: base_path must be absolute for posix repositories",
 				"restore_config.repository.base_path: base_path must be absolute for posix repositories",
+			},
+		},
+		{
+			name:         "invalid lib conf",
+			orchestrator: config.OrchestratorSwarm,
+			db:           &api.DatabaseSpec{},
+			node: &api.DatabaseNodeSpec{
+				HostIds: []api.Identifier{
+					api.Identifier("host-1"),
+				},
+				PostgresqlConf: map[string]any{"shared_preload_libraries": "snowflake"},
+			},
+			expected: []string{
+				`"spock" must be included in shared_preload_libraries`,
 			},
 		},
 	} {
@@ -1305,6 +1405,23 @@ func TestValidateDatabaseSpec(t *testing.T) {
 				`postgresql_conf[hba_file]: "hba_file" is not allowed`,
 				`postgresql_conf[ident_file]: "ident_file" is not allowed`,
 				`nodes[0].postgresql_conf[HBA_FILE]: "HBA_FILE" is not allowed`,
+			},
+		},
+		{
+			name: "invalid lib conf",
+			spec: &api.DatabaseSpec{
+				Nodes: []*api.DatabaseNodeSpec{
+					{
+						Name: "n1",
+						HostIds: []api.Identifier{
+							api.Identifier("host-1"),
+						},
+						PostgresqlConf: map[string]any{"shared_preload_libraries": "snowflake"},
+					},
+				},
+			},
+			expected: []string{
+				`"spock" must be included in shared_preload_libraries`,
 			},
 		},
 	} {


### PR DESCRIPTION
## Summary

Prevent users from disabling the spock extension via postgresql_conf.shared_preload_libraries. The control plane has a hard dependency on spock, so removing it would silently break replication.

## Changes

- Add validateConfLibraries to reject any postgresql_conf that explicitly sets shared_preload_libraries without including spock

- Wire into validateDatabaseSpec (spec-level conf) and validateNode (node-level conf) for the create path

- Wire into validateDatabaseUpdate for the update path, at both spec and node level

## Testing

- TestValidateConfLibraries: unit tests covering absent key, valid configs, uppercase param name, and missing spock

- Invalid postgresql_conf cases added to TestValidateDatabaseSpec and TestValidateNode to confirm the check is called in the right places

- TestValidateDatabaseUpdate_LibraryConf: confirms the check runs on update requests at both spec and node level