### PR TITLE
fix: small debian fixes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,15 +37,15 @@ nfpms:
       - rpm
       - deb
     bindir: /usr/sbin
-    scripts:
-      preremove: packaging/preremove.sh
     overrides:
       rpm:
         scripts:
           postinstall: packaging/rpm/postinstall.sh
+          preremove: packaging/rpm/preremove.sh
       deb:
         scripts:
           postinstall: packaging/deb/postinstall.sh
+          preremove: packaging/deb/preremove.sh
     contents:
       - src: packaging/pgedge-control-plane.service
         dst: /usr/lib/systemd/system/pgedge-control-plane.service

--- a/docs/installation/systemd.md
+++ b/docs/installation/systemd.md
@@ -151,10 +151,10 @@ ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 VERSION="v0.9.0"
 
 # Download the deb package
-curl -LO "https://github.com/pgedge/control-plane/releases/download/${VERSION}/pgedge-control-plane_${VERSION#v}_linux_${ARCH}.deb"
+curl -LO --output-dir /tmp "https://github.com/pgedge/control-plane/releases/download/${VERSION}/pgedge-control-plane_${VERSION#v}_linux_${ARCH}.deb"
 
 # Install the deb package
-sudo apt install ./pgedge-control-plane_${VERSION#v}_linux_${ARCH}.deb
+sudo apt install /tmp/pgedge-control-plane_${VERSION#v}_linux_${ARCH}.deb
 ```
 
 ## Configuration

--- a/docs/installation/systemd.md
+++ b/docs/installation/systemd.md
@@ -87,7 +87,7 @@ Run the following commands on each Debian-based host:
 ```sh
 # Install prerequisites for the pgEdge Enterprise Postgres packages
 sudo apt update
-sudo apt install curl gnupg2 lsb-release
+sudo apt install -y curl gnupg2 lsb-release
 
 # Install the pgEdge Enterprise Postgres repository
 curl -O --output-dir /tmp https://apt.pgedge.com/repodeb/pgedge-release_latest_all.deb

--- a/packaging/deb/preremove.sh
+++ b/packaging/deb/preremove.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "$1" = "remove" ]; then
+    /bin/systemctl stop pgedge-control-plane.service >/dev/null 2>&1 || :
+    /bin/systemctl --no-reload disable pgedge-control-plane.service >/dev/null 2>&1 || :
+fi

--- a/packaging/preremove.sh
+++ b/packaging/preremove.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-/bin/systemctl stop pgedge-control-plane.service >/dev/null 2>&1 || :
-/bin/systemctl --no-reload disable pgedge-control-plane.service >/dev/null 2>&1 || :

--- a/packaging/rpm/preremove.sh
+++ b/packaging/rpm/preremove.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "$1" -eq 0 ]; then
+    /bin/systemctl stop pgedge-control-plane.service >/dev/null 2>&1 || :
+    /bin/systemctl --no-reload disable pgedge-control-plane.service >/dev/null 2>&1 || :
+fi

--- a/server/internal/postgres/info.go
+++ b/server/internal/postgres/info.go
@@ -2,7 +2,14 @@ package postgres
 
 func GetPostgresVersion() Query[string] {
 	return Query[string]{
-		SQL: "SHOW server_version;",
+		// We're computing our own string from the numeric server version here
+		// because the text version from 'SHOW server_version' contains build
+		// information on Debian.
+		SQL: `WITH version_num AS (
+				SELECT current_setting('server_version_num')::integer AS num
+			)
+			SELECT (num / 10000)::text || '.' || (num % 10000)::text
+			FROM version_num;`,
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR contains three small fixes for Debian, each in its own commit:

- A change to how our Postgres version query works
  - `SHOW server_version` includes build information on Debian, like `18.4 (Debian 18.4-1.trixie)`, which breaks our database version reconciliation process. I've changed this query to compute the string using the integer representation instead, which is consistent across OSes.
- Adding a missing `-y` to one of the `apt` commands in `systemd.md`
- Download the deb file to `/tmp` in `systemd.md`
  - This gets rid of a warning message from `apt`

## Testing

```sh
# ensure your dev and dev-lima environments are stopped
make dev-reset
make dev-lima-reset

# make a test release to build the packages
make goreleaser-test-release

# deploy a VM with debian 13
# this can take a while.
limactl start -y --name=deb-test-1 lima/debian-13-template.yaml

# these machines will have your home directory mounted, so there's
# no need to copy the deb package to them.

# SSH to the machine, e.g.
ssh -F ~/.lima/deb-test-1/ssh.config lima-deb-test-1
# and follow the installation guide in the systemd.md file except
# that instead of downloading the deb file, install the one from
# your mounted home directory, e.g.
sudo apt install /Users/jasonlynch/workspace/pgEdge/control-plane/dist/pgedge-control-plane_0.9.0-rc.1-SNAPSHOT-84122367_linux_amd64.deb

# Then, initialize the cluster and create a database
curl http://localhost:3000/v1/cluster/init

curl -X POST http://localhost:3000/v1/databases \
    -H 'Content-Type:application/json' \
    --data '{
        "id": "example",
        "spec": {
            "database_name": "example",
            "database_users": [
                {
                    "username": "admin",
                    "password": "password",
                    "db_owner": true,
                    "attributes": ["SUPERUSER", "LOGIN"]
                }
            ],
            "port": 5432,
            "patroni_port": 8888,
            "nodes": [
                { "name": "n1", "host_ids": ["lima-deb-test-1"] }
            ]
        }
    }'

# you can poll the list-databases endpoint and wait for it
# to finish
curl http://localhost:3000/v1/databases | python3 -m json.tool

# When it is finished, you should see `18.4` in the instance's `postgres.version`
# field rather than `18.4 (Debian 18.4-1.trixie)`, which is what you'll see with the
# current release candidate.
```
