### PR TITLE
feat: add available_upgrades opt-in to databases API

### DIFF
--- a/api/apiv1/design/api.go
+++ b/api/apiv1/design/api.go
@@ -209,11 +209,18 @@ var _ = g.Service("control-plane", func() {
 	g.Method("list-databases", func() {
 		g.Description("Lists all databases in the cluster.")
 		g.Meta("openapi:summary", "List databases")
+		g.Payload(func() {
+			g.Attribute("include", g.ArrayOf(g.String), func() {
+				g.Description("Optional fields to include in each database response. Supported values: available_upgrades.")
+				g.Example([]string{"available_upgrades"})
+			})
+		})
 		g.Result(ListDatabasesResponse)
 		g.Error("cluster_not_initialized")
 
 		g.HTTP(func() {
 			g.GET("/v1/databases")
+			g.Param("include")
 
 			g.Meta("openapi:tag:Database")
 		})
@@ -245,6 +252,10 @@ var _ = g.Service("control-plane", func() {
 				g.Description("ID of the database to get.")
 				g.Example("my-app")
 			})
+			g.Attribute("include", g.ArrayOf(g.String), func() {
+				g.Description("Optional fields to include in the response. Supported values: available_upgrades.")
+				g.Example([]string{"available_upgrades"})
+			})
 
 			g.Required("database_id")
 		})
@@ -255,6 +266,7 @@ var _ = g.Service("control-plane", func() {
 
 		g.HTTP(func() {
 			g.GET("/v1/databases/{database_id}")
+			g.Param("include")
 
 			g.Meta("openapi:tag:Database")
 		})

--- a/api/apiv1/design/database.go
+++ b/api/apiv1/design/database.go
@@ -702,6 +702,26 @@ var DatabaseSpec = g.Type("DatabaseSpec", func() {
 	g.Required("database_name", "nodes")
 })
 
+var AvailableUpgrade = g.Type("AvailableUpgrade", func() {
+	g.Description("A newer stable image available for the database in the same Postgres major / Spock major bucket.")
+	g.Attribute("postgres_version", g.String, func() {
+		g.Description("Postgres version of the upgrade candidate.")
+		g.Example("17.10")
+		g.Meta("struct:tag:json", "postgres_version")
+	})
+	g.Attribute("spock_version", g.String, func() {
+		g.Description("Spock major version of the upgrade candidate.")
+		g.Example("5")
+		g.Meta("struct:tag:json", "spock_version")
+	})
+	g.Attribute("image", g.String, func() {
+		g.Description("Full container image reference for the upgrade candidate.")
+		g.Example("ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1")
+		g.Meta("struct:tag:json", "image")
+	})
+	g.Required("postgres_version", "spock_version", "image")
+})
+
 var Database = g.Type("Database", func() {
 	g.Attribute("id", Identifier, func() {
 		g.Description("Unique identifier for the database.")
@@ -754,6 +774,10 @@ var Database = g.Type("Database", func() {
 		g.Description("The user-provided specification for the database.")
 		g.Meta("struct:tag:json", "spec,omitempty")
 	})
+	g.Attribute("available_upgrades", g.ArrayOf(AvailableUpgrade), func() {
+		g.Description("Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.")
+		g.Meta("struct:tag:json", "available_upgrades,omitempty")
+	})
 
 	g.Example(exampleDatabase)
 
@@ -804,6 +828,10 @@ var DatabaseSummary = g.Type("DatabaseSummary", func() {
 	g.Attribute("instances", g.ArrayOf(Instance), func() {
 		g.Description("All of the instances in the database.")
 		g.Meta("struct:tag:json", "instances,omitempty")
+	})
+	g.Attribute("available_upgrades", g.ArrayOf(AvailableUpgrade), func() {
+		g.Description("Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.")
+		g.Meta("struct:tag:json", "available_upgrades,omitempty")
 	})
 
 	g.Required("id", "created_at", "updated_at", "state")

--- a/api/apiv1/gen/control_plane/client.go
+++ b/api/apiv1/gen/control_plane/client.go
@@ -206,9 +206,9 @@ func (c *Client) RemoveHost(ctx context.Context, p *RemoveHostPayload) (res *Rem
 //   - "cluster_not_initialized" (type *goa.ServiceError)
 //   - "server_error" (type *goa.ServiceError)
 //   - error: internal error
-func (c *Client) ListDatabases(ctx context.Context) (res *ListDatabasesResponse, err error) {
+func (c *Client) ListDatabases(ctx context.Context, p *ListDatabasesPayload) (res *ListDatabasesResponse, err error) {
 	var ires any
-	ires, err = c.ListDatabasesEndpoint(ctx, nil)
+	ires, err = c.ListDatabasesEndpoint(ctx, p)
 	if err != nil {
 		return
 	}

--- a/api/apiv1/gen/control_plane/endpoints.go
+++ b/api/apiv1/gen/control_plane/endpoints.go
@@ -188,7 +188,8 @@ func NewRemoveHostEndpoint(s Service) goa.Endpoint {
 // "list-databases" of service "control-plane".
 func NewListDatabasesEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req any) (any, error) {
-		return s.ListDatabases(ctx)
+		p := req.(*ListDatabasesPayload)
+		return s.ListDatabases(ctx, p)
 	}
 }
 

--- a/api/apiv1/gen/control_plane/service.go
+++ b/api/apiv1/gen/control_plane/service.go
@@ -32,7 +32,7 @@ type Service interface {
 	// Removes a host from the cluster.
 	RemoveHost(context.Context, *RemoveHostPayload) (res *RemoveHostResponse, err error)
 	// Lists all databases in the cluster.
-	ListDatabases(context.Context) (res *ListDatabasesResponse, err error)
+	ListDatabases(context.Context, *ListDatabasesPayload) (res *ListDatabasesResponse, err error)
 	// Creates a new database in the cluster.
 	CreateDatabase(context.Context, *CreateDatabaseRequest) (res *CreateDatabaseResponse, err error)
 	// Returns information about a particular database in the cluster.
@@ -99,6 +99,17 @@ type APIError struct {
 	Name string `json:"name"`
 	// The error message.
 	Message string `json:"message"`
+}
+
+// A newer stable image available for the database in the same Postgres major /
+// Spock major bucket.
+type AvailableUpgrade struct {
+	// Postgres version of the upgrade candidate.
+	PostgresVersion string `json:"postgres_version"`
+	// Spock major version of the upgrade candidate.
+	SpockVersion string `json:"spock_version"`
+	// Full container image reference for the upgrade candidate.
+	Image string `json:"image"`
 }
 
 type BackupConfigSpec struct {
@@ -318,6 +329,9 @@ type Database struct {
 	ServiceInstances []*ServiceInstance `json:"service_instances,omitempty"`
 	// The user-provided specification for the database.
 	Spec *DatabaseSpec `json:"spec,omitempty"`
+	// Newer stable image versions available in the same Postgres major / Spock
+	// major bucket. Present only when ?include=available_upgrades is set.
+	AvailableUpgrades []*AvailableUpgrade `json:"available_upgrades,omitempty"`
 }
 
 // Controls how the service connects to the database. When omitted, all nodes
@@ -471,6 +485,9 @@ type DatabaseSummary struct {
 	State string `json:"state"`
 	// All of the instances in the database.
 	Instances []*Instance `json:"instances,omitempty"`
+	// Newer stable image versions available in the same Postgres major / Spock
+	// major bucket. Present only when ?include=available_upgrades is set.
+	AvailableUpgrades []*AvailableUpgrade `json:"available_upgrades,omitempty"`
 }
 
 type DatabaseUserSpec struct {
@@ -558,6 +575,9 @@ type FailoverDatabaseNodeResponse struct {
 type GetDatabasePayload struct {
 	// ID of the database to get.
 	DatabaseID Identifier
+	// Optional fields to include in the response. Supported values:
+	// available_upgrades.
+	Include []string
 }
 
 // GetDatabaseTaskLogPayload is the payload type of the control-plane service
@@ -761,6 +781,14 @@ type ListDatabaseTasksPayload struct {
 type ListDatabaseTasksResponse struct {
 	// The tasks for the given database.
 	Tasks []*Task `json:"tasks"`
+}
+
+// ListDatabasesPayload is the payload type of the control-plane service
+// list-databases method.
+type ListDatabasesPayload struct {
+	// Optional fields to include in each database response. Supported values:
+	// available_upgrades.
+	Include []string
 }
 
 // ListDatabasesResponse is the result type of the control-plane service

--- a/api/apiv1/gen/http/cli/control_plane/cli.go
+++ b/api/apiv1/gen/http/cli/control_plane/cli.go
@@ -67,13 +67,15 @@ func ParseEndpoint(
 		controlPlaneRemoveHostHostIDFlag = controlPlaneRemoveHostFlags.String("host-id", "REQUIRED", "ID of the host to remove.")
 		controlPlaneRemoveHostForceFlag  = controlPlaneRemoveHostFlags.String("force", "", "")
 
-		controlPlaneListDatabasesFlags = flag.NewFlagSet("list-databases", flag.ExitOnError)
+		controlPlaneListDatabasesFlags       = flag.NewFlagSet("list-databases", flag.ExitOnError)
+		controlPlaneListDatabasesIncludeFlag = controlPlaneListDatabasesFlags.String("include", "", "")
 
 		controlPlaneCreateDatabaseFlags    = flag.NewFlagSet("create-database", flag.ExitOnError)
 		controlPlaneCreateDatabaseBodyFlag = controlPlaneCreateDatabaseFlags.String("body", "REQUIRED", "")
 
 		controlPlaneGetDatabaseFlags          = flag.NewFlagSet("get-database", flag.ExitOnError)
 		controlPlaneGetDatabaseDatabaseIDFlag = controlPlaneGetDatabaseFlags.String("database-id", "REQUIRED", "ID of the database to get.")
+		controlPlaneGetDatabaseIncludeFlag    = controlPlaneGetDatabaseFlags.String("include", "", "")
 
 		controlPlaneUpdateDatabaseFlags           = flag.NewFlagSet("update-database", flag.ExitOnError)
 		controlPlaneUpdateDatabaseBodyFlag        = controlPlaneUpdateDatabaseFlags.String("body", "REQUIRED", "")
@@ -366,12 +368,13 @@ func ParseEndpoint(
 				data, err = controlplanec.BuildRemoveHostPayload(*controlPlaneRemoveHostHostIDFlag, *controlPlaneRemoveHostForceFlag)
 			case "list-databases":
 				endpoint = c.ListDatabases()
+				data, err = controlplanec.BuildListDatabasesPayload(*controlPlaneListDatabasesIncludeFlag)
 			case "create-database":
 				endpoint = c.CreateDatabase()
 				data, err = controlplanec.BuildCreateDatabasePayload(*controlPlaneCreateDatabaseBodyFlag)
 			case "get-database":
 				endpoint = c.GetDatabase()
-				data, err = controlplanec.BuildGetDatabasePayload(*controlPlaneGetDatabaseDatabaseIDFlag)
+				data, err = controlplanec.BuildGetDatabasePayload(*controlPlaneGetDatabaseDatabaseIDFlag, *controlPlaneGetDatabaseIncludeFlag)
 			case "update-database":
 				endpoint = c.UpdateDatabase()
 				data, err = controlplanec.BuildUpdateDatabasePayload(*controlPlaneUpdateDatabaseBodyFlag, *controlPlaneUpdateDatabaseDatabaseIDFlag, *controlPlaneUpdateDatabaseForceUpdateFlag, *controlPlaneUpdateDatabaseRemoveHostFlag)
@@ -617,6 +620,7 @@ func controlPlaneRemoveHostUsage() {
 func controlPlaneListDatabasesUsage() {
 	// Header with flags
 	fmt.Fprintf(os.Stderr, "%s [flags] control-plane list-databases", os.Args[0])
+	fmt.Fprint(os.Stderr, " -include JSON")
 	fmt.Fprintln(os.Stderr)
 
 	// Description
@@ -624,10 +628,11 @@ func controlPlaneListDatabasesUsage() {
 	fmt.Fprintln(os.Stderr, `Lists all databases in the cluster.`)
 
 	// Flags list
+	fmt.Fprintln(os.Stderr, `    -include JSON: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane list-databases")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane list-databases --include '[\n      \"available_upgrades\"\n   ]'")
 }
 
 func controlPlaneCreateDatabaseUsage() {
@@ -652,6 +657,7 @@ func controlPlaneGetDatabaseUsage() {
 	// Header with flags
 	fmt.Fprintf(os.Stderr, "%s [flags] control-plane get-database", os.Args[0])
 	fmt.Fprint(os.Stderr, " -database-id STRING")
+	fmt.Fprint(os.Stderr, " -include JSON")
 	fmt.Fprintln(os.Stderr)
 
 	// Description
@@ -660,10 +666,11 @@ func controlPlaneGetDatabaseUsage() {
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -database-id STRING: ID of the database to get.`)
+	fmt.Fprintln(os.Stderr, `    -include JSON: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane get-database --database-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane get-database --database-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --include '[\n      \"available_upgrades\"\n   ]'")
 }
 
 func controlPlaneUpdateDatabaseUsage() {
@@ -687,7 +694,7 @@ func controlPlaneUpdateDatabaseUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane update-database --body '{\n      \"spec\": {\n         \"database_name\": \"storefront\",\n         \"database_users\": [\n            {\n               \"attributes\": [\n                  \"LOGIN\",\n                  \"SUPERUSER\"\n               ],\n               \"db_owner\": true,\n               \"username\": \"admin\"\n            }\n         ],\n         \"nodes\": [\n            {\n               \"backup_config\": {\n                  \"repositories\": [\n                     {\n                        \"s3_bucket\": \"storefront-db-backups-us-east-1\",\n                        \"type\": \"s3\"\n                     }\n                  ]\n               },\n               \"host_ids\": [\n                  \"us-east-1\"\n               ],\n               \"name\": \"n1\"\n            },\n            {\n               \"backup_config\": {\n                  \"repositories\": [\n                     {\n                        \"s3_bucket\": \"storefront-db-backups-ap-south-1\",\n                        \"type\": \"s3\"\n                     }\n                  ]\n               },\n               \"host_ids\": [\n                  \"ap-south-1\"\n               ],\n               \"name\": \"n2\"\n            },\n            {\n               \"backup_config\": {\n                  \"repositories\": [\n                     {\n                        \"s3_bucket\": \"storefront-db-backups-eu-central-1\",\n                        \"type\": \"s3\"\n                     }\n                  ]\n               },\n               \"host_ids\": [\n                  \"eu-central-1\"\n               ],\n               \"name\": \"n3\",\n               \"restore_config\": {\n                  \"repository\": {\n                     \"s3_bucket\": \"storefront-db-backups-us-east-1\",\n                     \"type\": \"s3\"\n                  },\n                  \"source_database_id\": \"storefront\",\n                  \"source_database_name\": \"storefront\",\n                  \"source_node_name\": \"n1\"\n               }\n            }\n         ],\n         \"port\": 5432\n      }\n   }' --database-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --force-update true --remove-host '[\n      \"Inventore officia rerum eum nemo autem.\",\n      \"Illo aspernatur non libero quibusdam.\"\n   ]'")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "control-plane update-database --body '{\n      \"spec\": {\n         \"database_name\": \"storefront\",\n         \"database_users\": [\n            {\n               \"attributes\": [\n                  \"LOGIN\",\n                  \"SUPERUSER\"\n               ],\n               \"db_owner\": true,\n               \"username\": \"admin\"\n            }\n         ],\n         \"nodes\": [\n            {\n               \"backup_config\": {\n                  \"repositories\": [\n                     {\n                        \"s3_bucket\": \"storefront-db-backups-us-east-1\",\n                        \"type\": \"s3\"\n                     }\n                  ]\n               },\n               \"host_ids\": [\n                  \"us-east-1\"\n               ],\n               \"name\": \"n1\"\n            },\n            {\n               \"backup_config\": {\n                  \"repositories\": [\n                     {\n                        \"s3_bucket\": \"storefront-db-backups-ap-south-1\",\n                        \"type\": \"s3\"\n                     }\n                  ]\n               },\n               \"host_ids\": [\n                  \"ap-south-1\"\n               ],\n               \"name\": \"n2\"\n            },\n            {\n               \"backup_config\": {\n                  \"repositories\": [\n                     {\n                        \"s3_bucket\": \"storefront-db-backups-eu-central-1\",\n                        \"type\": \"s3\"\n                     }\n                  ]\n               },\n               \"host_ids\": [\n                  \"eu-central-1\"\n               ],\n               \"name\": \"n3\",\n               \"restore_config\": {\n                  \"repository\": {\n                     \"s3_bucket\": \"storefront-db-backups-us-east-1\",\n                     \"type\": \"s3\"\n                  },\n                  \"source_database_id\": \"storefront\",\n                  \"source_database_name\": \"storefront\",\n                  \"source_node_name\": \"n1\"\n               }\n            }\n         ],\n         \"port\": 5432\n      }\n   }' --database-id \"76f9b8c0-4958-11f0-a489-3bb29577c696\" --force-update true --remove-host '[\n      \"In doloremque.\",\n      \"Officia rerum eum nemo autem iste illo.\",\n      \"Non libero quibusdam et sapiente.\"\n   ]'")
 }
 
 func controlPlaneDeleteDatabaseUsage() {

--- a/api/apiv1/gen/http/control_plane/client/cli.go
+++ b/api/apiv1/gen/http/control_plane/client/cli.go
@@ -182,6 +182,25 @@ func BuildRemoveHostPayload(controlPlaneRemoveHostHostID string, controlPlaneRem
 	return v, nil
 }
 
+// BuildListDatabasesPayload builds the payload for the control-plane
+// list-databases endpoint from CLI flags.
+func BuildListDatabasesPayload(controlPlaneListDatabasesInclude string) (*controlplane.ListDatabasesPayload, error) {
+	var err error
+	var include []string
+	{
+		if controlPlaneListDatabasesInclude != "" {
+			err = json.Unmarshal([]byte(controlPlaneListDatabasesInclude), &include)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON for include, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"available_upgrades\"\n   ]'")
+			}
+		}
+	}
+	v := &controlplane.ListDatabasesPayload{}
+	v.Include = include
+
+	return v, nil
+}
+
 // BuildCreateDatabasePayload builds the payload for the control-plane
 // create-database endpoint from CLI flags.
 func BuildCreateDatabasePayload(controlPlaneCreateDatabaseBody string) (*controlplane.CreateDatabaseRequest, error) {
@@ -242,7 +261,7 @@ func BuildCreateDatabasePayload(controlPlaneCreateDatabaseBody string) (*control
 
 // BuildGetDatabasePayload builds the payload for the control-plane
 // get-database endpoint from CLI flags.
-func BuildGetDatabasePayload(controlPlaneGetDatabaseDatabaseID string) (*controlplane.GetDatabasePayload, error) {
+func BuildGetDatabasePayload(controlPlaneGetDatabaseDatabaseID string, controlPlaneGetDatabaseInclude string) (*controlplane.GetDatabasePayload, error) {
 	var err error
 	var databaseID string
 	{
@@ -257,8 +276,18 @@ func BuildGetDatabasePayload(controlPlaneGetDatabaseDatabaseID string) (*control
 			return nil, err
 		}
 	}
+	var include []string
+	{
+		if controlPlaneGetDatabaseInclude != "" {
+			err = json.Unmarshal([]byte(controlPlaneGetDatabaseInclude), &include)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON for include, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"available_upgrades\"\n   ]'")
+			}
+		}
+	}
 	v := &controlplane.GetDatabasePayload{}
 	v.DatabaseID = controlplane.Identifier(databaseID)
+	v.Include = include
 
 	return v, nil
 }
@@ -322,7 +351,7 @@ func BuildUpdateDatabasePayload(controlPlaneUpdateDatabaseBody string, controlPl
 		if controlPlaneUpdateDatabaseRemoveHost != "" {
 			err = json.Unmarshal([]byte(controlPlaneUpdateDatabaseRemoveHost), &removeHost)
 			if err != nil {
-				return nil, fmt.Errorf("invalid JSON for removeHost, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"Inventore officia rerum eum nemo autem.\",\n      \"Illo aspernatur non libero quibusdam.\"\n   ]'")
+				return nil, fmt.Errorf("invalid JSON for removeHost, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"In doloremque.\",\n      \"Officia rerum eum nemo autem iste illo.\",\n      \"Non libero quibusdam et sapiente.\"\n   ]'")
 			}
 		}
 	}

--- a/api/apiv1/gen/http/control_plane/client/client.go
+++ b/api/apiv1/gen/http/control_plane/client/client.go
@@ -367,10 +367,15 @@ func (c *Client) RemoveHost() goa.Endpoint {
 // control-plane service list-databases server.
 func (c *Client) ListDatabases() goa.Endpoint {
 	var (
+		encodeRequest  = EncodeListDatabasesRequest(c.encoder)
 		decodeResponse = DecodeListDatabasesResponse(c.decoder, c.RestoreResponseBody)
 	)
 	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildListDatabasesRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
 		if err != nil {
 			return nil, err
 		}
@@ -410,10 +415,15 @@ func (c *Client) CreateDatabase() goa.Endpoint {
 // control-plane service get-database server.
 func (c *Client) GetDatabase() goa.Endpoint {
 	var (
+		encodeRequest  = EncodeGetDatabaseRequest(c.encoder)
 		decodeResponse = DecodeGetDatabaseResponse(c.decoder, c.RestoreResponseBody)
 	)
 	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildGetDatabaseRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
 		if err != nil {
 			return nil, err
 		}

--- a/api/apiv1/gen/http/control_plane/client/encode_decode.go
+++ b/api/apiv1/gen/http/control_plane/client/encode_decode.go
@@ -936,6 +936,23 @@ func (c *Client) BuildListDatabasesRequest(ctx context.Context, v any) (*http.Re
 	return req, nil
 }
 
+// EncodeListDatabasesRequest returns an encoder for requests sent to the
+// control-plane list-databases server.
+func EncodeListDatabasesRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*controlplane.ListDatabasesPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("control-plane", "list-databases", "*controlplane.ListDatabasesPayload", v)
+		}
+		values := req.URL.Query()
+		for _, value := range p.Include {
+			values.Add("include", value)
+		}
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
+}
+
 // DecodeListDatabasesResponse returns a decoder for responses returned by the
 // control-plane list-databases endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
@@ -1186,6 +1203,23 @@ func (c *Client) BuildGetDatabaseRequest(ctx context.Context, v any) (*http.Requ
 	}
 
 	return req, nil
+}
+
+// EncodeGetDatabaseRequest returns an encoder for requests sent to the
+// control-plane get-database server.
+func EncodeGetDatabaseRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*controlplane.GetDatabasePayload)
+		if !ok {
+			return goahttp.ErrInvalidType("control-plane", "get-database", "*controlplane.GetDatabasePayload", v)
+		}
+		values := req.URL.Query()
+		for _, value := range p.Include {
+			values.Add("include", value)
+		}
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
 }
 
 // DecodeGetDatabaseResponse returns a decoder for responses returned by the
@@ -4202,6 +4236,16 @@ func unmarshalDatabaseSummaryResponseBodyToControlplaneDatabaseSummary(v *Databa
 			res.Instances[i] = unmarshalInstanceResponseBodyToControlplaneInstance(val)
 		}
 	}
+	if v.AvailableUpgrades != nil {
+		res.AvailableUpgrades = make([]*controlplane.AvailableUpgrade, len(v.AvailableUpgrades))
+		for i, val := range v.AvailableUpgrades {
+			if val == nil {
+				res.AvailableUpgrades[i] = nil
+				continue
+			}
+			res.AvailableUpgrades[i] = unmarshalAvailableUpgradeResponseBodyToControlplaneAvailableUpgrade(val)
+		}
+	}
 
 	return res
 }
@@ -4309,6 +4353,22 @@ func unmarshalInstanceSubscriptionResponseBodyToControlplaneInstanceSubscription
 		ProviderNode: *v.ProviderNode,
 		Name:         *v.Name,
 		Status:       *v.Status,
+	}
+
+	return res
+}
+
+// unmarshalAvailableUpgradeResponseBodyToControlplaneAvailableUpgrade builds a
+// value of type *controlplane.AvailableUpgrade from a value of type
+// *AvailableUpgradeResponseBody.
+func unmarshalAvailableUpgradeResponseBodyToControlplaneAvailableUpgrade(v *AvailableUpgradeResponseBody) *controlplane.AvailableUpgrade {
+	if v == nil {
+		return nil
+	}
+	res := &controlplane.AvailableUpgrade{
+		PostgresVersion: *v.PostgresVersion,
+		SpockVersion:    *v.SpockVersion,
+		Image:           *v.Image,
 	}
 
 	return res
@@ -5345,6 +5405,16 @@ func unmarshalDatabaseResponseBodyToControlplaneDatabase(v *DatabaseResponseBody
 	}
 	if v.Spec != nil {
 		res.Spec = unmarshalDatabaseSpecResponseBodyToControlplaneDatabaseSpec(v.Spec)
+	}
+	if v.AvailableUpgrades != nil {
+		res.AvailableUpgrades = make([]*controlplane.AvailableUpgrade, len(v.AvailableUpgrades))
+		for i, val := range v.AvailableUpgrades {
+			if val == nil {
+				res.AvailableUpgrades[i] = nil
+				continue
+			}
+			res.AvailableUpgrades[i] = unmarshalAvailableUpgradeResponseBodyToControlplaneAvailableUpgrade(val)
+		}
 	}
 
 	return res

--- a/api/apiv1/gen/http/control_plane/client/types.go
+++ b/api/apiv1/gen/http/control_plane/client/types.go
@@ -215,6 +215,9 @@ type GetDatabaseResponseBody struct {
 	ServiceInstances []*ServiceInstanceResponseBody `json:"service_instances,omitempty"`
 	// The user-provided specification for the database.
 	Spec *DatabaseSpecResponseBody `json:"spec,omitempty"`
+	// Newer stable image versions available in the same Postgres major / Spock
+	// major bucket. Present only when ?include=available_upgrades is set.
+	AvailableUpgrades []*AvailableUpgradeResponseBody `json:"available_upgrades,omitempty"`
 }
 
 // UpdateDatabaseResponseBody is the type of the "control-plane" service
@@ -1731,6 +1734,9 @@ type DatabaseSummaryResponseBody struct {
 	State *string `json:"state"`
 	// All of the instances in the database.
 	Instances []*InstanceResponseBody `json:"instances,omitempty"`
+	// Newer stable image versions available in the same Postgres major / Spock
+	// major bucket. Present only when ?include=available_upgrades is set.
+	AvailableUpgrades []*AvailableUpgradeResponseBody `json:"available_upgrades,omitempty"`
 }
 
 // InstanceResponseBody is used to define fields on response body types.
@@ -1800,6 +1806,16 @@ type InstanceSubscriptionResponseBody struct {
 	Name *string `json:"name"`
 	// The current status of the subscription.
 	Status *string `json:"status"`
+}
+
+// AvailableUpgradeResponseBody is used to define fields on response body types.
+type AvailableUpgradeResponseBody struct {
+	// Postgres version of the upgrade candidate.
+	PostgresVersion *string `json:"postgres_version"`
+	// Spock major version of the upgrade candidate.
+	SpockVersion *string `json:"spock_version"`
+	// Full container image reference for the upgrade candidate.
+	Image *string `json:"image"`
 }
 
 // DatabaseSpecRequestBody is used to define fields on request body types.
@@ -2186,6 +2202,9 @@ type DatabaseResponseBody struct {
 	ServiceInstances []*ServiceInstanceResponseBody `json:"service_instances,omitempty"`
 	// The user-provided specification for the database.
 	Spec *DatabaseSpecResponseBody `json:"spec,omitempty"`
+	// Newer stable image versions available in the same Postgres major / Spock
+	// major bucket. Present only when ?include=available_upgrades is set.
+	AvailableUpgrades []*AvailableUpgradeResponseBody `json:"available_upgrades,omitempty"`
 }
 
 // ServiceInstanceResponseBody is used to define fields on response body types.
@@ -3689,6 +3708,16 @@ func NewGetDatabaseDatabaseOK(body *GetDatabaseResponseBody) *controlplane.Datab
 	}
 	if body.Spec != nil {
 		v.Spec = unmarshalDatabaseSpecResponseBodyToControlplaneDatabaseSpec(body.Spec)
+	}
+	if body.AvailableUpgrades != nil {
+		v.AvailableUpgrades = make([]*controlplane.AvailableUpgrade, len(body.AvailableUpgrades))
+		for i, val := range body.AvailableUpgrades {
+			if val == nil {
+				v.AvailableUpgrades[i] = nil
+				continue
+			}
+			v.AvailableUpgrades[i] = unmarshalAvailableUpgradeResponseBodyToControlplaneAvailableUpgrade(val)
+		}
 	}
 
 	return v
@@ -5804,6 +5833,12 @@ func ValidateInstanceSpockStatusResponseBody(body *InstanceSpockStatusResponseBo
 // ValidateInstanceSubscriptionResponseBody runs a no-op validation on
 // InstanceSubscriptionResponseBody
 func ValidateInstanceSubscriptionResponseBody(body *InstanceSubscriptionResponseBody) (err error) {
+	return
+}
+
+// ValidateAvailableUpgradeResponseBody runs a no-op validation on
+// AvailableUpgradeResponseBody
+func ValidateAvailableUpgradeResponseBody(body *AvailableUpgradeResponseBody) (err error) {
 	return
 }
 

--- a/api/apiv1/gen/http/control_plane/server/encode_decode.go
+++ b/api/apiv1/gen/http/control_plane/server/encode_decode.go
@@ -730,6 +730,20 @@ func EncodeListDatabasesResponse(encoder func(context.Context, http.ResponseWrit
 	}
 }
 
+// DecodeListDatabasesRequest returns a decoder for requests sent to the
+// control-plane list-databases endpoint.
+func DecodeListDatabasesRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*controlplane.ListDatabasesPayload, error) {
+	return func(r *http.Request) (*controlplane.ListDatabasesPayload, error) {
+		var (
+			include []string
+		)
+		include = r.URL.Query()["include"]
+		payload := NewListDatabasesPayload(include)
+
+		return payload, nil
+	}
+}
+
 // EncodeListDatabasesError returns an encoder for errors returned by the
 // list-databases control-plane endpoint.
 func EncodeListDatabasesError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
@@ -912,6 +926,7 @@ func DecodeGetDatabaseRequest(mux goahttp.Muxer, decoder func(*http.Request) goa
 	return func(r *http.Request) (*controlplane.GetDatabasePayload, error) {
 		var (
 			databaseID string
+			include    []string
 			err        error
 
 			params = mux.Vars(r)
@@ -923,10 +938,11 @@ func DecodeGetDatabaseRequest(mux goahttp.Muxer, decoder func(*http.Request) goa
 		if utf8.RuneCountInString(databaseID) > 36 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("database_id", databaseID, utf8.RuneCountInString(databaseID), 36, false))
 		}
+		include = r.URL.Query()["include"]
 		if err != nil {
 			return nil, err
 		}
-		payload := NewGetDatabasePayload(databaseID)
+		payload := NewGetDatabasePayload(databaseID, include)
 
 		return payload, nil
 	}
@@ -3583,6 +3599,16 @@ func marshalControlplaneDatabaseSummaryToDatabaseSummaryResponseBody(v *controlp
 			res.Instances[i] = marshalControlplaneInstanceToInstanceResponseBody(val)
 		}
 	}
+	if v.AvailableUpgrades != nil {
+		res.AvailableUpgrades = make([]*AvailableUpgradeResponseBody, len(v.AvailableUpgrades))
+		for i, val := range v.AvailableUpgrades {
+			if val == nil {
+				res.AvailableUpgrades[i] = nil
+				continue
+			}
+			res.AvailableUpgrades[i] = marshalControlplaneAvailableUpgradeToAvailableUpgradeResponseBody(val)
+		}
+	}
 
 	return res
 }
@@ -3690,6 +3716,22 @@ func marshalControlplaneInstanceSubscriptionToInstanceSubscriptionResponseBody(v
 		ProviderNode: v.ProviderNode,
 		Name:         v.Name,
 		Status:       v.Status,
+	}
+
+	return res
+}
+
+// marshalControlplaneAvailableUpgradeToAvailableUpgradeResponseBody builds a
+// value of type *AvailableUpgradeResponseBody from a value of type
+// *controlplane.AvailableUpgrade.
+func marshalControlplaneAvailableUpgradeToAvailableUpgradeResponseBody(v *controlplane.AvailableUpgrade) *AvailableUpgradeResponseBody {
+	if v == nil {
+		return nil
+	}
+	res := &AvailableUpgradeResponseBody{
+		PostgresVersion: v.PostgresVersion,
+		SpockVersion:    v.SpockVersion,
+		Image:           v.Image,
 	}
 
 	return res
@@ -4210,6 +4252,16 @@ func marshalControlplaneDatabaseToDatabaseResponseBody(v *controlplane.Database)
 	}
 	if v.Spec != nil {
 		res.Spec = marshalControlplaneDatabaseSpecToDatabaseSpecResponseBody(v.Spec)
+	}
+	if v.AvailableUpgrades != nil {
+		res.AvailableUpgrades = make([]*AvailableUpgradeResponseBody, len(v.AvailableUpgrades))
+		for i, val := range v.AvailableUpgrades {
+			if val == nil {
+				res.AvailableUpgrades[i] = nil
+				continue
+			}
+			res.AvailableUpgrades[i] = marshalControlplaneAvailableUpgradeToAvailableUpgradeResponseBody(val)
+		}
 	}
 
 	return res

--- a/api/apiv1/gen/http/control_plane/server/server.go
+++ b/api/apiv1/gen/http/control_plane/server/server.go
@@ -652,6 +652,7 @@ func NewListDatabasesHandler(
 	formatter func(ctx context.Context, err error) goahttp.Statuser,
 ) http.Handler {
 	var (
+		decodeRequest  = DecodeListDatabasesRequest(mux, decoder)
 		encodeResponse = EncodeListDatabasesResponse(encoder)
 		encodeError    = EncodeListDatabasesError(encoder, formatter)
 	)
@@ -659,8 +660,14 @@ func NewListDatabasesHandler(
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "list-databases")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "control-plane")
-		var err error
-		res, err := endpoint(ctx, nil)
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
 				errhandler(ctx, w, err)

--- a/api/apiv1/gen/http/control_plane/server/types.go
+++ b/api/apiv1/gen/http/control_plane/server/types.go
@@ -215,6 +215,9 @@ type GetDatabaseResponseBody struct {
 	ServiceInstances []*ServiceInstanceResponseBody `json:"service_instances,omitempty"`
 	// The user-provided specification for the database.
 	Spec *DatabaseSpecResponseBody `json:"spec,omitempty"`
+	// Newer stable image versions available in the same Postgres major / Spock
+	// major bucket. Present only when ?include=available_upgrades is set.
+	AvailableUpgrades []*AvailableUpgradeResponseBody `json:"available_upgrades,omitempty"`
 }
 
 // UpdateDatabaseResponseBody is the type of the "control-plane" service
@@ -1731,6 +1734,9 @@ type DatabaseSummaryResponseBody struct {
 	State string `json:"state"`
 	// All of the instances in the database.
 	Instances []*InstanceResponseBody `json:"instances,omitempty"`
+	// Newer stable image versions available in the same Postgres major / Spock
+	// major bucket. Present only when ?include=available_upgrades is set.
+	AvailableUpgrades []*AvailableUpgradeResponseBody `json:"available_upgrades,omitempty"`
 }
 
 // InstanceResponseBody is used to define fields on response body types.
@@ -1802,6 +1808,16 @@ type InstanceSubscriptionResponseBody struct {
 	Status string `json:"status"`
 }
 
+// AvailableUpgradeResponseBody is used to define fields on response body types.
+type AvailableUpgradeResponseBody struct {
+	// Postgres version of the upgrade candidate.
+	PostgresVersion string `json:"postgres_version"`
+	// Spock major version of the upgrade candidate.
+	SpockVersion string `json:"spock_version"`
+	// Full container image reference for the upgrade candidate.
+	Image string `json:"image"`
+}
+
 // DatabaseResponseBody is used to define fields on response body types.
 type DatabaseResponseBody struct {
 	// Unique identifier for the database.
@@ -1820,6 +1836,9 @@ type DatabaseResponseBody struct {
 	ServiceInstances []*ServiceInstanceResponseBody `json:"service_instances,omitempty"`
 	// The user-provided specification for the database.
 	Spec *DatabaseSpecResponseBody `json:"spec,omitempty"`
+	// Newer stable image versions available in the same Postgres major / Spock
+	// major bucket. Present only when ?include=available_upgrades is set.
+	AvailableUpgrades []*AvailableUpgradeResponseBody `json:"available_upgrades,omitempty"`
 }
 
 // ServiceInstanceResponseBody is used to define fields on response body types.
@@ -3236,6 +3255,16 @@ func NewGetDatabaseResponseBody(res *controlplane.Database) *GetDatabaseResponse
 	}
 	if res.Spec != nil {
 		body.Spec = marshalControlplaneDatabaseSpecToDatabaseSpecResponseBody(res.Spec)
+	}
+	if res.AvailableUpgrades != nil {
+		body.AvailableUpgrades = make([]*AvailableUpgradeResponseBody, len(res.AvailableUpgrades))
+		for i, val := range res.AvailableUpgrades {
+			if val == nil {
+				body.AvailableUpgrades[i] = nil
+				continue
+			}
+			body.AvailableUpgrades[i] = marshalControlplaneAvailableUpgradeToAvailableUpgradeResponseBody(val)
+		}
 	}
 	return body
 }
@@ -4809,6 +4838,15 @@ func NewRemoveHostPayload(hostID string, force bool) *controlplane.RemoveHostPay
 	return v
 }
 
+// NewListDatabasesPayload builds a control-plane service list-databases
+// endpoint payload.
+func NewListDatabasesPayload(include []string) *controlplane.ListDatabasesPayload {
+	v := &controlplane.ListDatabasesPayload{}
+	v.Include = include
+
+	return v
+}
+
 // NewCreateDatabaseRequest builds a control-plane service create-database
 // endpoint payload.
 func NewCreateDatabaseRequest(body *CreateDatabaseRequestBody) *controlplane.CreateDatabaseRequest {
@@ -4828,9 +4866,10 @@ func NewCreateDatabaseRequest(body *CreateDatabaseRequestBody) *controlplane.Cre
 
 // NewGetDatabasePayload builds a control-plane service get-database endpoint
 // payload.
-func NewGetDatabasePayload(databaseID string) *controlplane.GetDatabasePayload {
+func NewGetDatabasePayload(databaseID string, include []string) *controlplane.GetDatabasePayload {
 	v := &controlplane.GetDatabasePayload{}
 	v.DatabaseID = controlplane.Identifier(databaseID)
+	v.Include = include
 
 	return v
 }

--- a/api/apiv1/gen/http/openapi.json
+++ b/api/apiv1/gen/http/openapi.json
@@ -276,6 +276,19 @@
         "summary": "List databases",
         "description": "Lists all databases in the cluster.",
         "operationId": "control-plane#list-databases",
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Optional fields to include in each database response. Supported values: available_upgrades.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK response.",
@@ -399,6 +412,17 @@
         "description": "Returns information about a particular database in the cluster.",
         "operationId": "control-plane#get-database",
         "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Optional fields to include in the response. Supported values: available_upgrades.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
           {
             "name": "database_id",
             "in": "path",
@@ -2442,6 +2466,38 @@
         "message"
       ]
     },
+    "AvailableUpgrade": {
+      "title": "AvailableUpgrade",
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Full container image reference for the upgrade candidate.",
+          "example": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1"
+        },
+        "postgres_version": {
+          "type": "string",
+          "description": "Postgres version of the upgrade candidate.",
+          "example": "17.10"
+        },
+        "spock_version": {
+          "type": "string",
+          "description": "Spock major version of the upgrade candidate.",
+          "example": "5"
+        }
+      },
+      "description": "A newer stable image available for the database in the same Postgres major / Spock major bucket.",
+      "example": {
+        "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+        "postgres_version": "17.10",
+        "spock_version": "5"
+      },
+      "required": [
+        "postgres_version",
+        "spock_version",
+        "image"
+      ]
+    },
     "BackupConfigSpec": {
       "title": "BackupConfigSpec",
       "type": "object",
@@ -2678,7 +2734,7 @@
           },
           "additionalProperties": {
             "type": "string",
-            "example": "Labore explicabo culpa eos natus aperiam excepturi."
+            "example": "Explicabo culpa eos natus aperiam excepturi consectetur."
           }
         },
         "backup_options": {
@@ -2689,7 +2745,7 @@
           },
           "additionalProperties": {
             "type": "string",
-            "example": "Accusantium ut aperiam qui sed quis architecto."
+            "example": "Ut aperiam."
           }
         },
         "type": {
@@ -3235,7 +3291,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "example": "Id vero suscipit fugiat dignissimos modi accusamus."
+            "example": "Tenetur est illum."
           },
           "description": "Existing server to join",
           "example": [
@@ -3479,6 +3535,35 @@
       "title": "Database",
       "type": "object",
       "properties": {
+        "available_upgrades": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AvailableUpgrade"
+          },
+          "description": "Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.",
+          "example": [
+            {
+              "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+              "postgres_version": "17.10",
+              "spock_version": "5"
+            },
+            {
+              "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+              "postgres_version": "17.10",
+              "spock_version": "5"
+            },
+            {
+              "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+              "postgres_version": "17.10",
+              "spock_version": "5"
+            },
+            {
+              "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+              "postgres_version": "17.10",
+              "spock_version": "5"
+            }
+          ]
+        },
         "created_at": {
           "type": "string",
           "description": "The time that the database was created.",
@@ -3634,11 +3719,6 @@
                     "container_port": 8080,
                     "host_port": 8080,
                     "name": "web-client"
-                  },
-                  {
-                    "container_port": 8080,
-                    "host_port": 8080,
-                    "name": "web-client"
                   }
                 ],
                 "service_ready": true
@@ -3681,11 +3761,6 @@
                     "container_port": 8080,
                     "host_port": 8080,
                     "name": "web-client"
-                  },
-                  {
-                    "container_port": 8080,
-                    "host_port": 8080,
-                    "name": "web-client"
                   }
                 ],
                 "service_ready": true
@@ -3714,11 +3789,6 @@
                 "image_version": "1.0.0",
                 "last_health_at": "2025-01-28T10:00:00Z",
                 "ports": [
-                  {
-                    "container_port": 8080,
-                    "host_port": 8080,
-                    "name": "web-client"
-                  },
                   {
                     "container_port": 8080,
                     "host_port": 8080,
@@ -4126,29 +4196,6 @@
               "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
               "s3_region": "us-east-1",
               "type": "s3"
-            },
-            {
-              "azure_account": "pgedge-backups",
-              "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-              "azure_endpoint": "blob.core.usgovcloudapi.net",
-              "azure_key": "YXpLZXk=",
-              "base_path": "/backups",
-              "custom_options": {
-                "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                "storage-upload-chunk-size": "5MiB"
-              },
-              "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-              "gcs_endpoint": "localhost",
-              "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-              "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "retention_full": 2,
-              "retention_full_type": "count",
-              "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-              "s3_endpoint": "s3.us-east-1.amazonaws.com",
-              "s3_key": "AKIAIOSFODNN7EXAMPLE",
-              "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-              "s3_region": "us-east-1",
-              "type": "s3"
             }
           ],
           "schedules": [
@@ -4227,7 +4274,7 @@
                 "host_path": "/Users/user/backups/host"
               }
             ],
-            "image": "Dignissimos incidunt in quas totam eveniet possimus."
+            "image": "Incidunt in quas totam."
           }
         },
         "patroni_port": 8888,
@@ -4364,7 +4411,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -4377,7 +4424,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -4390,7 +4437,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -4461,29 +4508,6 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -4506,6 +4530,7 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
@@ -4563,7 +4588,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -4658,29 +4683,6 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -4703,6 +4705,7 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
@@ -4760,7 +4763,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -4855,29 +4858,6 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -4900,6 +4880,7 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
@@ -4957,7 +4938,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -5095,7 +5076,6 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -5151,7 +5131,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -5176,7 +5156,6 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -5232,7 +5211,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -5252,29 +5231,6 @@
       "example": {
         "backup_config": {
           "repositories": [
-            {
-              "azure_account": "pgedge-backups",
-              "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-              "azure_endpoint": "blob.core.usgovcloudapi.net",
-              "azure_key": "YXpLZXk=",
-              "base_path": "/backups",
-              "custom_options": {
-                "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                "storage-upload-chunk-size": "5MiB"
-              },
-              "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-              "gcs_endpoint": "localhost",
-              "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-              "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "retention_full": 2,
-              "retention_full_type": "count",
-              "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-              "s3_endpoint": "s3.us-east-1.amazonaws.com",
-              "s3_key": "AKIAIOSFODNN7EXAMPLE",
-              "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-              "s3_region": "us-east-1",
-              "type": "s3"
-            },
             {
               "azure_account": "pgedge-backups",
               "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -5349,7 +5305,7 @@
               "CREATEDB",
               "CREATEROLE"
             ],
-            "db_owner": true,
+            "db_owner": false,
             "password": "secret",
             "roles": [
               "pgedge_superuser"
@@ -5362,7 +5318,7 @@
               "CREATEDB",
               "CREATEROLE"
             ],
-            "db_owner": true,
+            "db_owner": false,
             "password": "secret",
             "roles": [
               "pgedge_superuser"
@@ -5375,7 +5331,7 @@
               "CREATEDB",
               "CREATEROLE"
             ],
-            "db_owner": true,
+            "db_owner": false,
             "password": "secret",
             "roles": [
               "pgedge_superuser"
@@ -5388,29 +5344,6 @@
           {
             "backup_config": {
               "repositories": [
-                {
-                  "azure_account": "pgedge-backups",
-                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "azure_endpoint": "blob.core.usgovcloudapi.net",
-                  "azure_key": "YXpLZXk=",
-                  "base_path": "/backups",
-                  "custom_options": {
-                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                    "storage-upload-chunk-size": "5MiB"
-                  },
-                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "gcs_endpoint": "localhost",
-                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "retention_full": 2,
-                  "retention_full_type": "count",
-                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                  "s3_region": "us-east-1",
-                  "type": "s3"
-                },
                 {
                   "azure_account": "pgedge-backups",
                   "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -5479,6 +5412,7 @@
             "cpus": "500m",
             "host_ids": [
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "memory": "500M",
@@ -5535,7 +5469,7 @@
                     "host_path": "/Users/user/backups/host"
                   }
                 ],
-                "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                "image": "Incidunt in quas totam."
               }
             },
             "patroni_port": 8888,
@@ -5630,29 +5564,6 @@
                   "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                   "s3_region": "us-east-1",
                   "type": "s3"
-                },
-                {
-                  "azure_account": "pgedge-backups",
-                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "azure_endpoint": "blob.core.usgovcloudapi.net",
-                  "azure_key": "YXpLZXk=",
-                  "base_path": "/backups",
-                  "custom_options": {
-                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                    "storage-upload-chunk-size": "5MiB"
-                  },
-                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "gcs_endpoint": "localhost",
-                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "retention_full": 2,
-                  "retention_full_type": "count",
-                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                  "s3_region": "us-east-1",
-                  "type": "s3"
                 }
               ],
               "schedules": [
@@ -5675,6 +5586,7 @@
             },
             "cpus": "500m",
             "host_ids": [
+              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
@@ -5732,7 +5644,7 @@
                     "host_path": "/Users/user/backups/host"
                   }
                 ],
-                "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                "image": "Incidunt in quas totam."
               }
             },
             "patroni_port": 8888,
@@ -5832,7 +5744,7 @@
                 "host_path": "/Users/user/backups/host"
               }
             ],
-            "image": "Dignissimos incidunt in quas totam eveniet possimus."
+            "image": "Incidunt in quas totam."
           }
         },
         "patroni_port": 8888,
@@ -5908,7 +5820,6 @@
             },
             "host_ids": [
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "memory": "512M",
@@ -5964,7 +5875,7 @@
                     "host_path": "/Users/user/backups/host"
                   }
                 ],
-                "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                "image": "Incidunt in quas totam."
               }
             },
             "port": 0,
@@ -5989,7 +5900,6 @@
             },
             "host_ids": [
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "memory": "512M",
@@ -6045,7 +5955,7 @@
                     "host_path": "/Users/user/backups/host"
                   }
                 ],
-                "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                "image": "Incidunt in quas totam."
               }
             },
             "port": 0,
@@ -6070,7 +5980,6 @@
             },
             "host_ids": [
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "memory": "512M",
@@ -6126,7 +6035,7 @@
                     "host_path": "/Users/user/backups/host"
                   }
                 ],
-                "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                "image": "Incidunt in quas totam."
               }
             },
             "port": 0,
@@ -6146,6 +6055,30 @@
       "title": "DatabaseSummary",
       "type": "object",
       "properties": {
+        "available_upgrades": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AvailableUpgrade"
+          },
+          "description": "Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.",
+          "example": [
+            {
+              "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+              "postgres_version": "17.10",
+              "spock_version": "5"
+            },
+            {
+              "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+              "postgres_version": "17.10",
+              "spock_version": "5"
+            },
+            {
+              "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+              "postgres_version": "17.10",
+              "spock_version": "5"
+            }
+          ]
+        },
         "created_at": {
           "type": "string",
           "description": "The time that the database was created.",
@@ -6261,7 +6194,7 @@
         "state": {
           "type": "string",
           "description": "Current state of the database.",
-          "example": "failed",
+          "example": "unknown",
           "enum": [
             "creating",
             "modifying",
@@ -6289,6 +6222,28 @@
         }
       },
       "example": {
+        "available_upgrades": [
+          {
+            "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+            "postgres_version": "17.10",
+            "spock_version": "5"
+          },
+          {
+            "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+            "postgres_version": "17.10",
+            "spock_version": "5"
+          },
+          {
+            "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+            "postgres_version": "17.10",
+            "spock_version": "5"
+          },
+          {
+            "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+            "postgres_version": "17.10",
+            "spock_version": "5"
+          }
+        ],
         "created_at": "2025-01-01T01:30:00Z",
         "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
         "instances": [
@@ -6381,99 +6336,9 @@
             "state": "available",
             "status_updated_at": "1993-04-25T23:06:28Z",
             "updated_at": "1981-08-22T23:20:01Z"
-          },
-          {
-            "connection_info": {
-              "addresses": [
-                "10.24.34.2",
-                "i-0123456789abcdef.ec2.internal"
-              ],
-              "port": 5432
-            },
-            "created_at": "2011-03-15T17:48:48Z",
-            "error": "failed to get patroni status: connection refused",
-            "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-            "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-            "node_name": "n1",
-            "postgres": {
-              "patroni_paused": false,
-              "patroni_state": "unknown",
-              "pending_restart": true,
-              "role": "primary",
-              "version": "18.1"
-            },
-            "spock": {
-              "read_only": "off",
-              "subscriptions": [
-                {
-                  "name": "sub_n1n2",
-                  "provider_node": "n2",
-                  "status": "down"
-                },
-                {
-                  "name": "sub_n1n2",
-                  "provider_node": "n2",
-                  "status": "down"
-                },
-                {
-                  "name": "sub_n1n2",
-                  "provider_node": "n2",
-                  "status": "down"
-                }
-              ],
-              "version": "4.10.0"
-            },
-            "state": "available",
-            "status_updated_at": "1993-04-25T23:06:28Z",
-            "updated_at": "1981-08-22T23:20:01Z"
-          },
-          {
-            "connection_info": {
-              "addresses": [
-                "10.24.34.2",
-                "i-0123456789abcdef.ec2.internal"
-              ],
-              "port": 5432
-            },
-            "created_at": "2011-03-15T17:48:48Z",
-            "error": "failed to get patroni status: connection refused",
-            "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-            "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-            "node_name": "n1",
-            "postgres": {
-              "patroni_paused": false,
-              "patroni_state": "unknown",
-              "pending_restart": true,
-              "role": "primary",
-              "version": "18.1"
-            },
-            "spock": {
-              "read_only": "off",
-              "subscriptions": [
-                {
-                  "name": "sub_n1n2",
-                  "provider_node": "n2",
-                  "status": "down"
-                },
-                {
-                  "name": "sub_n1n2",
-                  "provider_node": "n2",
-                  "status": "down"
-                },
-                {
-                  "name": "sub_n1n2",
-                  "provider_node": "n2",
-                  "status": "down"
-                }
-              ],
-              "version": "4.10.0"
-            },
-            "state": "available",
-            "status_updated_at": "1993-04-25T23:06:28Z",
-            "updated_at": "1981-08-22T23:20:01Z"
           }
         ],
-        "state": "backing_up",
+        "state": "creating",
         "tenant_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
         "updated_at": "2025-01-01T02:30:00Z"
       },
@@ -6664,7 +6529,7 @@
       },
       "example": {
         "candidate_instance_id": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi",
-        "skip_validation": false
+        "skip_validation": true
       }
     },
     "FailoverDatabaseNodeResponse": {
@@ -6733,7 +6598,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "example": "Officiis explicabo blanditiis."
+            "example": "Corporis rem consequuntur officiis."
           },
           "description": "The addresses that this host advertises to client applications.",
           "example": [
@@ -6788,7 +6653,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "example": "Molestiae corporis rem."
+            "example": "Fugiat dignissimos modi accusamus mollitia in ex."
           },
           "description": "The addresses that this host advertises to other hosts.",
           "example": [
@@ -6806,6 +6671,14 @@
           },
           "description": "The PgEdge versions supported by this host.",
           "example": [
+            {
+              "postgres_version": "17.6",
+              "spock_version": "5"
+            },
+            {
+              "postgres_version": "17.6",
+              "spock_version": "5"
+            },
             {
               "postgres_version": "17.6",
               "spock_version": "5"
@@ -6923,7 +6796,7 @@
           "type": "object",
           "description": "The status of each component of the host.",
           "example": {
-            "Officiis deleniti laborum ratione id ut.": {
+            "Sint consequuntur officiis deleniti.": {
               "details": {
                 "alarms": [
                   "3: NOSPACE"
@@ -6956,7 +6829,7 @@
       },
       "example": {
         "components": {
-          "Laborum quasi velit animi sint amet exercitationem.": {
+          "Id ut.": {
             "details": {
               "alarms": [
                 "3: NOSPACE"
@@ -6965,7 +6838,7 @@
             "error": "failed to connect to etcd",
             "healthy": false
           },
-          "Reprehenderit odit cumque excepturi atque.": {
+          "Incidunt reprehenderit odit cumque excepturi atque explicabo.": {
             "details": {
               "alarms": [
                 "3: NOSPACE"
@@ -6994,7 +6867,7 @@
         "created_at": {
           "type": "string",
           "description": "The time that the instance was created.",
-          "example": "1992-11-18T07:12:58Z",
+          "example": "2000-04-29T09:31:53Z",
           "format": "date-time"
         },
         "error": {
@@ -7025,7 +6898,7 @@
         },
         "state": {
           "type": "string",
-          "example": "creating",
+          "example": "stopped",
           "enum": [
             "creating",
             "modifying",
@@ -7041,13 +6914,13 @@
         "status_updated_at": {
           "type": "string",
           "description": "The time that the instance status information was last updated.",
-          "example": "1989-07-05T19:14:36Z",
+          "example": "1980-08-18T06:13:24Z",
           "format": "date-time"
         },
         "updated_at": {
           "type": "string",
           "description": "The time that the instance was last modified.",
-          "example": "1995-01-04T13:11:04Z",
+          "example": "1977-02-11T08:26:00Z",
           "format": "date-time"
         }
       },
@@ -7060,7 +6933,7 @@
           ],
           "port": 5432
         },
-        "created_at": "2009-12-01T18:01:55Z",
+        "created_at": "1989-11-23T15:19:47Z",
         "error": "failed to get patroni status: connection refused",
         "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
         "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
@@ -7093,9 +6966,9 @@
           ],
           "version": "4.10.0"
         },
-        "state": "available",
-        "status_updated_at": "1990-11-18T02:58:49Z",
-        "updated_at": "2001-04-12T07:00:21Z"
+        "state": "backing_up",
+        "status_updated_at": "1980-12-18T10:07:58Z",
+        "updated_at": "1985-09-02T23:18:20Z"
       },
       "required": [
         "id",
@@ -7114,7 +6987,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "example": "Qui animi quia."
+            "example": "Reiciendis placeat et autem ipsa."
           },
           "description": "The addresses of the host that's running this instance.",
           "example": [
@@ -7168,7 +7041,7 @@
       },
       "description": "Postgres status information for a pgEdge instance.",
       "example": {
-        "patroni_paused": true,
+        "patroni_paused": false,
         "patroni_state": "unknown",
         "pending_restart": false,
         "role": "primary",
@@ -7227,6 +7100,11 @@
             "name": "sub_n1n2",
             "provider_node": "n2",
             "status": "down"
+          },
+          {
+            "name": "sub_n1n2",
+            "provider_node": "n2",
+            "status": "down"
           }
         ],
         "version": "4.10.0"
@@ -7276,6 +7154,26 @@
           },
           "description": "The tasks for the given database.",
           "example": [
+            {
+              "completed_at": "2025-06-18T16:52:35Z",
+              "created_at": "2025-06-18T16:52:05Z",
+              "database_id": "storefront",
+              "entity_id": "storefront",
+              "scope": "database",
+              "status": "completed",
+              "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
+              "type": "create"
+            },
+            {
+              "completed_at": "2025-06-18T16:52:35Z",
+              "created_at": "2025-06-18T16:52:05Z",
+              "database_id": "storefront",
+              "entity_id": "storefront",
+              "scope": "database",
+              "status": "completed",
+              "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
+              "type": "create"
+            },
             {
               "completed_at": "2025-06-18T16:52:35Z",
               "created_at": "2025-06-18T16:52:05Z",
@@ -7360,6 +7258,28 @@
           "description": "The databases managed by this cluster.",
           "example": [
             {
+              "available_upgrades": [
+                {
+                  "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                  "postgres_version": "17.10",
+                  "spock_version": "5"
+                },
+                {
+                  "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                  "postgres_version": "17.10",
+                  "spock_version": "5"
+                },
+                {
+                  "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                  "postgres_version": "17.10",
+                  "spock_version": "5"
+                },
+                {
+                  "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                  "postgres_version": "17.10",
+                  "spock_version": "5"
+                }
+              ],
               "created_at": "2025-01-01T01:30:00Z",
               "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "instances": [
@@ -7459,6 +7379,28 @@
               "updated_at": "2025-01-01T02:30:00Z"
             },
             {
+              "available_upgrades": [
+                {
+                  "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                  "postgres_version": "17.10",
+                  "spock_version": "5"
+                },
+                {
+                  "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                  "postgres_version": "17.10",
+                  "spock_version": "5"
+                },
+                {
+                  "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                  "postgres_version": "17.10",
+                  "spock_version": "5"
+                },
+                {
+                  "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                  "postgres_version": "17.10",
+                  "spock_version": "5"
+                }
+              ],
               "created_at": "2025-01-01T01:30:00Z",
               "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "instances": [
@@ -7846,6 +7788,16 @@
               "status": "completed",
               "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
               "type": "create"
+            },
+            {
+              "completed_at": "2025-06-18T16:52:35Z",
+              "created_at": "2025-06-18T16:52:05Z",
+              "database_id": "storefront",
+              "entity_id": "storefront",
+              "scope": "database",
+              "status": "completed",
+              "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
+              "type": "create"
             }
           ]
         }
@@ -7879,64 +7831,6 @@
           },
           "description": "List of hosts in the cluster",
           "example": [
-            {
-              "client_addresses": [
-                "10.24.34.2",
-                "i-0123456789abcdef.ec2.internal"
-              ],
-              "cohort": {
-                "control_available": true,
-                "member_id": "lah4bsznw6kc0hp7biylmmmll",
-                "type": "swarm"
-              },
-              "cpus": 4,
-              "data_dir": "/data",
-              "default_pgedge_version": {
-                "postgres_version": "17.6",
-                "spock_version": "5"
-              },
-              "etcd_mode": "server",
-              "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "memory": "16GiB",
-              "orchestrator": "swarm",
-              "peer_addresses": [
-                "10.24.34.2",
-                "i-0123456789abcdef.ec2.internal"
-              ],
-              "status": {
-                "components": {
-                  "Id dolorem rerum labore commodi.": {
-                    "details": {
-                      "alarms": [
-                        "3: NOSPACE"
-                      ]
-                    },
-                    "error": "failed to connect to etcd",
-                    "healthy": false
-                  }
-                },
-                "state": "available",
-                "updated_at": "2021-07-01T12:34:56Z"
-              },
-              "supported_pgedge_versions": [
-                {
-                  "postgres_version": "17.6",
-                  "spock_version": "5"
-                },
-                {
-                  "postgres_version": "17.6",
-                  "spock_version": "5"
-                },
-                {
-                  "postgres_version": "17.6",
-                  "spock_version": "5"
-                },
-                {
-                  "postgres_version": "17.6",
-                  "spock_version": "5"
-                }
-              ]
-            },
             {
               "client_addresses": [
                 "10.24.34.2",
@@ -8229,6 +8123,16 @@
               "status": "completed",
               "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
               "type": "create"
+            },
+            {
+              "completed_at": "2025-06-18T16:52:35Z",
+              "created_at": "2025-06-18T16:52:05Z",
+              "database_id": "storefront",
+              "entity_id": "storefront",
+              "scope": "database",
+              "status": "completed",
+              "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
+              "type": "create"
             }
           ]
         }
@@ -8323,7 +8227,7 @@
               "host_path": "/Users/user/backups/host"
             }
           ],
-          "image": "Dignissimos incidunt in quas totam eveniet possimus."
+          "image": "Incidunt in quas totam."
         }
       }
     },
@@ -8401,16 +8305,6 @@
           },
           "description": "The tasks that will update databases affected by the host removal.",
           "example": [
-            {
-              "completed_at": "2025-06-18T16:52:35Z",
-              "created_at": "2025-06-18T16:52:05Z",
-              "database_id": "storefront",
-              "entity_id": "storefront",
-              "scope": "database",
-              "status": "completed",
-              "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
-              "type": "create"
-            },
             {
               "completed_at": "2025-06-18T16:52:35Z",
               "created_at": "2025-06-18T16:52:05Z",
@@ -8596,7 +8490,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "example": "Quo qui."
+            "example": "Et reprehenderit et nam quo qui."
           },
           "description": "The nodes to restore. Defaults to all nodes if empty or unspecified.",
           "example": [
@@ -8637,26 +8531,6 @@
           },
           "description": "The tasks that will restore each database node.",
           "example": [
-            {
-              "completed_at": "2025-06-18T16:52:35Z",
-              "created_at": "2025-06-18T16:52:05Z",
-              "database_id": "storefront",
-              "entity_id": "storefront",
-              "scope": "database",
-              "status": "completed",
-              "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
-              "type": "create"
-            },
-            {
-              "completed_at": "2025-06-18T16:52:35Z",
-              "created_at": "2025-06-18T16:52:05Z",
-              "database_id": "storefront",
-              "entity_id": "storefront",
-              "scope": "database",
-              "status": "completed",
-              "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
-              "type": "create"
-            },
             {
               "completed_at": "2025-06-18T16:52:35Z",
               "created_at": "2025-06-18T16:52:05Z",
@@ -9122,11 +8996,6 @@
               "container_port": 8080,
               "host_port": 8080,
               "name": "web-client"
-            },
-            {
-              "container_port": 8080,
-              "host_port": 8080,
-              "name": "web-client"
             }
           ],
           "service_ready": true
@@ -9395,7 +9264,7 @@
                 "host_path": "/Users/user/backups/host"
               }
             ],
-            "image": "Dignissimos incidunt in quas totam eveniet possimus."
+            "image": "Incidunt in quas totam."
           }
         },
         "port": 0,
@@ -9744,6 +9613,22 @@
           },
           "description": "Entries in the task log.",
           "example": [
+            {
+              "fields": {
+                "option.enabled": true,
+                "status": "creating"
+              },
+              "message": "task started",
+              "timestamp": "2025-05-29T15:43:13Z"
+            },
+            {
+              "fields": {
+                "option.enabled": true,
+                "status": "creating"
+              },
+              "message": "task started",
+              "timestamp": "2025-05-29T15:43:13Z"
+            },
             {
               "fields": {
                 "option.enabled": true,

--- a/api/apiv1/gen/http/openapi.yaml
+++ b/api/apiv1/gen/http/openapi.yaml
@@ -192,6 +192,15 @@ paths:
       summary: List databases
       description: Lists all databases in the cluster.
       operationId: control-plane#list-databases
+      parameters:
+        - name: include
+          in: query
+          description: 'Optional fields to include in each database response. Supported values: available_upgrades.'
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
       responses:
         "200":
           description: OK response.
@@ -276,6 +285,14 @@ paths:
       description: Returns information about a particular database in the cluster.
       operationId: control-plane#get-database
       parameters:
+        - name: include
+          in: query
+          description: 'Optional fields to include in the response. Supported values: available_upgrades.'
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
         - name: database_id
           in: path
           description: A user-specified identifier. Must be 1-36 characters, contain only lower-cased letters and hyphens, start and end with a letter or number, and not contain consecutive hyphens.
@@ -1702,6 +1719,31 @@ definitions:
     required:
       - name
       - message
+  AvailableUpgrade:
+    title: AvailableUpgrade
+    type: object
+    properties:
+      image:
+        type: string
+        description: Full container image reference for the upgrade candidate.
+        example: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+      postgres_version:
+        type: string
+        description: Postgres version of the upgrade candidate.
+        example: "17.10"
+      spock_version:
+        type: string
+        description: Spock major version of the upgrade candidate.
+        example: "5"
+    description: A newer stable image available for the database in the same Postgres major / Spock major bucket.
+    example:
+      image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+      postgres_version: "17.10"
+      spock_version: "5"
+    required:
+      - postgres_version
+      - spock_version
+      - image
   BackupConfigSpec:
     title: BackupConfigSpec
     type: object
@@ -1889,7 +1931,7 @@ definitions:
           key: value
         additionalProperties:
           type: string
-          example: Labore explicabo culpa eos natus aperiam excepturi.
+          example: Explicabo culpa eos natus aperiam excepturi consectetur.
       backup_options:
         type: object
         description: Options for the backup.
@@ -1897,7 +1939,7 @@ definitions:
           archive-check: "n"
         additionalProperties:
           type: string
-          example: Accusantium ut aperiam qui sed quis architecto.
+          example: Ut aperiam.
       type:
         type: string
         description: The type of backup.
@@ -2303,7 +2345,7 @@ definitions:
         type: array
         items:
           type: string
-          example: Id vero suscipit fugiat dignissimos modi accusamus.
+          example: Tenetur est illum.
         description: Existing server to join
         example:
           - http://192.168.1.1:3000
@@ -2470,6 +2512,24 @@ definitions:
     title: Database
     type: object
     properties:
+      available_upgrades:
+        type: array
+        items:
+          $ref: '#/definitions/AvailableUpgrade'
+        description: Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.
+        example:
+          - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+            postgres_version: "17.10"
+            spock_version: "5"
+          - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+            postgres_version: "17.10"
+            spock_version: "5"
+          - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+            postgres_version: "17.10"
+            spock_version: "5"
+          - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+            postgres_version: "17.10"
+            spock_version: "5"
       created_at:
         type: string
         description: The time that the database was created.
@@ -2585,9 +2645,6 @@ definitions:
                 - container_port: 8080
                   host_port: 8080
                   name: web-client
-                - container_port: 8080
-                  host_port: 8080
-                  name: web-client
               service_ready: true
             updated_at: "2025-01-28T10:05:00Z"
           - created_at: "2025-01-28T10:00:00Z"
@@ -2618,9 +2675,6 @@ definitions:
                 - container_port: 8080
                   host_port: 8080
                   name: web-client
-                - container_port: 8080
-                  host_port: 8080
-                  name: web-client
               service_ready: true
             updated_at: "2025-01-28T10:05:00Z"
           - created_at: "2025-01-28T10:00:00Z"
@@ -2642,9 +2696,6 @@ definitions:
               image_version: 1.0.0
               last_health_at: "2025-01-28T10:00:00Z"
               ports:
-                - container_port: 8080
-                  host_port: 8080
-                  name: web-client
                 - container_port: 8080
                   host_port: 8080
                   name: web-client
@@ -2947,26 +2998,6 @@ definitions:
             s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
             s3_region: us-east-1
             type: s3
-          - azure_account: pgedge-backups
-            azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-            azure_endpoint: blob.core.usgovcloudapi.net
-            azure_key: YXpLZXk=
-            base_path: /backups
-            custom_options:
-              s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-              storage-upload-chunk-size: 5MiB
-            gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-            gcs_endpoint: localhost
-            gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-            id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-            retention_full: 2
-            retention_full_type: count
-            s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-            s3_endpoint: s3.us-east-1.amazonaws.com
-            s3_key: AKIAIOSFODNN7EXAMPLE
-            s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-            s3_region: us-east-1
-            type: s3
         schedules:
           - cron_expression: 0 6 * * ?
             id: daily-full-backup
@@ -3013,7 +3044,7 @@ definitions:
               host_path: /Users/user/backups/host
             - destination_path: /backups/container
               host_path: /Users/user/backups/host
-          image: Dignissimos incidunt in quas totam eveniet possimus.
+          image: Incidunt in quas totam.
       patroni_port: 8888
       pg_hba_conf:
         - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -3121,7 +3152,7 @@ definitions:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -3130,7 +3161,7 @@ definitions:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -3139,7 +3170,7 @@ definitions:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -3198,26 +3229,6 @@ definitions:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -3230,6 +3241,7 @@ definitions:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
@@ -3265,7 +3277,7 @@ definitions:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -3344,26 +3356,6 @@ definitions:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -3376,6 +3368,7 @@ definitions:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
@@ -3411,7 +3404,7 @@ definitions:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -3490,26 +3483,6 @@ definitions:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -3522,6 +3495,7 @@ definitions:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
@@ -3557,7 +3531,7 @@ definitions:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -3665,7 +3639,6 @@ definitions:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -3698,7 +3671,7 @@ definitions:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -3717,7 +3690,6 @@ definitions:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -3750,7 +3722,7 @@ definitions:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -3763,26 +3735,6 @@ definitions:
     example:
       backup_config:
         repositories:
-          - azure_account: pgedge-backups
-            azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-            azure_endpoint: blob.core.usgovcloudapi.net
-            azure_key: YXpLZXk=
-            base_path: /backups
-            custom_options:
-              s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-              storage-upload-chunk-size: 5MiB
-            gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-            gcs_endpoint: localhost
-            gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-            id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-            retention_full: 2
-            retention_full_type: count
-            s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-            s3_endpoint: s3.us-east-1.amazonaws.com
-            s3_key: AKIAIOSFODNN7EXAMPLE
-            s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-            s3_region: us-east-1
-            type: s3
           - azure_account: pgedge-backups
             azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
             azure_endpoint: blob.core.usgovcloudapi.net
@@ -3840,7 +3792,7 @@ definitions:
             - LOGIN
             - CREATEDB
             - CREATEROLE
-          db_owner: true
+          db_owner: false
           password: secret
           roles:
             - pgedge_superuser
@@ -3849,7 +3801,7 @@ definitions:
             - LOGIN
             - CREATEDB
             - CREATEROLE
-          db_owner: true
+          db_owner: false
           password: secret
           roles:
             - pgedge_superuser
@@ -3858,7 +3810,7 @@ definitions:
             - LOGIN
             - CREATEDB
             - CREATEROLE
-          db_owner: true
+          db_owner: false
           password: secret
           roles:
             - pgedge_superuser
@@ -3867,26 +3819,6 @@ definitions:
       nodes:
         - backup_config:
             repositories:
-              - azure_account: pgedge-backups
-                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                azure_endpoint: blob.core.usgovcloudapi.net
-                azure_key: YXpLZXk=
-                base_path: /backups
-                custom_options:
-                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  storage-upload-chunk-size: 5MiB
-                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                gcs_endpoint: localhost
-                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                retention_full: 2
-                retention_full_type: count
-                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                s3_endpoint: s3.us-east-1.amazonaws.com
-                s3_key: AKIAIOSFODNN7EXAMPLE
-                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                s3_region: us-east-1
-                type: s3
               - azure_account: pgedge-backups
                 azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
                 azure_endpoint: blob.core.usgovcloudapi.net
@@ -3941,6 +3873,7 @@ definitions:
           host_ids:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           memory: 500M
           name: n1
           orchestrator_opts:
@@ -3974,7 +3907,7 @@ definitions:
                   host_path: /Users/user/backups/host
                 - destination_path: /backups/container
                   host_path: /Users/user/backups/host
-              image: Dignissimos incidunt in quas totam eveniet possimus.
+              image: Incidunt in quas totam.
           patroni_port: 8888
           pg_hba_conf:
             - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -4053,26 +3986,6 @@ definitions:
                 s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                 s3_region: us-east-1
                 type: s3
-              - azure_account: pgedge-backups
-                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                azure_endpoint: blob.core.usgovcloudapi.net
-                azure_key: YXpLZXk=
-                base_path: /backups
-                custom_options:
-                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  storage-upload-chunk-size: 5MiB
-                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                gcs_endpoint: localhost
-                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                retention_full: 2
-                retention_full_type: count
-                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                s3_endpoint: s3.us-east-1.amazonaws.com
-                s3_key: AKIAIOSFODNN7EXAMPLE
-                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                s3_region: us-east-1
-                type: s3
             schedules:
               - cron_expression: 0 6 * * ?
                 id: daily-full-backup
@@ -4085,6 +3998,7 @@ definitions:
                 type: full
           cpus: 500m
           host_ids:
+            - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
           memory: 500M
@@ -4120,7 +4034,7 @@ definitions:
                   host_path: /Users/user/backups/host
                 - destination_path: /backups/container
                   host_path: /Users/user/backups/host
-              image: Dignissimos incidunt in quas totam eveniet possimus.
+              image: Incidunt in quas totam.
           patroni_port: 8888
           pg_hba_conf:
             - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -4188,7 +4102,7 @@ definitions:
               host_path: /Users/user/backups/host
             - destination_path: /backups/container
               host_path: /Users/user/backups/host
-          image: Dignissimos incidunt in quas totam eveniet possimus.
+          image: Incidunt in quas totam.
       patroni_port: 8888
       pg_hba_conf:
         - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -4249,7 +4163,6 @@ definitions:
           host_ids:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           memory: 512M
           orchestrator_opts:
             swarm:
@@ -4282,7 +4195,7 @@ definitions:
                   host_path: /Users/user/backups/host
                 - destination_path: /backups/container
                   host_path: /Users/user/backups/host
-              image: Dignissimos incidunt in quas totam eveniet possimus.
+              image: Incidunt in quas totam.
           port: 0
           service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
           service_type: rag
@@ -4301,7 +4214,6 @@ definitions:
           host_ids:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           memory: 512M
           orchestrator_opts:
             swarm:
@@ -4334,7 +4246,7 @@ definitions:
                   host_path: /Users/user/backups/host
                 - destination_path: /backups/container
                   host_path: /Users/user/backups/host
-              image: Dignissimos incidunt in quas totam eveniet possimus.
+              image: Incidunt in quas totam.
           port: 0
           service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
           service_type: rag
@@ -4353,7 +4265,6 @@ definitions:
           host_ids:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           memory: 512M
           orchestrator_opts:
             swarm:
@@ -4386,7 +4297,7 @@ definitions:
                   host_path: /Users/user/backups/host
                 - destination_path: /backups/container
                   host_path: /Users/user/backups/host
-              image: Dignissimos incidunt in quas totam eveniet possimus.
+              image: Incidunt in quas totam.
           port: 0
           service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
           service_type: rag
@@ -4399,6 +4310,21 @@ definitions:
     title: DatabaseSummary
     type: object
     properties:
+      available_upgrades:
+        type: array
+        items:
+          $ref: '#/definitions/AvailableUpgrade'
+        description: Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.
+        example:
+          - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+            postgres_version: "17.10"
+            spock_version: "5"
+          - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+            postgres_version: "17.10"
+            spock_version: "5"
+          - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+            postgres_version: "17.10"
+            spock_version: "5"
       created_at:
         type: string
         description: The time that the database was created.
@@ -4483,7 +4409,7 @@ definitions:
       state:
         type: string
         description: Current state of the database.
-        example: failed
+        example: unknown
         enum:
           - creating
           - modifying
@@ -4506,6 +4432,19 @@ definitions:
         example: "2025-01-01T02:30:00Z"
         format: date-time
     example:
+      available_upgrades:
+        - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+          postgres_version: "17.10"
+          spock_version: "5"
+        - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+          postgres_version: "17.10"
+          spock_version: "5"
+        - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+          postgres_version: "17.10"
+          spock_version: "5"
+        - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+          postgres_version: "17.10"
+          spock_version: "5"
       created_at: "2025-01-01T01:30:00Z"
       id: 76f9b8c0-4958-11f0-a489-3bb29577c696
       instances:
@@ -4573,71 +4512,7 @@ definitions:
           state: available
           status_updated_at: "1993-04-25T23:06:28Z"
           updated_at: "1981-08-22T23:20:01Z"
-        - connection_info:
-            addresses:
-              - 10.24.34.2
-              - i-0123456789abcdef.ec2.internal
-            port: 5432
-          created_at: "2011-03-15T17:48:48Z"
-          error: 'failed to get patroni status: connection refused'
-          host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-          id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-          node_name: n1
-          postgres:
-            patroni_paused: false
-            patroni_state: unknown
-            pending_restart: true
-            role: primary
-            version: "18.1"
-          spock:
-            read_only: "off"
-            subscriptions:
-              - name: sub_n1n2
-                provider_node: n2
-                status: down
-              - name: sub_n1n2
-                provider_node: n2
-                status: down
-              - name: sub_n1n2
-                provider_node: n2
-                status: down
-            version: 4.10.0
-          state: available
-          status_updated_at: "1993-04-25T23:06:28Z"
-          updated_at: "1981-08-22T23:20:01Z"
-        - connection_info:
-            addresses:
-              - 10.24.34.2
-              - i-0123456789abcdef.ec2.internal
-            port: 5432
-          created_at: "2011-03-15T17:48:48Z"
-          error: 'failed to get patroni status: connection refused'
-          host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-          id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-          node_name: n1
-          postgres:
-            patroni_paused: false
-            patroni_state: unknown
-            pending_restart: true
-            role: primary
-            version: "18.1"
-          spock:
-            read_only: "off"
-            subscriptions:
-              - name: sub_n1n2
-                provider_node: n2
-                status: down
-              - name: sub_n1n2
-                provider_node: n2
-                status: down
-              - name: sub_n1n2
-                provider_node: n2
-                status: down
-            version: 4.10.0
-          state: available
-          status_updated_at: "1993-04-25T23:06:28Z"
-          updated_at: "1981-08-22T23:20:01Z"
-      state: backing_up
+      state: creating
       tenant_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
       updated_at: "2025-01-01T02:30:00Z"
     required:
@@ -4782,7 +4657,7 @@ definitions:
         example: false
     example:
       candidate_instance_id: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
-      skip_validation: false
+      skip_validation: true
   FailoverDatabaseNodeResponse:
     title: FailoverDatabaseNodeResponse
     type: object
@@ -4835,7 +4710,7 @@ definitions:
         type: array
         items:
           type: string
-          example: Officiis explicabo blanditiis.
+          example: Corporis rem consequuntur officiis.
         description: The addresses that this host advertises to client applications.
         example:
           - 10.24.34.2
@@ -4878,7 +4753,7 @@ definitions:
         type: array
         items:
           type: string
-          example: Molestiae corporis rem.
+          example: Fugiat dignissimos modi accusamus mollitia in ex.
         description: The addresses that this host advertises to other hosts.
         example:
           - 10.24.34.2
@@ -4891,6 +4766,10 @@ definitions:
           $ref: '#/definitions/PgEdgeVersion'
         description: The PgEdge versions supported by this host.
         example:
+          - postgres_version: "17.6"
+            spock_version: "5"
+          - postgres_version: "17.6"
+            spock_version: "5"
           - postgres_version: "17.6"
             spock_version: "5"
           - postgres_version: "17.6"
@@ -4973,7 +4852,7 @@ definitions:
         type: object
         description: The status of each component of the host.
         example:
-          Officiis deleniti laborum ratione id ut.:
+          Sint consequuntur officiis deleniti.:
             details:
               alarms:
                 - '3: NOSPACE'
@@ -4996,13 +4875,13 @@ definitions:
         format: date-time
     example:
       components:
-        Laborum quasi velit animi sint amet exercitationem.:
+        Id ut.:
           details:
             alarms:
               - '3: NOSPACE'
           error: failed to connect to etcd
           healthy: false
-        Reprehenderit odit cumque excepturi atque.:
+        Incidunt reprehenderit odit cumque excepturi atque explicabo.:
           details:
             alarms:
               - '3: NOSPACE'
@@ -5023,7 +4902,7 @@ definitions:
       created_at:
         type: string
         description: The time that the instance was created.
-        example: "1992-11-18T07:12:58Z"
+        example: "2000-04-29T09:31:53Z"
         format: date-time
       error:
         type: string
@@ -5047,7 +4926,7 @@ definitions:
         $ref: '#/definitions/InstanceSpockStatus'
       state:
         type: string
-        example: creating
+        example: stopped
         enum:
           - creating
           - modifying
@@ -5061,12 +4940,12 @@ definitions:
       status_updated_at:
         type: string
         description: The time that the instance status information was last updated.
-        example: "1989-07-05T19:14:36Z"
+        example: "1980-08-18T06:13:24Z"
         format: date-time
       updated_at:
         type: string
         description: The time that the instance was last modified.
-        example: "1995-01-04T13:11:04Z"
+        example: "1977-02-11T08:26:00Z"
         format: date-time
     description: An instance of pgEdge Postgres running on a host.
     example:
@@ -5075,7 +4954,7 @@ definitions:
           - 10.24.34.2
           - i-0123456789abcdef.ec2.internal
         port: 5432
-      created_at: "2009-12-01T18:01:55Z"
+      created_at: "1989-11-23T15:19:47Z"
       error: 'failed to get patroni status: connection refused'
       host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
       id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
@@ -5099,9 +4978,9 @@ definitions:
             provider_node: n2
             status: down
         version: 4.10.0
-      state: available
-      status_updated_at: "1990-11-18T02:58:49Z"
-      updated_at: "2001-04-12T07:00:21Z"
+      state: backing_up
+      status_updated_at: "1980-12-18T10:07:58Z"
+      updated_at: "1985-09-02T23:18:20Z"
     required:
       - id
       - host_id
@@ -5117,7 +4996,7 @@ definitions:
         type: array
         items:
           type: string
-          example: Qui animi quia.
+          example: Reiciendis placeat et autem ipsa.
         description: The addresses of the host that's running this instance.
         example:
           - 10.24.34.2
@@ -5157,7 +5036,7 @@ definitions:
         example: "18.1"
     description: Postgres status information for a pgEdge instance.
     example:
-      patroni_paused: true
+      patroni_paused: false
       patroni_state: unknown
       pending_restart: false
       role: primary
@@ -5193,6 +5072,9 @@ definitions:
     example:
       read_only: "off"
       subscriptions:
+        - name: sub_n1n2
+          provider_node: n2
+          status: down
         - name: sub_n1n2
           provider_node: n2
           status: down
@@ -5236,6 +5118,22 @@ definitions:
           $ref: '#/definitions/Task'
         description: The tasks for the given database.
         example:
+          - completed_at: "2025-06-18T16:52:35Z"
+            created_at: "2025-06-18T16:52:05Z"
+            database_id: storefront
+            entity_id: storefront
+            scope: database
+            status: completed
+            task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
+            type: create
+          - completed_at: "2025-06-18T16:52:35Z"
+            created_at: "2025-06-18T16:52:05Z"
+            database_id: storefront
+            entity_id: storefront
+            scope: database
+            status: completed
+            task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
+            type: create
           - completed_at: "2025-06-18T16:52:35Z"
             created_at: "2025-06-18T16:52:05Z"
             database_id: storefront
@@ -5299,7 +5197,20 @@ definitions:
           $ref: '#/definitions/DatabaseSummary'
         description: The databases managed by this cluster.
         example:
-          - created_at: "2025-01-01T01:30:00Z"
+          - available_upgrades:
+              - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                postgres_version: "17.10"
+                spock_version: "5"
+              - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                postgres_version: "17.10"
+                spock_version: "5"
+              - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                postgres_version: "17.10"
+                spock_version: "5"
+              - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                postgres_version: "17.10"
+                spock_version: "5"
+            created_at: "2025-01-01T01:30:00Z"
             id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             instances:
               - connection_info:
@@ -5369,7 +5280,20 @@ definitions:
             state: restoring
             tenant_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             updated_at: "2025-01-01T02:30:00Z"
-          - created_at: "2025-01-01T01:30:00Z"
+          - available_upgrades:
+              - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                postgres_version: "17.10"
+                spock_version: "5"
+              - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                postgres_version: "17.10"
+                spock_version: "5"
+              - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                postgres_version: "17.10"
+                spock_version: "5"
+              - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                postgres_version: "17.10"
+                spock_version: "5"
+            created_at: "2025-01-01T01:30:00Z"
             id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             instances:
               - connection_info:
@@ -5643,6 +5567,14 @@ definitions:
             status: completed
             task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
             type: create
+          - completed_at: "2025-06-18T16:52:35Z"
+            created_at: "2025-06-18T16:52:05Z"
+            database_id: storefront
+            entity_id: storefront
+            scope: database
+            status: completed
+            task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
+            type: create
     example:
       tasks:
         - completed_at: "2025-06-18T17:54:36Z"
@@ -5665,44 +5597,6 @@ definitions:
           $ref: '#/definitions/Host'
         description: List of hosts in the cluster
         example:
-          - client_addresses:
-              - 10.24.34.2
-              - i-0123456789abcdef.ec2.internal
-            cohort:
-              control_available: true
-              member_id: lah4bsznw6kc0hp7biylmmmll
-              type: swarm
-            cpus: 4
-            data_dir: /data
-            default_pgedge_version:
-              postgres_version: "17.6"
-              spock_version: "5"
-            etcd_mode: server
-            id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 16GiB
-            orchestrator: swarm
-            peer_addresses:
-              - 10.24.34.2
-              - i-0123456789abcdef.ec2.internal
-            status:
-              components:
-                Id dolorem rerum labore commodi.:
-                  details:
-                    alarms:
-                      - '3: NOSPACE'
-                  error: failed to connect to etcd
-                  healthy: false
-              state: available
-              updated_at: "2021-07-01T12:34:56Z"
-            supported_pgedge_versions:
-              - postgres_version: "17.6"
-                spock_version: "5"
-              - postgres_version: "17.6"
-                spock_version: "5"
-              - postgres_version: "17.6"
-                spock_version: "5"
-              - postgres_version: "17.6"
-                spock_version: "5"
           - client_addresses:
               - 10.24.34.2
               - i-0123456789abcdef.ec2.internal
@@ -5902,6 +5796,14 @@ definitions:
             status: completed
             task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
             type: create
+          - completed_at: "2025-06-18T16:52:35Z"
+            created_at: "2025-06-18T16:52:05Z"
+            database_id: storefront
+            entity_id: storefront
+            scope: database
+            status: completed
+            task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
+            type: create
     example:
       tasks:
         - completed_at: "2025-06-18T17:54:36Z"
@@ -5961,7 +5863,7 @@ definitions:
             host_path: /Users/user/backups/host
           - destination_path: /backups/container
             host_path: /Users/user/backups/host
-        image: Dignissimos incidunt in quas totam eveniet possimus.
+        image: Incidunt in quas totam.
   PgEdgeVersion:
     title: PgEdgeVersion
     type: object
@@ -6021,14 +5923,6 @@ definitions:
           $ref: '#/definitions/Task'
         description: The tasks that will update databases affected by the host removal.
         example:
-          - completed_at: "2025-06-18T16:52:35Z"
-            created_at: "2025-06-18T16:52:05Z"
-            database_id: storefront
-            entity_id: storefront
-            scope: database
-            status: completed
-            task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
-            type: create
           - completed_at: "2025-06-18T16:52:35Z"
             created_at: "2025-06-18T16:52:05Z"
             database_id: storefront
@@ -6175,7 +6069,7 @@ definitions:
         type: array
         items:
           type: string
-          example: Quo qui.
+          example: Et reprehenderit et nam quo qui.
         description: The nodes to restore. Defaults to all nodes if empty or unspecified.
         example:
           - n1
@@ -6204,22 +6098,6 @@ definitions:
           $ref: '#/definitions/Task'
         description: The tasks that will restore each database node.
         example:
-          - completed_at: "2025-06-18T16:52:35Z"
-            created_at: "2025-06-18T16:52:05Z"
-            database_id: storefront
-            entity_id: storefront
-            scope: database
-            status: completed
-            task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
-            type: create
-          - completed_at: "2025-06-18T16:52:35Z"
-            created_at: "2025-06-18T16:52:05Z"
-            database_id: storefront
-            entity_id: storefront
-            scope: database
-            status: completed
-            task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
-            type: create
           - completed_at: "2025-06-18T16:52:35Z"
             created_at: "2025-06-18T16:52:05Z"
             database_id: storefront
@@ -6574,9 +6452,6 @@ definitions:
           - container_port: 8080
             host_port: 8080
             name: web-client
-          - container_port: 8080
-            host_port: 8080
-            name: web-client
         service_ready: true
       updated_at: "2025-01-28T10:05:00Z"
     required:
@@ -6771,7 +6646,7 @@ definitions:
               host_path: /Users/user/backups/host
             - destination_path: /backups/container
               host_path: /Users/user/backups/host
-          image: Dignissimos incidunt in quas totam eveniet possimus.
+          image: Incidunt in quas totam.
       port: 0
       service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
       service_type: rag
@@ -7023,6 +6898,16 @@ definitions:
           $ref: '#/definitions/TaskLogEntry'
         description: Entries in the task log.
         example:
+          - fields:
+              option.enabled: true
+              status: creating
+            message: task started
+            timestamp: "2025-05-29T15:43:13Z"
+          - fields:
+              option.enabled: true
+              status: creating
+            message: task started
+            timestamp: "2025-05-29T15:43:13Z"
           - fields:
               option.enabled: true
               status: creating

--- a/api/apiv1/gen/http/openapi3.json
+++ b/api/apiv1/gen/http/openapi3.json
@@ -508,6 +508,28 @@
         "summary": "List databases",
         "description": "Lists all databases in the cluster.",
         "operationId": "list-databases",
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Optional fields to include in each database response. Supported values: available_upgrades.",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "Esse id natus aut omnis minus."
+              },
+              "description": "Optional fields to include in each database response. Supported values: available_upgrades.",
+              "example": [
+                "available_upgrades"
+              ]
+            },
+            "example": [
+              "available_upgrades"
+            ]
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK response.",
@@ -1468,6 +1490,26 @@
         "operationId": "get-database",
         "parameters": [
           {
+            "name": "include",
+            "in": "query",
+            "description": "Optional fields to include in the response. Supported values: available_upgrades.",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "Totam et et architecto voluptatem."
+              },
+              "description": "Optional fields to include in the response. Supported values: available_upgrades.",
+              "example": [
+                "available_upgrades"
+              ]
+            },
+            "example": [
+              "available_upgrades"
+            ]
+          },
+          {
             "name": "database_id",
             "in": "path",
             "description": "ID of the database to get.",
@@ -1750,21 +1792,18 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "example": "Possimus sit commodi in dolor unde."
+                "example": "Fuga qui id libero dignissimos."
               },
               "description": "Host IDs to treat as removed during this update. Events targeting these hosts will be skipped.",
               "example": [
-                "Ut sint cumque quia non enim.",
-                "Doloremque nam.",
-                "Sed esse id natus aut.",
-                "Minus sint totam et et."
+                "Numquam perspiciatis et exercitationem sequi saepe velit.",
+                "Ex sint dolorum vel.",
+                "Laboriosam aut dolorum est."
               ]
             },
             "example": [
-              "Quia fuga qui id libero dignissimos voluptates.",
-              "Numquam perspiciatis et exercitationem sequi saepe velit.",
-              "Ex sint dolorum vel.",
-              "Laboriosam aut dolorum est."
+              "Mollitia illo delectus.",
+              "Aut ducimus aut aut veritatis ut."
             ]
           },
           {
@@ -5543,6 +5582,37 @@
           "message"
         ]
       },
+      "AvailableUpgrade": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "string",
+            "description": "Full container image reference for the upgrade candidate.",
+            "example": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1"
+          },
+          "postgres_version": {
+            "type": "string",
+            "description": "Postgres version of the upgrade candidate.",
+            "example": "17.10"
+          },
+          "spock_version": {
+            "type": "string",
+            "description": "Spock major version of the upgrade candidate.",
+            "example": "5"
+          }
+        },
+        "description": "A newer stable image available for the database in the same Postgres major / Spock major bucket.",
+        "example": {
+          "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+          "postgres_version": "17.10",
+          "spock_version": "5"
+        },
+        "required": [
+          "postgres_version",
+          "spock_version",
+          "image"
+        ]
+      },
       "BackupConfigSpec": {
         "type": "object",
         "properties": {
@@ -6780,6 +6850,25 @@
       "Database": {
         "type": "object",
         "properties": {
+          "available_upgrades": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvailableUpgrade"
+            },
+            "description": "Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.",
+            "example": [
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              }
+            ]
+          },
           "created_at": {
             "type": "string",
             "description": "The time that the database was created.",
@@ -7266,6 +7355,25 @@
       "Database2": {
         "type": "object",
         "properties": {
+          "available_upgrades": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvailableUpgrade"
+            },
+            "description": "Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.",
+            "example": [
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              }
+            ]
+          },
           "created_at": {
             "type": "string",
             "description": "The time that the database was created.",
@@ -7286,51 +7394,6 @@
             },
             "description": "All of the instances in the database.",
             "example": [
-              {
-                "connection_info": {
-                  "addresses": [
-                    "10.24.34.2",
-                    "i-0123456789abcdef.ec2.internal"
-                  ],
-                  "port": 5432
-                },
-                "created_at": "2011-03-15T17:48:48Z",
-                "error": "failed to get patroni status: connection refused",
-                "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-                "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-                "node_name": "n1",
-                "postgres": {
-                  "patroni_paused": false,
-                  "patroni_state": "unknown",
-                  "pending_restart": true,
-                  "role": "primary",
-                  "version": "18.1"
-                },
-                "spock": {
-                  "read_only": "off",
-                  "subscriptions": [
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
-                    },
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
-                    },
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
-                    }
-                  ],
-                  "version": "4.10.0"
-                },
-                "state": "available",
-                "status_updated_at": "1993-04-25T23:06:28Z",
-                "updated_at": "1981-08-22T23:20:01Z"
-              },
               {
                 "connection_info": {
                   "addresses": [
@@ -7466,6 +7529,43 @@
                       "container_port": 8080,
                       "host_port": 8080,
                       "name": "web-client"
+                    }
+                  ],
+                  "service_ready": true
+                },
+                "updated_at": "2025-01-28T10:05:00Z"
+              },
+              {
+                "created_at": "2025-01-28T10:00:00Z",
+                "database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "error": "failed to start container: image not found",
+                "host_id": "host-1",
+                "service_id": "mcp-server",
+                "service_instance_id": "mcp-server-host-1",
+                "state": "running",
+                "status": {
+                  "addresses": [
+                    "10.24.34.2",
+                    "i-0123456789abcdef.ec2.internal"
+                  ],
+                  "container_id": "a1b2c3d4e5f6",
+                  "health_check": {
+                    "checked_at": "2025-01-28T10:00:00Z",
+                    "message": "Connection refused",
+                    "status": "healthy"
+                  },
+                  "image_version": "1.0.0",
+                  "last_health_at": "2025-01-28T10:00:00Z",
+                  "ports": [
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
                     },
                     {
                       "container_port": 8080,
@@ -7513,11 +7613,6 @@
                       "container_port": 8080,
                       "host_port": 8080,
                       "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
                     }
                   ],
                   "service_ready": true
@@ -7532,7 +7627,7 @@
           "state": {
             "type": "string",
             "description": "Current state of the database.",
-            "example": "creating",
+            "example": "degraded",
             "enum": [
               "creating",
               "modifying",
@@ -7723,6 +7818,35 @@
       "Database3": {
         "type": "object",
         "properties": {
+          "available_upgrades": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvailableUpgrade"
+            },
+            "description": "Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.",
+            "example": [
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              }
+            ]
+          },
           "created_at": {
             "type": "string",
             "description": "The time that the database was created.",
@@ -7743,6 +7867,51 @@
             },
             "description": "All of the instances in the database.",
             "example": [
+              {
+                "connection_info": {
+                  "addresses": [
+                    "10.24.34.2",
+                    "i-0123456789abcdef.ec2.internal"
+                  ],
+                  "port": 5432
+                },
+                "created_at": "2011-03-15T17:48:48Z",
+                "error": "failed to get patroni status: connection refused",
+                "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+                "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
+                "node_name": "n1",
+                "postgres": {
+                  "patroni_paused": false,
+                  "patroni_state": "unknown",
+                  "pending_restart": true,
+                  "role": "primary",
+                  "version": "18.1"
+                },
+                "spock": {
+                  "read_only": "off",
+                  "subscriptions": [
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    },
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    },
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    }
+                  ],
+                  "version": "4.10.0"
+                },
+                "state": "available",
+                "status_updated_at": "1993-04-25T23:06:28Z",
+                "updated_at": "1981-08-22T23:20:01Z"
+              },
               {
                 "connection_info": {
                   "addresses": [
@@ -7878,6 +8047,43 @@
                       "container_port": 8080,
                       "host_port": 8080,
                       "name": "web-client"
+                    }
+                  ],
+                  "service_ready": true
+                },
+                "updated_at": "2025-01-28T10:05:00Z"
+              },
+              {
+                "created_at": "2025-01-28T10:00:00Z",
+                "database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "error": "failed to start container: image not found",
+                "host_id": "host-1",
+                "service_id": "mcp-server",
+                "service_instance_id": "mcp-server-host-1",
+                "state": "running",
+                "status": {
+                  "addresses": [
+                    "10.24.34.2",
+                    "i-0123456789abcdef.ec2.internal"
+                  ],
+                  "container_id": "a1b2c3d4e5f6",
+                  "health_check": {
+                    "checked_at": "2025-01-28T10:00:00Z",
+                    "message": "Connection refused",
+                    "status": "healthy"
+                  },
+                  "image_version": "1.0.0",
+                  "last_health_at": "2025-01-28T10:00:00Z",
+                  "ports": [
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
+                    },
+                    {
+                      "container_port": 8080,
+                      "host_port": 8080,
+                      "name": "web-client"
                     },
                     {
                       "container_port": 8080,
@@ -7925,11 +8131,6 @@
                       "container_port": 8080,
                       "host_port": 8080,
                       "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
                     }
                   ],
                   "service_ready": true
@@ -7958,11 +8159,6 @@
                   "image_version": "1.0.0",
                   "last_health_at": "2025-01-28T10:00:00Z",
                   "ports": [
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
                     {
                       "container_port": 8080,
                       "host_port": 8080,
@@ -7991,7 +8187,7 @@
           "state": {
             "type": "string",
             "description": "Current state of the database.",
-            "example": "deleting",
+            "example": "unknown",
             "enum": [
               "creating",
               "modifying",
@@ -8182,6 +8378,35 @@
       "Database4": {
         "type": "object",
         "properties": {
+          "available_upgrades": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvailableUpgrade"
+            },
+            "description": "Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.",
+            "example": [
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              }
+            ]
+          },
           "created_at": {
             "type": "string",
             "description": "The time that the database was created.",
@@ -8202,51 +8427,6 @@
             },
             "description": "All of the instances in the database.",
             "example": [
-              {
-                "connection_info": {
-                  "addresses": [
-                    "10.24.34.2",
-                    "i-0123456789abcdef.ec2.internal"
-                  ],
-                  "port": 5432
-                },
-                "created_at": "2011-03-15T17:48:48Z",
-                "error": "failed to get patroni status: connection refused",
-                "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-                "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-                "node_name": "n1",
-                "postgres": {
-                  "patroni_paused": false,
-                  "patroni_state": "unknown",
-                  "pending_restart": true,
-                  "role": "primary",
-                  "version": "18.1"
-                },
-                "spock": {
-                  "read_only": "off",
-                  "subscriptions": [
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
-                    },
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
-                    },
-                    {
-                      "name": "sub_n1n2",
-                      "provider_node": "n2",
-                      "status": "down"
-                    }
-                  ],
-                  "version": "4.10.0"
-                },
-                "state": "available",
-                "status_updated_at": "1993-04-25T23:06:28Z",
-                "updated_at": "1981-08-22T23:20:01Z"
-              },
               {
                 "connection_info": {
                   "addresses": [
@@ -8382,11 +8562,6 @@
                       "container_port": 8080,
                       "host_port": 8080,
                       "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
                     }
                   ],
                   "service_ready": true
@@ -8415,11 +8590,6 @@
                   "image_version": "1.0.0",
                   "last_health_at": "2025-01-28T10:00:00Z",
                   "ports": [
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
                     {
                       "container_port": 8080,
                       "host_port": 8080,
@@ -8639,6 +8809,25 @@
       "Database5": {
         "type": "object",
         "properties": {
+          "available_upgrades": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvailableUpgrade"
+            },
+            "description": "Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.",
+            "example": [
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              }
+            ]
+          },
           "created_at": {
             "type": "string",
             "description": "The time that the database was created.",
@@ -8659,6 +8848,51 @@
             },
             "description": "All of the instances in the database.",
             "example": [
+              {
+                "connection_info": {
+                  "addresses": [
+                    "10.24.34.2",
+                    "i-0123456789abcdef.ec2.internal"
+                  ],
+                  "port": 5432
+                },
+                "created_at": "2011-03-15T17:48:48Z",
+                "error": "failed to get patroni status: connection refused",
+                "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
+                "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
+                "node_name": "n1",
+                "postgres": {
+                  "patroni_paused": false,
+                  "patroni_state": "unknown",
+                  "pending_restart": true,
+                  "role": "primary",
+                  "version": "18.1"
+                },
+                "spock": {
+                  "read_only": "off",
+                  "subscriptions": [
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    },
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    },
+                    {
+                      "name": "sub_n1n2",
+                      "provider_node": "n2",
+                      "status": "down"
+                    }
+                  ],
+                  "version": "4.10.0"
+                },
+                "state": "available",
+                "status_updated_at": "1993-04-25T23:06:28Z",
+                "updated_at": "1981-08-22T23:20:01Z"
+              },
               {
                 "connection_info": {
                   "addresses": [
@@ -8839,11 +9073,6 @@
                       "container_port": 8080,
                       "host_port": 8080,
                       "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
                     }
                   ],
                   "service_ready": true
@@ -8886,11 +9115,6 @@
                       "container_port": 8080,
                       "host_port": 8080,
                       "name": "web-client"
-                    },
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
                     }
                   ],
                   "service_ready": true
@@ -8919,11 +9143,6 @@
                   "image_version": "1.0.0",
                   "last_health_at": "2025-01-28T10:00:00Z",
                   "ports": [
-                    {
-                      "container_port": 8080,
-                      "host_port": 8080,
-                      "name": "web-client"
-                    },
                     {
                       "container_port": 8080,
                       "host_port": 8080,
@@ -8952,7 +9171,7 @@
           "state": {
             "type": "string",
             "description": "Current state of the database.",
-            "example": "deleting",
+            "example": "restoring",
             "enum": [
               "creating",
               "modifying",
@@ -9515,7 +9734,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Excepturi sapiente neque doloribus consequatur voluptatibus."
+              "example": "Sapiente neque doloribus consequatur voluptatibus sed."
             },
             "description": "Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.",
             "example": [
@@ -9526,7 +9745,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Et nisi nihil corporis."
+              "example": "Nisi nihil corporis perspiciatis et."
             },
             "description": "Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.",
             "example": [
@@ -9612,6 +9831,29 @@
                 "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                 "s3_region": "us-east-1",
                 "type": "s3"
+              },
+              {
+                "azure_account": "pgedge-backups",
+                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "azure_endpoint": "blob.core.usgovcloudapi.net",
+                "azure_key": "YXpLZXk=",
+                "base_path": "/backups",
+                "custom_options": {
+                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                  "storage-upload-chunk-size": "5MiB"
+                },
+                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "gcs_endpoint": "localhost",
+                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "retention_full": 2,
+                "retention_full_type": "count",
+                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "s3_region": "us-east-1",
+                "type": "s3"
               }
             ],
             "schedules": [
@@ -9634,6 +9876,7 @@
           },
           "cpus": "500m",
           "host_ids": [
+            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "500M",
@@ -9690,7 +9933,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Necessitatibus excepturi reprehenderit."
+              "image": "Reprehenderit atque aliquid."
             }
           },
           "patroni_port": 8888,
@@ -9764,7 +10007,6 @@
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -9796,7 +10038,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Velit distinctio sed amet."
+              "example": "Distinctio sed amet rem voluptas qui."
             },
             "description": "Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.",
             "example": [
@@ -9807,7 +10049,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Voluptas qui."
+              "example": "Voluptatem nesciunt dignissimos voluptas vel earum."
             },
             "description": "Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.",
             "example": [
@@ -9848,29 +10090,6 @@
         "example": {
           "backup_config": {
             "repositories": [
-              {
-                "azure_account": "pgedge-backups",
-                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "azure_endpoint": "blob.core.usgovcloudapi.net",
-                "azure_key": "YXpLZXk=",
-                "base_path": "/backups",
-                "custom_options": {
-                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                  "storage-upload-chunk-size": "5MiB"
-                },
-                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "gcs_endpoint": "localhost",
-                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "retention_full": 2,
-                "retention_full_type": "count",
-                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                "s3_region": "us-east-1",
-                "type": "s3"
-              },
               {
                 "azure_account": "pgedge-backups",
                 "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -9996,7 +10215,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "patroni_port": 8888,
@@ -10071,6 +10290,7 @@
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -10102,7 +10322,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Numquam incidunt eaque totam at culpa ut."
+              "example": "Harum iste dignissimos."
             },
             "description": "Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.",
             "example": [
@@ -10113,7 +10333,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Iste dignissimos exercitationem."
+              "example": "Beatae nobis quam sequi quasi aliquid."
             },
             "description": "Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.",
             "example": [
@@ -10199,29 +10419,6 @@
                 "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                 "s3_region": "us-east-1",
                 "type": "s3"
-              },
-              {
-                "azure_account": "pgedge-backups",
-                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "azure_endpoint": "blob.core.usgovcloudapi.net",
-                "azure_key": "YXpLZXk=",
-                "base_path": "/backups",
-                "custom_options": {
-                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                  "storage-upload-chunk-size": "5MiB"
-                },
-                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "gcs_endpoint": "localhost",
-                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "retention_full": 2,
-                "retention_full_type": "count",
-                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                "s3_region": "us-east-1",
-                "type": "s3"
               }
             ],
             "schedules": [
@@ -10244,8 +10441,6 @@
           },
           "cpus": "500m",
           "host_ids": [
-            "76f9b8c0-4958-11f0-a489-3bb29577c696",
-            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "500M",
@@ -10302,7 +10497,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "patroni_port": 8888,
@@ -10377,6 +10572,7 @@
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -10408,7 +10604,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Consequuntur et."
+              "example": "Dolor sit quae et tempore et aut."
             },
             "description": "Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.",
             "example": [
@@ -10419,7 +10615,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Et nulla omnis nobis dolor sit."
+              "example": "Nisi eveniet sit dignissimos ducimus."
             },
             "description": "Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.",
             "example": [
@@ -10460,6 +10656,29 @@
         "example": {
           "backup_config": {
             "repositories": [
+              {
+                "azure_account": "pgedge-backups",
+                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "azure_endpoint": "blob.core.usgovcloudapi.net",
+                "azure_key": "YXpLZXk=",
+                "base_path": "/backups",
+                "custom_options": {
+                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                  "storage-upload-chunk-size": "5MiB"
+                },
+                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "gcs_endpoint": "localhost",
+                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "retention_full": 2,
+                "retention_full_type": "count",
+                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "s3_region": "us-east-1",
+                "type": "s3"
+              },
               {
                 "azure_account": "pgedge-backups",
                 "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -10583,7 +10802,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Quia reiciendis et odio omnis itaque cum."
+              "image": "Et odio."
             }
           },
           "patroni_port": 8888,
@@ -10657,6 +10876,7 @@
             },
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
+              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -10688,7 +10908,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Deserunt quis."
+              "example": "Laudantium molestiae error quas iste."
             },
             "description": "Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.",
             "example": [
@@ -10699,7 +10919,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Officiis libero."
+              "example": "Assumenda et."
             },
             "description": "Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.",
             "example": [
@@ -10740,29 +10960,6 @@
         "example": {
           "backup_config": {
             "repositories": [
-              {
-                "azure_account": "pgedge-backups",
-                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "azure_endpoint": "blob.core.usgovcloudapi.net",
-                "azure_key": "YXpLZXk=",
-                "base_path": "/backups",
-                "custom_options": {
-                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                  "storage-upload-chunk-size": "5MiB"
-                },
-                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "gcs_endpoint": "localhost",
-                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "retention_full": 2,
-                "retention_full_type": "count",
-                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                "s3_region": "us-east-1",
-                "type": "s3"
-              },
               {
                 "azure_account": "pgedge-backups",
                 "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -10886,7 +11083,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "patroni_port": 8888,
@@ -10961,7 +11158,6 @@
             "description": "The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.",
             "example": [
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -10993,7 +11189,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Aperiam rerum at eveniet consectetur facilis autem."
+              "example": "Praesentium possimus id laudantium sed delectus."
             },
             "description": "Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.",
             "example": [
@@ -11004,7 +11200,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Voluptatem velit dolorem."
+              "example": "Ut distinctio expedita."
             },
             "description": "Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.",
             "example": [
@@ -11045,29 +11241,6 @@
         "example": {
           "backup_config": {
             "repositories": [
-              {
-                "azure_account": "pgedge-backups",
-                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "azure_endpoint": "blob.core.usgovcloudapi.net",
-                "azure_key": "YXpLZXk=",
-                "base_path": "/backups",
-                "custom_options": {
-                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                  "storage-upload-chunk-size": "5MiB"
-                },
-                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "gcs_endpoint": "localhost",
-                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "retention_full": 2,
-                "retention_full_type": "count",
-                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                "s3_region": "us-east-1",
-                "type": "s3"
-              },
               {
                 "azure_account": "pgedge-backups",
                 "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -11193,7 +11366,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "patroni_port": 8888,
@@ -13043,6 +13216,29 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
+                    },
+                    {
+                      "azure_account": "pgedge-backups",
+                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "azure_endpoint": "blob.core.usgovcloudapi.net",
+                      "azure_key": "YXpLZXk=",
+                      "base_path": "/backups",
+                      "custom_options": {
+                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                        "storage-upload-chunk-size": "5MiB"
+                      },
+                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "gcs_endpoint": "localhost",
+                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                      "retention_full": 2,
+                      "retention_full_type": "count",
+                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                      "s3_region": "us-east-1",
+                      "type": "s3"
                     }
                   ],
                   "schedules": [
@@ -13065,6 +13261,8 @@
                 },
                 "cpus": "500m",
                 "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "500M",
@@ -13121,180 +13319,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Necessitatibus excepturi reprehenderit."
-                  }
-                },
-                "patroni_port": 8888,
-                "pg_hba_conf": [
-                  "host example myapp_user 10.0.0.0/8 scram-sha-256"
-                ],
-                "pg_ident_conf": [
-                  "ssl_users  CN=alice,O=example  alice"
-                ],
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
-              },
-              {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
-                },
-                "cpus": "500m",
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "500M",
-                "name": "n1",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ],
-                    "image": "Necessitatibus excepturi reprehenderit."
+                    "image": "Reprehenderit atque aliquid."
                   }
                 },
                 "patroni_port": 8888,
@@ -13360,7 +13385,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Fuga occaecati optio accusantium eos voluptatibus sunt."
+              "example": "Optio accusantium."
             },
             "description": "Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.",
             "example": [
@@ -13372,7 +13397,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Sapiente doloribus."
+              "example": "Voluptatibus sunt deserunt sapiente doloribus est."
             },
             "description": "Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.",
             "example": [
@@ -13431,7 +13456,6 @@
                   "target_session_attrs": "primary"
                 },
                 "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "512M",
@@ -13487,7 +13511,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Necessitatibus excepturi reprehenderit."
+                    "image": "Reprehenderit atque aliquid."
                   }
                 },
                 "port": 0,
@@ -13511,7 +13535,6 @@
                   "target_session_attrs": "primary"
                 },
                 "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "512M",
@@ -13567,7 +13590,86 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Necessitatibus excepturi reprehenderit."
+                    "image": "Reprehenderit atque aliquid."
+                  }
+                },
+                "port": 0,
+                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "service_type": "rag",
+                "version": "latest"
+              },
+              {
+                "config": {
+                  "llm_model": "gpt-4",
+                  "llm_provider": "openai",
+                  "openai_api_key": "sk-..."
+                },
+                "connect_as": "app",
+                "cpus": "500m",
+                "database_connection": {
+                  "target_nodes": [
+                    "n1",
+                    "n2"
+                  ],
+                  "target_session_attrs": "primary"
+                },
+                "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
+                ],
+                "memory": "512M",
+                "orchestrator_opts": {
+                  "swarm": {
+                    "extra_labels": {
+                      "traefik.enable": "true",
+                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                    },
+                    "extra_networks": [
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      }
+                    ],
+                    "extra_volumes": [
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      }
+                    ],
+                    "image": "Reprehenderit atque aliquid."
                   }
                 },
                 "port": 0,
@@ -13587,6 +13689,29 @@
         "example": {
           "backup_config": {
             "repositories": [
+              {
+                "azure_account": "pgedge-backups",
+                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "azure_endpoint": "blob.core.usgovcloudapi.net",
+                "azure_key": "YXpLZXk=",
+                "base_path": "/backups",
+                "custom_options": {
+                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                  "storage-upload-chunk-size": "5MiB"
+                },
+                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "gcs_endpoint": "localhost",
+                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "retention_full": 2,
+                "retention_full_type": "count",
+                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "s3_region": "us-east-1",
+                "type": "s3"
+              },
               {
                 "azure_account": "pgedge-backups",
                 "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -13745,6 +13870,29 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
+                  },
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -13767,6 +13915,8 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "500M",
@@ -13823,7 +13973,403 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Necessitatibus excepturi reprehenderit."
+                  "image": "Reprehenderit atque aliquid."
+                }
+              },
+              "patroni_port": 8888,
+              "pg_hba_conf": [
+                "host example myapp_user 10.0.0.0/8 scram-sha-256"
+              ],
+              "pg_ident_conf": [
+                "ssl_users  CN=alice,O=example  alice"
+              ],
+              "port": 5432,
+              "postgres_version": "17.6",
+              "postgresql_conf": {
+                "max_connections": 1000
+              },
+              "restore_config": {
+                "repository": {
+                  "azure_account": "pgedge-backups",
+                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "azure_endpoint": "blob.core.usgovcloudapi.net",
+                  "azure_key": "YXpLZXk=",
+                  "base_path": "/backups",
+                  "custom_options": {
+                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
+                  },
+                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "gcs_endpoint": "localhost",
+                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                  "s3_region": "us-east-1",
+                  "type": "s3"
+                },
+                "restore_options": {
+                  "set": "20250505-153628F",
+                  "target": "123456",
+                  "type": "xid"
+                },
+                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "source_database_name": "northwind",
+                "source_node_name": "n1"
+              },
+              "source_node": "n1"
+            },
+            {
+              "backup_config": {
+                "repositories": [
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  },
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  },
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  }
+                ],
+                "schedules": [
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  },
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  },
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  }
+                ]
+              },
+              "cpus": "500m",
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "500M",
+              "name": "n1",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ],
+                  "image": "Reprehenderit atque aliquid."
+                }
+              },
+              "patroni_port": 8888,
+              "pg_hba_conf": [
+                "host example myapp_user 10.0.0.0/8 scram-sha-256"
+              ],
+              "pg_ident_conf": [
+                "ssl_users  CN=alice,O=example  alice"
+              ],
+              "port": 5432,
+              "postgres_version": "17.6",
+              "postgresql_conf": {
+                "max_connections": 1000
+              },
+              "restore_config": {
+                "repository": {
+                  "azure_account": "pgedge-backups",
+                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "azure_endpoint": "blob.core.usgovcloudapi.net",
+                  "azure_key": "YXpLZXk=",
+                  "base_path": "/backups",
+                  "custom_options": {
+                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
+                  },
+                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "gcs_endpoint": "localhost",
+                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                  "s3_region": "us-east-1",
+                  "type": "s3"
+                },
+                "restore_options": {
+                  "set": "20250505-153628F",
+                  "target": "123456",
+                  "type": "xid"
+                },
+                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "source_database_name": "northwind",
+                "source_node_name": "n1"
+              },
+              "source_node": "n1"
+            },
+            {
+              "backup_config": {
+                "repositories": [
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  },
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  },
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  }
+                ],
+                "schedules": [
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  },
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  },
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  }
+                ]
+              },
+              "cpus": "500m",
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "500M",
+              "name": "n1",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ],
+                  "image": "Reprehenderit atque aliquid."
                 }
               },
               "patroni_port": 8888,
@@ -13923,7 +14469,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Necessitatibus excepturi reprehenderit."
+              "image": "Reprehenderit atque aliquid."
             }
           },
           "patroni_port": 8888,
@@ -13998,7 +14544,6 @@
                 "target_session_attrs": "primary"
               },
               "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -14054,7 +14599,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Necessitatibus excepturi reprehenderit."
+                  "image": "Reprehenderit atque aliquid."
                 }
               },
               "port": 0,
@@ -14078,7 +14623,6 @@
                 "target_session_attrs": "primary"
               },
               "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -14134,87 +14678,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Necessitatibus excepturi reprehenderit."
-                }
-              },
-              "port": 0,
-              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "service_type": "rag",
-              "version": "latest"
-            },
-            {
-              "config": {
-                "llm_model": "gpt-4",
-                "llm_provider": "openai",
-                "openai_api_key": "sk-..."
-              },
-              "connect_as": "app",
-              "cpus": "500m",
-              "database_connection": {
-                "target_nodes": [
-                  "n1",
-                  "n2"
-                ],
-                "target_session_attrs": "primary"
-              },
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "512M",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ],
-                  "image": "Necessitatibus excepturi reprehenderit."
+                  "image": "Reprehenderit atque aliquid."
                 }
               },
               "port": 0,
@@ -14262,7 +14726,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -14275,7 +14739,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -14288,7 +14752,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -14359,29 +14823,6 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
                     }
                   ],
                   "schedules": [
@@ -14404,6 +14845,7 @@
                 },
                 "cpus": "500m",
                 "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
@@ -14461,7 +14903,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "patroni_port": 8888,
@@ -14556,29 +14998,6 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
                     }
                   ],
                   "schedules": [
@@ -14601,6 +15020,7 @@
                 },
                 "cpus": "500m",
                 "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
@@ -14658,204 +15078,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
-                  }
-                },
-                "patroni_port": 8888,
-                "pg_hba_conf": [
-                  "host example myapp_user 10.0.0.0/8 scram-sha-256"
-                ],
-                "pg_ident_conf": [
-                  "ssl_users  CN=alice,O=example  alice"
-                ],
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
-              },
-              {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
-                },
-                "cpus": "500m",
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "500M",
-                "name": "n1",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "patroni_port": 8888,
@@ -14921,7 +15144,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Eaque et."
+              "example": "Quo perferendis et qui."
             },
             "description": "Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.",
             "example": [
@@ -14933,7 +15156,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Minima ipsum ut impedit quo."
+              "example": "Quaerat rem."
             },
             "description": "Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.",
             "example": [
@@ -14993,7 +15216,6 @@
                 },
                 "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "512M",
@@ -15049,7 +15271,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "port": 0,
@@ -15074,6 +15296,85 @@
                 },
                 "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
+                ],
+                "memory": "512M",
+                "orchestrator_opts": {
+                  "swarm": {
+                    "extra_labels": {
+                      "traefik.enable": "true",
+                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                    },
+                    "extra_networks": [
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      }
+                    ],
+                    "extra_volumes": [
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      }
+                    ],
+                    "image": "Incidunt in quas totam."
+                  }
+                },
+                "port": 0,
+                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "service_type": "rag",
+                "version": "latest"
+              },
+              {
+                "config": {
+                  "llm_model": "gpt-4",
+                  "llm_provider": "openai",
+                  "openai_api_key": "sk-..."
+                },
+                "connect_as": "app",
+                "cpus": "500m",
+                "database_connection": {
+                  "target_nodes": [
+                    "n1",
+                    "n2"
+                  ],
+                  "target_session_attrs": "primary"
+                },
+                "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
@@ -15130,7 +15431,87 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
+                  }
+                },
+                "port": 0,
+                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "service_type": "rag",
+                "version": "latest"
+              },
+              {
+                "config": {
+                  "llm_model": "gpt-4",
+                  "llm_provider": "openai",
+                  "openai_api_key": "sk-..."
+                },
+                "connect_as": "app",
+                "cpus": "500m",
+                "database_connection": {
+                  "target_nodes": [
+                    "n1",
+                    "n2"
+                  ],
+                  "target_session_attrs": "primary"
+                },
+                "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
+                ],
+                "memory": "512M",
+                "orchestrator_opts": {
+                  "swarm": {
+                    "extra_labels": {
+                      "traefik.enable": "true",
+                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                    },
+                    "extra_networks": [
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      }
+                    ],
+                    "extra_volumes": [
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      }
+                    ],
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "port": 0,
@@ -15150,29 +15531,6 @@
         "example": {
           "backup_config": {
             "repositories": [
-              {
-                "azure_account": "pgedge-backups",
-                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "azure_endpoint": "blob.core.usgovcloudapi.net",
-                "azure_key": "YXpLZXk=",
-                "base_path": "/backups",
-                "custom_options": {
-                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                  "storage-upload-chunk-size": "5MiB"
-                },
-                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "gcs_endpoint": "localhost",
-                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "retention_full": 2,
-                "retention_full_type": "count",
-                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                "s3_region": "us-east-1",
-                "type": "s3"
-              },
               {
                 "azure_account": "pgedge-backups",
                 "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -15247,7 +15605,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -15260,7 +15618,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -15273,7 +15631,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -15286,29 +15644,6 @@
             {
               "backup_config": {
                 "repositories": [
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
                   {
                     "azure_account": "pgedge-backups",
                     "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -15377,6 +15712,7 @@
               "cpus": "500m",
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "500M",
@@ -15433,7 +15769,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -15528,29 +15864,6 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -15573,6 +15886,7 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
@@ -15630,7 +15944,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -15730,7 +16044,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "patroni_port": 8888,
@@ -15806,7 +16120,6 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -15862,7 +16175,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -15887,6 +16200,85 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "512M",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ],
+                  "image": "Incidunt in quas totam."
+                }
+              },
+              "port": 0,
+              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "service_type": "rag",
+              "version": "latest"
+            },
+            {
+              "config": {
+                "llm_model": "gpt-4",
+                "llm_provider": "openai",
+                "openai_api_key": "sk-..."
+              },
+              "connect_as": "app",
+              "cpus": "500m",
+              "database_connection": {
+                "target_nodes": [
+                  "n1",
+                  "n2"
+                ],
+                "target_session_attrs": "primary"
+              },
+              "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
@@ -15943,7 +16335,87 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
+                }
+              },
+              "port": 0,
+              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "service_type": "rag",
+              "version": "latest"
+            },
+            {
+              "config": {
+                "llm_model": "gpt-4",
+                "llm_provider": "openai",
+                "openai_api_key": "sk-..."
+              },
+              "connect_as": "app",
+              "cpus": "500m",
+              "database_connection": {
+                "target_nodes": [
+                  "n1",
+                  "n2"
+                ],
+                "target_session_attrs": "primary"
+              },
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "512M",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ],
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -15991,7 +16463,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -16004,7 +16476,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -16017,7 +16489,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -16088,29 +16560,6 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
                     }
                   ],
                   "schedules": [
@@ -16133,6 +16582,7 @@
                 },
                 "cpus": "500m",
                 "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
@@ -16190,7 +16640,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "patroni_port": 8888,
@@ -16285,29 +16735,6 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
                     }
                   ],
                   "schedules": [
@@ -16330,6 +16757,7 @@
                 },
                 "cpus": "500m",
                 "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
@@ -16387,7 +16815,182 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
+                  }
+                },
+                "patroni_port": 8888,
+                "pg_hba_conf": [
+                  "host example myapp_user 10.0.0.0/8 scram-sha-256"
+                ],
+                "pg_ident_conf": [
+                  "ssl_users  CN=alice,O=example  alice"
+                ],
+                "port": 5432,
+                "postgres_version": "17.6",
+                "postgresql_conf": {
+                  "max_connections": 1000
+                },
+                "restore_config": {
+                  "repository": {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  },
+                  "restore_options": {
+                    "set": "20250505-153628F",
+                    "target": "123456",
+                    "type": "xid"
+                  },
+                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "source_database_name": "northwind",
+                  "source_node_name": "n1"
+                },
+                "source_node": "n1"
+              },
+              {
+                "backup_config": {
+                  "repositories": [
+                    {
+                      "azure_account": "pgedge-backups",
+                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "azure_endpoint": "blob.core.usgovcloudapi.net",
+                      "azure_key": "YXpLZXk=",
+                      "base_path": "/backups",
+                      "custom_options": {
+                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                        "storage-upload-chunk-size": "5MiB"
+                      },
+                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "gcs_endpoint": "localhost",
+                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                      "retention_full": 2,
+                      "retention_full_type": "count",
+                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                      "s3_region": "us-east-1",
+                      "type": "s3"
+                    },
+                    {
+                      "azure_account": "pgedge-backups",
+                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "azure_endpoint": "blob.core.usgovcloudapi.net",
+                      "azure_key": "YXpLZXk=",
+                      "base_path": "/backups",
+                      "custom_options": {
+                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                        "storage-upload-chunk-size": "5MiB"
+                      },
+                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "gcs_endpoint": "localhost",
+                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                      "retention_full": 2,
+                      "retention_full_type": "count",
+                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                      "s3_region": "us-east-1",
+                      "type": "s3"
+                    }
+                  ],
+                  "schedules": [
+                    {
+                      "cron_expression": "0 6 * * ?",
+                      "id": "daily-full-backup",
+                      "type": "full"
+                    },
+                    {
+                      "cron_expression": "0 6 * * ?",
+                      "id": "daily-full-backup",
+                      "type": "full"
+                    },
+                    {
+                      "cron_expression": "0 6 * * ?",
+                      "id": "daily-full-backup",
+                      "type": "full"
+                    }
+                  ]
+                },
+                "cpus": "500m",
+                "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
+                ],
+                "memory": "500M",
+                "name": "n1",
+                "orchestrator_opts": {
+                  "swarm": {
+                    "extra_labels": {
+                      "traefik.enable": "true",
+                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                    },
+                    "extra_networks": [
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      }
+                    ],
+                    "extra_volumes": [
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      }
+                    ],
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "patroni_port": 8888,
@@ -16453,7 +17056,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Dolorum natus sunt harum magnam sunt."
+              "example": "Tempora in veniam officia ratione minus."
             },
             "description": "Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.",
             "example": [
@@ -16465,7 +17068,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "In veniam officia ratione."
+              "example": "Occaecati et et consequuntur."
             },
             "description": "Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.",
             "example": [
@@ -16525,7 +17128,6 @@
                 },
                 "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "512M",
@@ -16581,7 +17183,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "port": 0,
@@ -16606,6 +17208,85 @@
                 },
                 "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
+                ],
+                "memory": "512M",
+                "orchestrator_opts": {
+                  "swarm": {
+                    "extra_labels": {
+                      "traefik.enable": "true",
+                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                    },
+                    "extra_networks": [
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      }
+                    ],
+                    "extra_volumes": [
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      }
+                    ],
+                    "image": "Incidunt in quas totam."
+                  }
+                },
+                "port": 0,
+                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "service_type": "rag",
+                "version": "latest"
+              },
+              {
+                "config": {
+                  "llm_model": "gpt-4",
+                  "llm_provider": "openai",
+                  "openai_api_key": "sk-..."
+                },
+                "connect_as": "app",
+                "cpus": "500m",
+                "database_connection": {
+                  "target_nodes": [
+                    "n1",
+                    "n2"
+                  ],
+                  "target_session_attrs": "primary"
+                },
+                "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
@@ -16662,7 +17343,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "port": 0,
@@ -16682,29 +17363,6 @@
         "example": {
           "backup_config": {
             "repositories": [
-              {
-                "azure_account": "pgedge-backups",
-                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "azure_endpoint": "blob.core.usgovcloudapi.net",
-                "azure_key": "YXpLZXk=",
-                "base_path": "/backups",
-                "custom_options": {
-                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                  "storage-upload-chunk-size": "5MiB"
-                },
-                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "gcs_endpoint": "localhost",
-                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "retention_full": 2,
-                "retention_full_type": "count",
-                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                "s3_region": "us-east-1",
-                "type": "s3"
-              },
               {
                 "azure_account": "pgedge-backups",
                 "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -16779,7 +17437,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -16792,7 +17450,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -16805,7 +17463,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -16863,29 +17521,6 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -16908,6 +17543,7 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
@@ -16965,7 +17601,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -17060,29 +17696,6 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -17105,6 +17718,7 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
@@ -17162,7 +17776,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -17257,29 +17871,6 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -17302,6 +17893,7 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
@@ -17359,7 +17951,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -17459,7 +18051,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "patroni_port": 8888,
@@ -17535,7 +18127,6 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -17591,7 +18182,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -17616,7 +18207,6 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -17672,7 +18262,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -17697,7 +18287,6 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -17753,7 +18342,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -17778,7 +18367,6 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -17834,7 +18422,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -17979,6 +18567,29 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
+                    },
+                    {
+                      "azure_account": "pgedge-backups",
+                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "azure_endpoint": "blob.core.usgovcloudapi.net",
+                      "azure_key": "YXpLZXk=",
+                      "base_path": "/backups",
+                      "custom_options": {
+                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                        "storage-upload-chunk-size": "5MiB"
+                      },
+                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "gcs_endpoint": "localhost",
+                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                      "retention_full": 2,
+                      "retention_full_type": "count",
+                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                      "s3_region": "us-east-1",
+                      "type": "s3"
                     }
                   ],
                   "schedules": [
@@ -18001,6 +18612,7 @@
                 },
                 "cpus": "500m",
                 "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "500M",
@@ -18057,7 +18669,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Quia reiciendis et odio omnis itaque cum."
+                    "image": "Et odio."
                   }
                 },
                 "patroni_port": 8888,
@@ -18152,6 +18764,29 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
+                    },
+                    {
+                      "azure_account": "pgedge-backups",
+                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "azure_endpoint": "blob.core.usgovcloudapi.net",
+                      "azure_key": "YXpLZXk=",
+                      "base_path": "/backups",
+                      "custom_options": {
+                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                        "storage-upload-chunk-size": "5MiB"
+                      },
+                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "gcs_endpoint": "localhost",
+                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                      "retention_full": 2,
+                      "retention_full_type": "count",
+                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                      "s3_region": "us-east-1",
+                      "type": "s3"
                     }
                   ],
                   "schedules": [
@@ -18174,6 +18809,7 @@
                 },
                 "cpus": "500m",
                 "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "500M",
@@ -18230,180 +18866,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Quia reiciendis et odio omnis itaque cum."
-                  }
-                },
-                "patroni_port": 8888,
-                "pg_hba_conf": [
-                  "host example myapp_user 10.0.0.0/8 scram-sha-256"
-                ],
-                "pg_ident_conf": [
-                  "ssl_users  CN=alice,O=example  alice"
-                ],
-                "port": 5432,
-                "postgres_version": "17.6",
-                "postgresql_conf": {
-                  "max_connections": 1000
-                },
-                "restore_config": {
-                  "repository": {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
-                  "restore_options": {
-                    "set": "20250505-153628F",
-                    "target": "123456",
-                    "type": "xid"
-                  },
-                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "source_database_name": "northwind",
-                  "source_node_name": "n1"
-                },
-                "source_node": "n1"
-              },
-              {
-                "backup_config": {
-                  "repositories": [
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
-                    }
-                  ],
-                  "schedules": [
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    },
-                    {
-                      "cron_expression": "0 6 * * ?",
-                      "id": "daily-full-backup",
-                      "type": "full"
-                    }
-                  ]
-                },
-                "cpus": "500m",
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "500M",
-                "name": "n1",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ],
-                    "image": "Quia reiciendis et odio omnis itaque cum."
+                    "image": "Et odio."
                   }
                 },
                 "patroni_port": 8888,
@@ -18469,7 +18932,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Eveniet sit dignissimos ducimus reiciendis asperiores."
+              "example": "Iure molestiae."
             },
             "description": "Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.",
             "example": [
@@ -18481,7 +18944,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Veritatis consequuntur molestiae architecto."
+              "example": "Nesciunt quia quis aut ducimus deserunt."
             },
             "description": "Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.",
             "example": [
@@ -18596,7 +19059,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Quia reiciendis et odio omnis itaque cum."
+                    "image": "Et odio."
                   }
                 },
                 "port": 0,
@@ -18676,7 +19139,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Quia reiciendis et odio omnis itaque cum."
+                    "image": "Et odio."
                   }
                 },
                 "port": 0,
@@ -18756,87 +19219,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Quia reiciendis et odio omnis itaque cum."
-                  }
-                },
-                "port": 0,
-                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "service_type": "rag",
-                "version": "latest"
-              },
-              {
-                "config": {
-                  "llm_model": "gpt-4",
-                  "llm_provider": "openai",
-                  "openai_api_key": "sk-..."
-                },
-                "connect_as": "app",
-                "cpus": "500m",
-                "database_connection": {
-                  "target_nodes": [
-                    "n1",
-                    "n2"
-                  ],
-                  "target_session_attrs": "primary"
-                },
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "512M",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ],
-                    "image": "Quia reiciendis et odio omnis itaque cum."
+                    "image": "Et odio."
                   }
                 },
                 "port": 0,
@@ -18856,6 +19239,29 @@
         "example": {
           "backup_config": {
             "repositories": [
+              {
+                "azure_account": "pgedge-backups",
+                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "azure_endpoint": "blob.core.usgovcloudapi.net",
+                "azure_key": "YXpLZXk=",
+                "base_path": "/backups",
+                "custom_options": {
+                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                  "storage-upload-chunk-size": "5MiB"
+                },
+                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "gcs_endpoint": "localhost",
+                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "retention_full": 2,
+                "retention_full_type": "count",
+                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "s3_region": "us-east-1",
+                "type": "s3"
+              },
               {
                 "azure_account": "pgedge-backups",
                 "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -19014,6 +19420,29 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
+                  },
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -19036,6 +19465,7 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "500M",
@@ -19092,7 +19522,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Quia reiciendis et odio omnis itaque cum."
+                  "image": "Et odio."
                 }
               },
               "patroni_port": 8888,
@@ -19187,6 +19617,29 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
+                  },
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -19209,6 +19662,7 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "500M",
@@ -19265,7 +19719,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Quia reiciendis et odio omnis itaque cum."
+                  "image": "Et odio."
                 }
               },
               "patroni_port": 8888,
@@ -19365,7 +19819,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Quia reiciendis et odio omnis itaque cum."
+              "image": "Et odio."
             }
           },
           "patroni_port": 8888,
@@ -19496,7 +19950,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Quia reiciendis et odio omnis itaque cum."
+                  "image": "Et odio."
                 }
               },
               "port": 0,
@@ -19576,7 +20030,167 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Quia reiciendis et odio omnis itaque cum."
+                  "image": "Et odio."
+                }
+              },
+              "port": 0,
+              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "service_type": "rag",
+              "version": "latest"
+            },
+            {
+              "config": {
+                "llm_model": "gpt-4",
+                "llm_provider": "openai",
+                "openai_api_key": "sk-..."
+              },
+              "connect_as": "app",
+              "cpus": "500m",
+              "database_connection": {
+                "target_nodes": [
+                  "n1",
+                  "n2"
+                ],
+                "target_session_attrs": "primary"
+              },
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "512M",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ],
+                  "image": "Et odio."
+                }
+              },
+              "port": 0,
+              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "service_type": "rag",
+              "version": "latest"
+            },
+            {
+              "config": {
+                "llm_model": "gpt-4",
+                "llm_provider": "openai",
+                "openai_api_key": "sk-..."
+              },
+              "connect_as": "app",
+              "cpus": "500m",
+              "database_connection": {
+                "target_nodes": [
+                  "n1",
+                  "n2"
+                ],
+                "target_session_attrs": "primary"
+              },
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "512M",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ],
+                  "image": "Et odio."
                 }
               },
               "port": 0,
@@ -19624,7 +20238,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -19637,7 +20251,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -19650,7 +20264,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -19721,29 +20335,6 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
                     }
                   ],
                   "schedules": [
@@ -19766,6 +20357,7 @@
                 },
                 "cpus": "500m",
                 "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
@@ -19823,7 +20415,182 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
+                  }
+                },
+                "patroni_port": 8888,
+                "pg_hba_conf": [
+                  "host example myapp_user 10.0.0.0/8 scram-sha-256"
+                ],
+                "pg_ident_conf": [
+                  "ssl_users  CN=alice,O=example  alice"
+                ],
+                "port": 5432,
+                "postgres_version": "17.6",
+                "postgresql_conf": {
+                  "max_connections": 1000
+                },
+                "restore_config": {
+                  "repository": {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  },
+                  "restore_options": {
+                    "set": "20250505-153628F",
+                    "target": "123456",
+                    "type": "xid"
+                  },
+                  "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "source_database_name": "northwind",
+                  "source_node_name": "n1"
+                },
+                "source_node": "n1"
+              },
+              {
+                "backup_config": {
+                  "repositories": [
+                    {
+                      "azure_account": "pgedge-backups",
+                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "azure_endpoint": "blob.core.usgovcloudapi.net",
+                      "azure_key": "YXpLZXk=",
+                      "base_path": "/backups",
+                      "custom_options": {
+                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                        "storage-upload-chunk-size": "5MiB"
+                      },
+                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "gcs_endpoint": "localhost",
+                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                      "retention_full": 2,
+                      "retention_full_type": "count",
+                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                      "s3_region": "us-east-1",
+                      "type": "s3"
+                    },
+                    {
+                      "azure_account": "pgedge-backups",
+                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "azure_endpoint": "blob.core.usgovcloudapi.net",
+                      "azure_key": "YXpLZXk=",
+                      "base_path": "/backups",
+                      "custom_options": {
+                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                        "storage-upload-chunk-size": "5MiB"
+                      },
+                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "gcs_endpoint": "localhost",
+                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                      "retention_full": 2,
+                      "retention_full_type": "count",
+                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                      "s3_region": "us-east-1",
+                      "type": "s3"
+                    }
+                  ],
+                  "schedules": [
+                    {
+                      "cron_expression": "0 6 * * ?",
+                      "id": "daily-full-backup",
+                      "type": "full"
+                    },
+                    {
+                      "cron_expression": "0 6 * * ?",
+                      "id": "daily-full-backup",
+                      "type": "full"
+                    },
+                    {
+                      "cron_expression": "0 6 * * ?",
+                      "id": "daily-full-backup",
+                      "type": "full"
+                    }
+                  ]
+                },
+                "cpus": "500m",
+                "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
+                ],
+                "memory": "500M",
+                "name": "n1",
+                "orchestrator_opts": {
+                  "swarm": {
+                    "extra_labels": {
+                      "traefik.enable": "true",
+                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                    },
+                    "extra_networks": [
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      },
+                      {
+                        "aliases": [
+                          "pg-db",
+                          "db-alias"
+                        ],
+                        "driver_opts": {
+                          "com.docker.network.endpoint.expose": "true"
+                        },
+                        "id": "traefik-public"
+                      }
+                    ],
+                    "extra_volumes": [
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      },
+                      {
+                        "destination_path": "/backups/container",
+                        "host_path": "/Users/user/backups/host"
+                      }
+                    ],
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "patroni_port": 8888,
@@ -19889,7 +20656,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Quas iste dicta assumenda."
+              "example": "Modi facere est."
             },
             "description": "Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.",
             "example": [
@@ -19901,7 +20668,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Vero dolorem aut."
+              "example": "Qui excepturi debitis aperiam rerum at."
             },
             "description": "Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.",
             "example": [
@@ -19961,7 +20728,6 @@
                 },
                 "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "512M",
@@ -20017,7 +20783,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "port": 0,
@@ -20042,7 +20808,6 @@
                 },
                 "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "512M",
@@ -20098,7 +20863,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "port": 0,
@@ -20123,7 +20888,6 @@
                 },
                 "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "512M",
@@ -20179,7 +20943,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "port": 0,
@@ -20204,7 +20968,6 @@
                 },
                 "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "512M",
@@ -20260,7 +21023,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "port": 0,
@@ -20280,29 +21043,6 @@
         "example": {
           "backup_config": {
             "repositories": [
-              {
-                "azure_account": "pgedge-backups",
-                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "azure_endpoint": "blob.core.usgovcloudapi.net",
-                "azure_key": "YXpLZXk=",
-                "base_path": "/backups",
-                "custom_options": {
-                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                  "storage-upload-chunk-size": "5MiB"
-                },
-                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "gcs_endpoint": "localhost",
-                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "retention_full": 2,
-                "retention_full_type": "count",
-                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                "s3_region": "us-east-1",
-                "type": "s3"
-              },
               {
                 "azure_account": "pgedge-backups",
                 "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -20377,7 +21117,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -20390,7 +21130,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -20403,7 +21143,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -20416,29 +21156,6 @@
             {
               "backup_config": {
                 "repositories": [
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
                   {
                     "azure_account": "pgedge-backups",
                     "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -20507,6 +21224,7 @@
               "cpus": "500m",
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "500M",
@@ -20563,7 +21281,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -20658,29 +21376,6 @@
                     "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                     "s3_region": "us-east-1",
                     "type": "s3"
-                  },
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
                   }
                 ],
                 "schedules": [
@@ -20703,6 +21398,7 @@
               },
               "cpus": "500m",
               "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
@@ -20760,7 +21456,182 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
+                }
+              },
+              "patroni_port": 8888,
+              "pg_hba_conf": [
+                "host example myapp_user 10.0.0.0/8 scram-sha-256"
+              ],
+              "pg_ident_conf": [
+                "ssl_users  CN=alice,O=example  alice"
+              ],
+              "port": 5432,
+              "postgres_version": "17.6",
+              "postgresql_conf": {
+                "max_connections": 1000
+              },
+              "restore_config": {
+                "repository": {
+                  "azure_account": "pgedge-backups",
+                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "azure_endpoint": "blob.core.usgovcloudapi.net",
+                  "azure_key": "YXpLZXk=",
+                  "base_path": "/backups",
+                  "custom_options": {
+                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
+                  },
+                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "gcs_endpoint": "localhost",
+                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                  "s3_region": "us-east-1",
+                  "type": "s3"
+                },
+                "restore_options": {
+                  "set": "20250505-153628F",
+                  "target": "123456",
+                  "type": "xid"
+                },
+                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "source_database_name": "northwind",
+                "source_node_name": "n1"
+              },
+              "source_node": "n1"
+            },
+            {
+              "backup_config": {
+                "repositories": [
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  },
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  }
+                ],
+                "schedules": [
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  },
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  },
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  }
+                ]
+              },
+              "cpus": "500m",
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "500M",
+              "name": "n1",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ],
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -20860,7 +21731,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "patroni_port": 8888,
@@ -20936,7 +21807,6 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -20992,7 +21862,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -21017,7 +21887,6 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -21073,169 +21942,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
-                }
-              },
-              "port": 0,
-              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "service_type": "rag",
-              "version": "latest"
-            },
-            {
-              "config": {
-                "llm_model": "gpt-4",
-                "llm_provider": "openai",
-                "openai_api_key": "sk-..."
-              },
-              "connect_as": "app",
-              "cpus": "500m",
-              "database_connection": {
-                "target_nodes": [
-                  "n1",
-                  "n2"
-                ],
-                "target_session_attrs": "primary"
-              },
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "512M",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
-                }
-              },
-              "port": 0,
-              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-              "service_type": "rag",
-              "version": "latest"
-            },
-            {
-              "config": {
-                "llm_model": "gpt-4",
-                "llm_provider": "openai",
-                "openai_api_key": "sk-..."
-              },
-              "connect_as": "app",
-              "cpus": "500m",
-              "database_connection": {
-                "target_nodes": [
-                  "n1",
-                  "n2"
-                ],
-                "target_session_attrs": "primary"
-              },
-              "host_ids": [
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696"
-              ],
-              "memory": "512M",
-              "orchestrator_opts": {
-                "swarm": {
-                  "extra_labels": {
-                    "traefik.enable": "true",
-                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                  },
-                  "extra_networks": [
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    },
-                    {
-                      "aliases": [
-                        "pg-db",
-                        "db-alias"
-                      ],
-                      "driver_opts": {
-                        "com.docker.network.endpoint.expose": "true"
-                      },
-                      "id": "traefik-public"
-                    }
-                  ],
-                  "extra_volumes": [
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    },
-                    {
-                      "destination_path": "/backups/container",
-                      "host_path": "/Users/user/backups/host"
-                    }
-                  ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -21283,7 +21990,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -21296,7 +22003,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -21309,7 +22016,7 @@
                   "CREATEDB",
                   "CREATEROLE"
                 ],
-                "db_owner": true,
+                "db_owner": false,
                 "password": "secret",
                 "roles": [
                   "pgedge_superuser"
@@ -21380,29 +22087,6 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
                     }
                   ],
                   "schedules": [
@@ -21425,6 +22109,7 @@
                 },
                 "cpus": "500m",
                 "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
@@ -21482,7 +22167,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "patroni_port": 8888,
@@ -21577,29 +22262,6 @@
                       "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                       "s3_region": "us-east-1",
                       "type": "s3"
-                    },
-                    {
-                      "azure_account": "pgedge-backups",
-                      "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "azure_endpoint": "blob.core.usgovcloudapi.net",
-                      "azure_key": "YXpLZXk=",
-                      "base_path": "/backups",
-                      "custom_options": {
-                        "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                        "storage-upload-chunk-size": "5MiB"
-                      },
-                      "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "gcs_endpoint": "localhost",
-                      "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                      "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                      "retention_full": 2,
-                      "retention_full_type": "count",
-                      "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                      "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                      "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                      "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                      "s3_region": "us-east-1",
-                      "type": "s3"
                     }
                   ],
                   "schedules": [
@@ -21622,6 +22284,7 @@
                 },
                 "cpus": "500m",
                 "host_ids": [
+                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
@@ -21679,7 +22342,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "patroni_port": 8888,
@@ -21745,7 +22408,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Laudantium sed delectus vel ut."
+              "example": "Possimus sit commodi in dolor unde."
             },
             "description": "Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.",
             "example": [
@@ -21757,7 +22420,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Expedita maiores cumque esse."
+              "example": "Illo ut sint cumque quia non enim."
             },
             "description": "Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.",
             "example": [
@@ -21817,7 +22480,6 @@
                 },
                 "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "512M",
@@ -21873,7 +22535,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "port": 0,
@@ -21898,7 +22560,6 @@
                 },
                 "host_ids": [
                   "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
                   "76f9b8c0-4958-11f0-a489-3bb29577c696"
                 ],
                 "memory": "512M",
@@ -21954,169 +22615,7 @@
                         "host_path": "/Users/user/backups/host"
                       }
                     ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
-                  }
-                },
-                "port": 0,
-                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "service_type": "rag",
-                "version": "latest"
-              },
-              {
-                "config": {
-                  "llm_model": "gpt-4",
-                  "llm_provider": "openai",
-                  "openai_api_key": "sk-..."
-                },
-                "connect_as": "app",
-                "cpus": "500m",
-                "database_connection": {
-                  "target_nodes": [
-                    "n1",
-                    "n2"
-                  ],
-                  "target_session_attrs": "primary"
-                },
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "512M",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
-                  }
-                },
-                "port": 0,
-                "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "service_type": "rag",
-                "version": "latest"
-              },
-              {
-                "config": {
-                  "llm_model": "gpt-4",
-                  "llm_provider": "openai",
-                  "openai_api_key": "sk-..."
-                },
-                "connect_as": "app",
-                "cpus": "500m",
-                "database_connection": {
-                  "target_nodes": [
-                    "n1",
-                    "n2"
-                  ],
-                  "target_session_attrs": "primary"
-                },
-                "host_ids": [
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                  "76f9b8c0-4958-11f0-a489-3bb29577c696"
-                ],
-                "memory": "512M",
-                "orchestrator_opts": {
-                  "swarm": {
-                    "extra_labels": {
-                      "traefik.enable": "true",
-                      "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
-                    },
-                    "extra_networks": [
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      },
-                      {
-                        "aliases": [
-                          "pg-db",
-                          "db-alias"
-                        ],
-                        "driver_opts": {
-                          "com.docker.network.endpoint.expose": "true"
-                        },
-                        "id": "traefik-public"
-                      }
-                    ],
-                    "extra_volumes": [
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      },
-                      {
-                        "destination_path": "/backups/container",
-                        "host_path": "/Users/user/backups/host"
-                      }
-                    ],
-                    "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                    "image": "Incidunt in quas totam."
                   }
                 },
                 "port": 0,
@@ -22136,29 +22635,6 @@
         "example": {
           "backup_config": {
             "repositories": [
-              {
-                "azure_account": "pgedge-backups",
-                "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "azure_endpoint": "blob.core.usgovcloudapi.net",
-                "azure_key": "YXpLZXk=",
-                "base_path": "/backups",
-                "custom_options": {
-                  "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                  "storage-upload-chunk-size": "5MiB"
-                },
-                "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "gcs_endpoint": "localhost",
-                "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "retention_full": 2,
-                "retention_full_type": "count",
-                "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                "s3_region": "us-east-1",
-                "type": "s3"
-              },
               {
                 "azure_account": "pgedge-backups",
                 "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -22233,7 +22709,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -22246,7 +22722,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -22259,7 +22735,7 @@
                 "CREATEDB",
                 "CREATEROLE"
               ],
-              "db_owner": true,
+              "db_owner": false,
               "password": "secret",
               "roles": [
                 "pgedge_superuser"
@@ -22272,29 +22748,6 @@
             {
               "backup_config": {
                 "repositories": [
-                  {
-                    "azure_account": "pgedge-backups",
-                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "azure_endpoint": "blob.core.usgovcloudapi.net",
-                    "azure_key": "YXpLZXk=",
-                    "base_path": "/backups",
-                    "custom_options": {
-                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
-                      "storage-upload-chunk-size": "5MiB"
-                    },
-                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "gcs_endpoint": "localhost",
-                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
-                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                    "retention_full": 2,
-                    "retention_full_type": "count",
-                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
-                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
-                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
-                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                    "s3_region": "us-east-1",
-                    "type": "s3"
-                  },
                   {
                     "azure_account": "pgedge-backups",
                     "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
@@ -22363,6 +22816,7 @@
               "cpus": "500m",
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "500M",
@@ -22419,7 +22873,357 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
+                }
+              },
+              "patroni_port": 8888,
+              "pg_hba_conf": [
+                "host example myapp_user 10.0.0.0/8 scram-sha-256"
+              ],
+              "pg_ident_conf": [
+                "ssl_users  CN=alice,O=example  alice"
+              ],
+              "port": 5432,
+              "postgres_version": "17.6",
+              "postgresql_conf": {
+                "max_connections": 1000
+              },
+              "restore_config": {
+                "repository": {
+                  "azure_account": "pgedge-backups",
+                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "azure_endpoint": "blob.core.usgovcloudapi.net",
+                  "azure_key": "YXpLZXk=",
+                  "base_path": "/backups",
+                  "custom_options": {
+                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
+                  },
+                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "gcs_endpoint": "localhost",
+                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                  "s3_region": "us-east-1",
+                  "type": "s3"
+                },
+                "restore_options": {
+                  "set": "20250505-153628F",
+                  "target": "123456",
+                  "type": "xid"
+                },
+                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "source_database_name": "northwind",
+                "source_node_name": "n1"
+              },
+              "source_node": "n1"
+            },
+            {
+              "backup_config": {
+                "repositories": [
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  },
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  }
+                ],
+                "schedules": [
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  },
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  },
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  }
+                ]
+              },
+              "cpus": "500m",
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "500M",
+              "name": "n1",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ],
+                  "image": "Incidunt in quas totam."
+                }
+              },
+              "patroni_port": 8888,
+              "pg_hba_conf": [
+                "host example myapp_user 10.0.0.0/8 scram-sha-256"
+              ],
+              "pg_ident_conf": [
+                "ssl_users  CN=alice,O=example  alice"
+              ],
+              "port": 5432,
+              "postgres_version": "17.6",
+              "postgresql_conf": {
+                "max_connections": 1000
+              },
+              "restore_config": {
+                "repository": {
+                  "azure_account": "pgedge-backups",
+                  "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "azure_endpoint": "blob.core.usgovcloudapi.net",
+                  "azure_key": "YXpLZXk=",
+                  "base_path": "/backups",
+                  "custom_options": {
+                    "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab"
+                  },
+                  "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "gcs_endpoint": "localhost",
+                  "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                  "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                  "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                  "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                  "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                  "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                  "s3_region": "us-east-1",
+                  "type": "s3"
+                },
+                "restore_options": {
+                  "set": "20250505-153628F",
+                  "target": "123456",
+                  "type": "xid"
+                },
+                "source_database_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "source_database_name": "northwind",
+                "source_node_name": "n1"
+              },
+              "source_node": "n1"
+            },
+            {
+              "backup_config": {
+                "repositories": [
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  },
+                  {
+                    "azure_account": "pgedge-backups",
+                    "azure_container": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "azure_endpoint": "blob.core.usgovcloudapi.net",
+                    "azure_key": "YXpLZXk=",
+                    "base_path": "/backups",
+                    "custom_options": {
+                      "s3-kms-key-id": "1234abcd-12ab-34cd-56ef-1234567890ab",
+                      "storage-upload-chunk-size": "5MiB"
+                    },
+                    "gcs_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "gcs_endpoint": "localhost",
+                    "gcs_key": "ZXhhbXBsZSBnY3Mga2V5Cg==",
+                    "id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                    "retention_full": 2,
+                    "retention_full_type": "count",
+                    "s3_bucket": "pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1",
+                    "s3_endpoint": "s3.us-east-1.amazonaws.com",
+                    "s3_key": "AKIAIOSFODNN7EXAMPLE",
+                    "s3_key_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                    "s3_region": "us-east-1",
+                    "type": "s3"
+                  }
+                ],
+                "schedules": [
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  },
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  },
+                  {
+                    "cron_expression": "0 6 * * ?",
+                    "id": "daily-full-backup",
+                    "type": "full"
+                  }
+                ]
+              },
+              "cpus": "500m",
+              "host_ids": [
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "500M",
+              "name": "n1",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ],
+                  "image": "Incidunt in quas totam."
                 }
               },
               "patroni_port": 8888,
@@ -22519,7 +23323,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "patroni_port": 8888,
@@ -22595,7 +23399,6 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
-                "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
               "memory": "512M",
@@ -22651,7 +23454,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -22676,6 +23479,85 @@
               },
               "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
+                "76f9b8c0-4958-11f0-a489-3bb29577c696"
+              ],
+              "memory": "512M",
+              "orchestrator_opts": {
+                "swarm": {
+                  "extra_labels": {
+                    "traefik.enable": "true",
+                    "traefik.tcp.routers.mydb.rule": "HostSNI(`mydb.example.com`)"
+                  },
+                  "extra_networks": [
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    },
+                    {
+                      "aliases": [
+                        "pg-db",
+                        "db-alias"
+                      ],
+                      "driver_opts": {
+                        "com.docker.network.endpoint.expose": "true"
+                      },
+                      "id": "traefik-public"
+                    }
+                  ],
+                  "extra_volumes": [
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    },
+                    {
+                      "destination_path": "/backups/container",
+                      "host_path": "/Users/user/backups/host"
+                    }
+                  ],
+                  "image": "Incidunt in quas totam."
+                }
+              },
+              "port": 0,
+              "service_id": "76f9b8c0-4958-11f0-a489-3bb29577c696",
+              "service_type": "rag",
+              "version": "latest"
+            },
+            {
+              "config": {
+                "llm_model": "gpt-4",
+                "llm_provider": "openai",
+                "openai_api_key": "sk-..."
+              },
+              "connect_as": "app",
+              "cpus": "500m",
+              "database_connection": {
+                "target_nodes": [
+                  "n1",
+                  "n2"
+                ],
+                "target_session_attrs": "primary"
+              },
+              "host_ids": [
                 "76f9b8c0-4958-11f0-a489-3bb29577c696",
                 "76f9b8c0-4958-11f0-a489-3bb29577c696"
               ],
@@ -22732,7 +23614,7 @@
                       "host_path": "/Users/user/backups/host"
                     }
                   ],
-                  "image": "Dignissimos incidunt in quas totam eveniet possimus."
+                  "image": "Incidunt in quas totam."
                 }
               },
               "port": 0,
@@ -22751,6 +23633,30 @@
       "DatabaseSummary": {
         "type": "object",
         "properties": {
+          "available_upgrades": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvailableUpgrade"
+            },
+            "description": "Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.",
+            "example": [
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              },
+              {
+                "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                "postgres_version": "17.10",
+                "spock_version": "5"
+              }
+            ]
+          },
           "created_at": {
             "type": "string",
             "description": "The time that the database was created.",
@@ -22894,6 +23800,23 @@
           }
         },
         "example": {
+          "available_upgrades": [
+            {
+              "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+              "postgres_version": "17.10",
+              "spock_version": "5"
+            },
+            {
+              "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+              "postgres_version": "17.10",
+              "spock_version": "5"
+            },
+            {
+              "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+              "postgres_version": "17.10",
+              "spock_version": "5"
+            }
+          ],
           "created_at": "2025-01-01T01:30:00Z",
           "id": "02f1a7db-fca8-4521-b57a-2a375c1ced51",
           "instances": [
@@ -23078,7 +24001,7 @@
               "updated_at": "1996-05-27T17:04:41Z"
             }
           ],
-          "state": "restoring",
+          "state": "available",
           "tenant_id": "8210ec10-2dca-406c-ac4a-0661d2189954",
           "updated_at": "2025-01-01T02:30:00Z"
         },
@@ -23344,12 +24267,12 @@
             "type": "boolean",
             "description": "If true, skip the health validations that prevent running failover on a healthy cluster.",
             "default": false,
-            "example": false
+            "example": true
           }
         },
         "example": {
           "candidate_instance_id": "68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi",
-          "skip_validation": true
+          "skip_validation": false
         }
       },
       "FailoverDatabaseNodeResponse": {
@@ -24012,16 +24935,6 @@
                 "status": "completed",
                 "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
                 "type": "create"
-              },
-              {
-                "completed_at": "2025-06-18T16:52:35Z",
-                "created_at": "2025-06-18T16:52:05Z",
-                "database_id": "storefront",
-                "entity_id": "storefront",
-                "scope": "database",
-                "status": "completed",
-                "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
-                "type": "create"
               }
             ]
           }
@@ -24086,6 +24999,28 @@
             "description": "The databases managed by this cluster.",
             "example": [
               {
+                "available_upgrades": [
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  },
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  },
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  },
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  }
+                ],
                 "created_at": "2025-01-01T01:30:00Z",
                 "id": "02f1a7db-fca8-4521-b57a-2a375c1ced51",
                 "instances": [
@@ -24178,58 +25113,35 @@
                     "state": "modifying",
                     "status_updated_at": "1976-03-01T20:13:25Z",
                     "updated_at": "1996-05-27T17:04:41Z"
-                  },
-                  {
-                    "connection_info": {
-                      "addresses": [
-                        "10.24.34.2",
-                        "i-0123456789abcdef.ec2.internal"
-                      ],
-                      "port": 5432
-                    },
-                    "created_at": "1984-01-30T10:40:13Z",
-                    "error": "failed to get patroni status: connection refused",
-                    "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-                    "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-                    "node_name": "n1",
-                    "postgres": {
-                      "patroni_paused": true,
-                      "patroni_state": "unknown",
-                      "pending_restart": true,
-                      "role": "primary",
-                      "version": "18.1"
-                    },
-                    "spock": {
-                      "read_only": "off",
-                      "subscriptions": [
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        }
-                      ],
-                      "version": "4.10.0"
-                    },
-                    "state": "modifying",
-                    "status_updated_at": "1976-03-01T20:13:25Z",
-                    "updated_at": "1996-05-27T17:04:41Z"
                   }
                 ],
-                "state": "modifying",
+                "state": "backing_up",
                 "tenant_id": "8210ec10-2dca-406c-ac4a-0661d2189954",
                 "updated_at": "2025-01-01T02:30:00Z"
               },
               {
+                "available_upgrades": [
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  },
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  },
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  },
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  }
+                ],
                 "created_at": "2025-01-01T01:30:00Z",
                 "id": "02f1a7db-fca8-4521-b57a-2a375c1ced51",
                 "instances": [
@@ -24322,58 +25234,35 @@
                     "state": "modifying",
                     "status_updated_at": "1976-03-01T20:13:25Z",
                     "updated_at": "1996-05-27T17:04:41Z"
-                  },
-                  {
-                    "connection_info": {
-                      "addresses": [
-                        "10.24.34.2",
-                        "i-0123456789abcdef.ec2.internal"
-                      ],
-                      "port": 5432
-                    },
-                    "created_at": "1984-01-30T10:40:13Z",
-                    "error": "failed to get patroni status: connection refused",
-                    "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-                    "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-                    "node_name": "n1",
-                    "postgres": {
-                      "patroni_paused": true,
-                      "patroni_state": "unknown",
-                      "pending_restart": true,
-                      "role": "primary",
-                      "version": "18.1"
-                    },
-                    "spock": {
-                      "read_only": "off",
-                      "subscriptions": [
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        }
-                      ],
-                      "version": "4.10.0"
-                    },
-                    "state": "modifying",
-                    "status_updated_at": "1976-03-01T20:13:25Z",
-                    "updated_at": "1996-05-27T17:04:41Z"
                   }
                 ],
-                "state": "modifying",
+                "state": "backing_up",
                 "tenant_id": "8210ec10-2dca-406c-ac4a-0661d2189954",
                 "updated_at": "2025-01-01T02:30:00Z"
               },
               {
+                "available_upgrades": [
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  },
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  },
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  },
+                  {
+                    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
+                    "postgres_version": "17.10",
+                    "spock_version": "5"
+                  }
+                ],
                 "created_at": "2025-01-01T01:30:00Z",
                 "id": "02f1a7db-fca8-4521-b57a-2a375c1ced51",
                 "instances": [
@@ -24466,198 +25355,9 @@
                     "state": "modifying",
                     "status_updated_at": "1976-03-01T20:13:25Z",
                     "updated_at": "1996-05-27T17:04:41Z"
-                  },
-                  {
-                    "connection_info": {
-                      "addresses": [
-                        "10.24.34.2",
-                        "i-0123456789abcdef.ec2.internal"
-                      ],
-                      "port": 5432
-                    },
-                    "created_at": "1984-01-30T10:40:13Z",
-                    "error": "failed to get patroni status: connection refused",
-                    "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-                    "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-                    "node_name": "n1",
-                    "postgres": {
-                      "patroni_paused": true,
-                      "patroni_state": "unknown",
-                      "pending_restart": true,
-                      "role": "primary",
-                      "version": "18.1"
-                    },
-                    "spock": {
-                      "read_only": "off",
-                      "subscriptions": [
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        }
-                      ],
-                      "version": "4.10.0"
-                    },
-                    "state": "modifying",
-                    "status_updated_at": "1976-03-01T20:13:25Z",
-                    "updated_at": "1996-05-27T17:04:41Z"
                   }
                 ],
-                "state": "modifying",
-                "tenant_id": "8210ec10-2dca-406c-ac4a-0661d2189954",
-                "updated_at": "2025-01-01T02:30:00Z"
-              },
-              {
-                "created_at": "2025-01-01T01:30:00Z",
-                "id": "02f1a7db-fca8-4521-b57a-2a375c1ced51",
-                "instances": [
-                  {
-                    "connection_info": {
-                      "addresses": [
-                        "10.24.34.2",
-                        "i-0123456789abcdef.ec2.internal"
-                      ],
-                      "port": 5432
-                    },
-                    "created_at": "1984-01-30T10:40:13Z",
-                    "error": "failed to get patroni status: connection refused",
-                    "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-                    "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-                    "node_name": "n1",
-                    "postgres": {
-                      "patroni_paused": true,
-                      "patroni_state": "unknown",
-                      "pending_restart": true,
-                      "role": "primary",
-                      "version": "18.1"
-                    },
-                    "spock": {
-                      "read_only": "off",
-                      "subscriptions": [
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        }
-                      ],
-                      "version": "4.10.0"
-                    },
-                    "state": "modifying",
-                    "status_updated_at": "1976-03-01T20:13:25Z",
-                    "updated_at": "1996-05-27T17:04:41Z"
-                  },
-                  {
-                    "connection_info": {
-                      "addresses": [
-                        "10.24.34.2",
-                        "i-0123456789abcdef.ec2.internal"
-                      ],
-                      "port": 5432
-                    },
-                    "created_at": "1984-01-30T10:40:13Z",
-                    "error": "failed to get patroni status: connection refused",
-                    "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-                    "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-                    "node_name": "n1",
-                    "postgres": {
-                      "patroni_paused": true,
-                      "patroni_state": "unknown",
-                      "pending_restart": true,
-                      "role": "primary",
-                      "version": "18.1"
-                    },
-                    "spock": {
-                      "read_only": "off",
-                      "subscriptions": [
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        }
-                      ],
-                      "version": "4.10.0"
-                    },
-                    "state": "modifying",
-                    "status_updated_at": "1976-03-01T20:13:25Z",
-                    "updated_at": "1996-05-27T17:04:41Z"
-                  },
-                  {
-                    "connection_info": {
-                      "addresses": [
-                        "10.24.34.2",
-                        "i-0123456789abcdef.ec2.internal"
-                      ],
-                      "port": 5432
-                    },
-                    "created_at": "1984-01-30T10:40:13Z",
-                    "error": "failed to get patroni status: connection refused",
-                    "host_id": "de3b1388-1f0c-42f1-a86c-59ab72f255ec",
-                    "id": "a67cbb36-c3c3-49c9-8aac-f4a0438a883d",
-                    "node_name": "n1",
-                    "postgres": {
-                      "patroni_paused": true,
-                      "patroni_state": "unknown",
-                      "pending_restart": true,
-                      "role": "primary",
-                      "version": "18.1"
-                    },
-                    "spock": {
-                      "read_only": "off",
-                      "subscriptions": [
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        },
-                        {
-                          "name": "sub_n1n2",
-                          "provider_node": "n2",
-                          "status": "down"
-                        }
-                      ],
-                      "version": "4.10.0"
-                    },
-                    "state": "modifying",
-                    "status_updated_at": "1976-03-01T20:13:25Z",
-                    "updated_at": "1996-05-27T17:04:41Z"
-                  }
-                ],
-                "state": "modifying",
+                "state": "backing_up",
                 "tenant_id": "8210ec10-2dca-406c-ac4a-0661d2189954",
                 "updated_at": "2025-01-01T02:30:00Z"
               }
@@ -25514,6 +26214,16 @@
                 "status": "completed",
                 "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
                 "type": "create"
+              },
+              {
+                "completed_at": "2025-06-18T16:52:35Z",
+                "created_at": "2025-06-18T16:52:05Z",
+                "database_id": "storefront",
+                "entity_id": "storefront",
+                "scope": "database",
+                "status": "completed",
+                "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
+                "type": "create"
               }
             ]
           }
@@ -25957,16 +26667,6 @@
             },
             "description": "The tasks that will restore each database node.",
             "example": [
-              {
-                "completed_at": "2025-06-18T16:52:35Z",
-                "created_at": "2025-06-18T16:52:05Z",
-                "database_id": "storefront",
-                "entity_id": "storefront",
-                "scope": "database",
-                "status": "completed",
-                "task_id": "019783f4-75f4-71e7-85a3-c9b96b345d77",
-                "type": "create"
-              },
               {
                 "completed_at": "2025-06-18T16:52:35Z",
                 "created_at": "2025-06-18T16:52:05Z",
@@ -26470,7 +27170,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "Quis in sunt dignissimos occaecati cupiditate."
+              "example": "Dignissimos occaecati cupiditate."
             },
             "description": "The addresses of the host that's running this service instance.",
             "example": [
@@ -26831,6 +27531,7 @@
           },
           "host_ids": [
             "76f9b8c0-4958-11f0-a489-3bb29577c696",
+            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "512M",
@@ -26886,7 +27587,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Necessitatibus excepturi reprehenderit."
+              "image": "Reprehenderit atque aliquid."
             }
           },
           "port": 0,
@@ -26939,7 +27640,6 @@
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
             "minItems": 1
@@ -27057,7 +27757,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "port": 0,
@@ -27228,7 +27928,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "port": 0,
@@ -27281,7 +27981,6 @@
             },
             "description": "The IDs of the hosts that should run this service. One service instance will be created per host.",
             "example": [
-              "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696",
               "76f9b8c0-4958-11f0-a489-3bb29577c696"
             ],
@@ -27345,7 +28044,6 @@
           },
           "host_ids": [
             "76f9b8c0-4958-11f0-a489-3bb29577c696",
-            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "512M",
@@ -27401,7 +28099,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Quia reiciendis et odio omnis itaque cum."
+              "image": "Et odio."
             }
           },
           "port": 0,
@@ -27516,6 +28214,8 @@
             "target_session_attrs": "primary"
           },
           "host_ids": [
+            "76f9b8c0-4958-11f0-a489-3bb29577c696",
+            "76f9b8c0-4958-11f0-a489-3bb29577c696",
             "76f9b8c0-4958-11f0-a489-3bb29577c696"
           ],
           "memory": "512M",
@@ -27571,7 +28271,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "port": 0,
@@ -27740,7 +28440,7 @@
                   "host_path": "/Users/user/backups/host"
                 }
               ],
-              "image": "Dignissimos incidunt in quas totam eveniet possimus."
+              "image": "Incidunt in quas totam."
             }
           },
           "port": 0,

--- a/api/apiv1/gen/http/openapi3.yaml
+++ b/api/apiv1/gen/http/openapi3.yaml
@@ -336,6 +336,21 @@ paths:
       summary: List databases
       description: Lists all databases in the cluster.
       operationId: list-databases
+      parameters:
+        - name: include
+          in: query
+          description: 'Optional fields to include in each database response. Supported values: available_upgrades.'
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+              example: Esse id natus aut omnis minus.
+            description: 'Optional fields to include in each database response. Supported values: available_upgrades.'
+            example:
+              - available_upgrades
+          example:
+            - available_upgrades
       responses:
         "200":
           description: OK response.
@@ -949,6 +964,20 @@ paths:
       description: Returns information about a particular database in the cluster.
       operationId: get-database
       parameters:
+        - name: include
+          in: query
+          description: 'Optional fields to include in the response. Supported values: available_upgrades.'
+          allowEmptyValue: true
+          schema:
+            type: array
+            items:
+              type: string
+              example: Totam et et architecto voluptatem.
+            description: 'Optional fields to include in the response. Supported values: available_upgrades.'
+            example:
+              - available_upgrades
+          example:
+            - available_upgrades
         - name: database_id
           in: path
           description: ID of the database to get.
@@ -1142,18 +1171,15 @@ paths:
             type: array
             items:
               type: string
-              example: Possimus sit commodi in dolor unde.
+              example: Fuga qui id libero dignissimos.
             description: Host IDs to treat as removed during this update. Events targeting these hosts will be skipped.
             example:
-              - Ut sint cumque quia non enim.
-              - Doloremque nam.
-              - Sed esse id natus aut.
-              - Minus sint totam et et.
+              - Numquam perspiciatis et exercitationem sequi saepe velit.
+              - Ex sint dolorum vel.
+              - Laboriosam aut dolorum est.
           example:
-            - Quia fuga qui id libero dignissimos voluptates.
-            - Numquam perspiciatis et exercitationem sequi saepe velit.
-            - Ex sint dolorum vel.
-            - Laboriosam aut dolorum est.
+            - Mollitia illo delectus.
+            - Aut ducimus aut aut veritatis ut.
         - name: database_id
           in: path
           description: ID of the database to update.
@@ -3713,6 +3739,30 @@ components:
       required:
         - name
         - message
+    AvailableUpgrade:
+      type: object
+      properties:
+        image:
+          type: string
+          description: Full container image reference for the upgrade candidate.
+          example: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+        postgres_version:
+          type: string
+          description: Postgres version of the upgrade candidate.
+          example: "17.10"
+        spock_version:
+          type: string
+          description: Spock major version of the upgrade candidate.
+          example: "5"
+      description: A newer stable image available for the database in the same Postgres major / Spock major bucket.
+      example:
+        image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+        postgres_version: "17.10"
+        spock_version: "5"
+      required:
+        - postgres_version
+        - spock_version
+        - image
     BackupConfigSpec:
       type: object
       properties:
@@ -4611,6 +4661,18 @@ components:
     Database:
       type: object
       properties:
+        available_upgrades:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailableUpgrade'
+          description: Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.
+          example:
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
         created_at:
           type: string
           description: The time that the database was created.
@@ -4957,6 +5019,18 @@ components:
     Database2:
       type: object
       properties:
+        available_upgrades:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailableUpgrade'
+          description: Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.
+          example:
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
         created_at:
           type: string
           description: The time that the database was created.
@@ -4974,38 +5048,6 @@ components:
             $ref: '#/components/schemas/Instance'
           description: All of the instances in the database.
           example:
-            - connection_info:
-                addresses:
-                  - 10.24.34.2
-                  - i-0123456789abcdef.ec2.internal
-                port: 5432
-              created_at: "2011-03-15T17:48:48Z"
-              error: 'failed to get patroni status: connection refused'
-              host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-              id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-              node_name: n1
-              postgres:
-                patroni_paused: false
-                patroni_state: unknown
-                pending_restart: true
-                role: primary
-                version: "18.1"
-              spock:
-                read_only: "off"
-                subscriptions:
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
-                version: 4.10.0
-              state: available
-              status_updated_at: "1993-04-25T23:06:28Z"
-              updated_at: "1981-08-22T23:20:01Z"
             - connection_info:
                 addresses:
                   - 10.24.34.2
@@ -5104,6 +5146,33 @@ components:
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
+                service_ready: true
+              updated_at: "2025-01-28T10:05:00Z"
+            - created_at: "2025-01-28T10:00:00Z"
+              database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              error: 'failed to start container: image not found'
+              host_id: host-1
+              service_id: mcp-server
+              service_instance_id: mcp-server-host-1
+              state: running
+              status:
+                addresses:
+                  - 10.24.34.2
+                  - i-0123456789abcdef.ec2.internal
+                container_id: a1b2c3d4e5f6
+                health_check:
+                  checked_at: "2025-01-28T10:00:00Z"
+                  message: Connection refused
+                  status: healthy
+                image_version: 1.0.0
+                last_health_at: "2025-01-28T10:00:00Z"
+                ports:
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
@@ -5137,9 +5206,6 @@ components:
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
                 service_ready: true
               updated_at: "2025-01-28T10:05:00Z"
         spec:
@@ -5147,7 +5213,7 @@ components:
         state:
           type: string
           description: Current state of the database.
-          example: creating
+          example: degraded
           enum:
             - creating
             - modifying
@@ -5281,6 +5347,24 @@ components:
     Database3:
       type: object
       properties:
+        available_upgrades:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailableUpgrade'
+          description: Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.
+          example:
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
         created_at:
           type: string
           description: The time that the database was created.
@@ -5298,6 +5382,38 @@ components:
             $ref: '#/components/schemas/Instance'
           description: All of the instances in the database.
           example:
+            - connection_info:
+                addresses:
+                  - 10.24.34.2
+                  - i-0123456789abcdef.ec2.internal
+                port: 5432
+              created_at: "2011-03-15T17:48:48Z"
+              error: 'failed to get patroni status: connection refused'
+              host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+              id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
+              node_name: n1
+              postgres:
+                patroni_paused: false
+                patroni_state: unknown
+                pending_restart: true
+                role: primary
+                version: "18.1"
+              spock:
+                read_only: "off"
+                subscriptions:
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                version: 4.10.0
+              state: available
+              status_updated_at: "1993-04-25T23:06:28Z"
+              updated_at: "1981-08-22T23:20:01Z"
             - connection_info:
                 addresses:
                   - 10.24.34.2
@@ -5396,6 +5512,33 @@ components:
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
+                service_ready: true
+              updated_at: "2025-01-28T10:05:00Z"
+            - created_at: "2025-01-28T10:00:00Z"
+              database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              error: 'failed to start container: image not found'
+              host_id: host-1
+              service_id: mcp-server
+              service_instance_id: mcp-server-host-1
+              state: running
+              status:
+                addresses:
+                  - 10.24.34.2
+                  - i-0123456789abcdef.ec2.internal
+                container_id: a1b2c3d4e5f6
+                health_check:
+                  checked_at: "2025-01-28T10:00:00Z"
+                  message: Connection refused
+                  status: healthy
+                image_version: 1.0.0
+                last_health_at: "2025-01-28T10:00:00Z"
+                ports:
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
+                  - container_port: 8080
+                    host_port: 8080
+                    name: web-client
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
@@ -5429,9 +5572,6 @@ components:
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
                 service_ready: true
               updated_at: "2025-01-28T10:05:00Z"
             - created_at: "2025-01-28T10:00:00Z"
@@ -5453,9 +5593,6 @@ components:
                 image_version: 1.0.0
                 last_health_at: "2025-01-28T10:00:00Z"
                 ports:
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
@@ -5472,7 +5609,7 @@ components:
         state:
           type: string
           description: Current state of the database.
-          example: deleting
+          example: unknown
           enum:
             - creating
             - modifying
@@ -5606,6 +5743,24 @@ components:
     Database4:
       type: object
       properties:
+        available_upgrades:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailableUpgrade'
+          description: Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.
+          example:
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
         created_at:
           type: string
           description: The time that the database was created.
@@ -5623,38 +5778,6 @@ components:
             $ref: '#/components/schemas/Instance'
           description: All of the instances in the database.
           example:
-            - connection_info:
-                addresses:
-                  - 10.24.34.2
-                  - i-0123456789abcdef.ec2.internal
-                port: 5432
-              created_at: "2011-03-15T17:48:48Z"
-              error: 'failed to get patroni status: connection refused'
-              host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-              id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-              node_name: n1
-              postgres:
-                patroni_paused: false
-                patroni_state: unknown
-                pending_restart: true
-                role: primary
-                version: "18.1"
-              spock:
-                read_only: "off"
-                subscriptions:
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
-                  - name: sub_n1n2
-                    provider_node: n2
-                    status: down
-                version: 4.10.0
-              state: available
-              status_updated_at: "1993-04-25T23:06:28Z"
-              updated_at: "1981-08-22T23:20:01Z"
             - connection_info:
                 addresses:
                   - 10.24.34.2
@@ -5753,9 +5876,6 @@ components:
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
                 service_ready: true
               updated_at: "2025-01-28T10:05:00Z"
             - created_at: "2025-01-28T10:00:00Z"
@@ -5777,9 +5897,6 @@ components:
                 image_version: 1.0.0
                 last_health_at: "2025-01-28T10:00:00Z"
                 ports:
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
@@ -5930,6 +6047,18 @@ components:
     Database5:
       type: object
       properties:
+        available_upgrades:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailableUpgrade'
+          description: Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.
+          example:
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
         created_at:
           type: string
           description: The time that the database was created.
@@ -5947,6 +6076,38 @@ components:
             $ref: '#/components/schemas/Instance'
           description: All of the instances in the database.
           example:
+            - connection_info:
+                addresses:
+                  - 10.24.34.2
+                  - i-0123456789abcdef.ec2.internal
+                port: 5432
+              created_at: "2011-03-15T17:48:48Z"
+              error: 'failed to get patroni status: connection refused'
+              host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
+              id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
+              node_name: n1
+              postgres:
+                patroni_paused: false
+                patroni_state: unknown
+                pending_restart: true
+                role: primary
+                version: "18.1"
+              spock:
+                read_only: "off"
+                subscriptions:
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                  - name: sub_n1n2
+                    provider_node: n2
+                    status: down
+                version: 4.10.0
+              state: available
+              status_updated_at: "1993-04-25T23:06:28Z"
+              updated_at: "1981-08-22T23:20:01Z"
             - connection_info:
                 addresses:
                   - 10.24.34.2
@@ -6077,9 +6238,6 @@ components:
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
                 service_ready: true
               updated_at: "2025-01-28T10:05:00Z"
             - created_at: "2025-01-28T10:00:00Z"
@@ -6110,9 +6268,6 @@ components:
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
                 service_ready: true
               updated_at: "2025-01-28T10:05:00Z"
             - created_at: "2025-01-28T10:00:00Z"
@@ -6134,9 +6289,6 @@ components:
                 image_version: 1.0.0
                 last_health_at: "2025-01-28T10:00:00Z"
                 ports:
-                  - container_port: 8080
-                    host_port: 8080
-                    name: web-client
                   - container_port: 8080
                     host_port: 8080
                     name: web-client
@@ -6153,7 +6305,7 @@ components:
         state:
           type: string
           description: Current state of the database.
-          example: deleting
+          example: restoring
           enum:
             - creating
             - modifying
@@ -6570,7 +6722,7 @@ components:
           type: array
           items:
             type: string
-            example: Excepturi sapiente neque doloribus consequatur voluptatibus.
+            example: Sapiente neque doloribus consequatur voluptatibus sed.
           description: Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.
           example:
             - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -6578,7 +6730,7 @@ components:
           type: array
           items:
             type: string
-            example: Et nisi nihil corporis.
+            example: Nisi nihil corporis perspiciatis et.
           description: Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -6649,6 +6801,26 @@ components:
               s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
               s3_region: us-east-1
               type: s3
+            - azure_account: pgedge-backups
+              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              azure_endpoint: blob.core.usgovcloudapi.net
+              azure_key: YXpLZXk=
+              base_path: /backups
+              custom_options:
+                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                storage-upload-chunk-size: 5MiB
+              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              gcs_endpoint: localhost
+              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              retention_full: 2
+              retention_full_type: count
+              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              s3_endpoint: s3.us-east-1.amazonaws.com
+              s3_key: AKIAIOSFODNN7EXAMPLE
+              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              s3_region: us-east-1
+              type: s3
           schedules:
             - cron_expression: 0 6 * * ?
               id: daily-full-backup
@@ -6661,6 +6833,7 @@ components:
               type: full
         cpus: 500m
         host_ids:
+          - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 500M
         name: n1
@@ -6695,7 +6868,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Necessitatibus excepturi reprehenderit.
+            image: Reprehenderit atque aliquid.
         patroni_port: 8888
         pg_hba_conf:
           - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -6755,7 +6928,6 @@ components:
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
           type: string
@@ -6780,7 +6952,7 @@ components:
           type: array
           items:
             type: string
-            example: Velit distinctio sed amet.
+            example: Distinctio sed amet rem voluptas qui.
           description: Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.
           example:
             - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -6788,7 +6960,7 @@ components:
           type: array
           items:
             type: string
-            example: Voluptas qui.
+            example: Voluptatem nesciunt dignissimos voluptas vel earum.
           description: Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -6819,26 +6991,6 @@ components:
       example:
         backup_config:
           repositories:
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
             - azure_account: pgedge-backups
               azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
               azure_endpoint: blob.core.usgovcloudapi.net
@@ -6927,7 +7079,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         patroni_port: 8888
         pg_hba_conf:
           - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -6988,6 +7140,7 @@ components:
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
           type: string
@@ -7012,7 +7165,7 @@ components:
           type: array
           items:
             type: string
-            example: Numquam incidunt eaque totam at culpa ut.
+            example: Harum iste dignissimos.
           description: Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.
           example:
             - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -7020,7 +7173,7 @@ components:
           type: array
           items:
             type: string
-            example: Iste dignissimos exercitationem.
+            example: Beatae nobis quam sequi quasi aliquid.
           description: Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -7091,26 +7244,6 @@ components:
               s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
               s3_region: us-east-1
               type: s3
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
           schedules:
             - cron_expression: 0 6 * * ?
               id: daily-full-backup
@@ -7123,8 +7256,6 @@ components:
               type: full
         cpus: 500m
         host_ids:
-          - 76f9b8c0-4958-11f0-a489-3bb29577c696
-          - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 500M
         name: n1
@@ -7159,7 +7290,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         patroni_port: 8888
         pg_hba_conf:
           - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -7220,6 +7351,7 @@ components:
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
           type: string
@@ -7244,7 +7376,7 @@ components:
           type: array
           items:
             type: string
-            example: Consequuntur et.
+            example: Dolor sit quae et tempore et aut.
           description: Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.
           example:
             - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -7252,7 +7384,7 @@ components:
           type: array
           items:
             type: string
-            example: Et nulla omnis nobis dolor sit.
+            example: Nisi eveniet sit dignissimos ducimus.
           description: Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -7283,6 +7415,26 @@ components:
       example:
         backup_config:
           repositories:
+            - azure_account: pgedge-backups
+              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              azure_endpoint: blob.core.usgovcloudapi.net
+              azure_key: YXpLZXk=
+              base_path: /backups
+              custom_options:
+                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                storage-upload-chunk-size: 5MiB
+              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              gcs_endpoint: localhost
+              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              retention_full: 2
+              retention_full_type: count
+              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              s3_endpoint: s3.us-east-1.amazonaws.com
+              s3_key: AKIAIOSFODNN7EXAMPLE
+              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              s3_region: us-east-1
+              type: s3
             - azure_account: pgedge-backups
               azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
               azure_endpoint: blob.core.usgovcloudapi.net
@@ -7369,7 +7521,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Quia reiciendis et odio omnis itaque cum.
+            image: Et odio.
         patroni_port: 8888
         pg_hba_conf:
           - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -7429,6 +7581,7 @@ components:
           description: The IDs of the hosts that should run this node. When multiple hosts are specified, one host will chosen as a primary, and the others will be read replicas.
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
           type: string
@@ -7453,7 +7606,7 @@ components:
           type: array
           items:
             type: string
-            example: Deserunt quis.
+            example: Laudantium molestiae error quas iste.
           description: Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.
           example:
             - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -7461,7 +7614,7 @@ components:
           type: array
           items:
             type: string
-            example: Officiis libero.
+            example: Assumenda et.
           description: Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -7492,26 +7645,6 @@ components:
       example:
         backup_config:
           repositories:
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
             - azure_account: pgedge-backups
               azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
               azure_endpoint: blob.core.usgovcloudapi.net
@@ -7598,7 +7731,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         patroni_port: 8888
         pg_hba_conf:
           - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -7659,7 +7792,6 @@ components:
           example:
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
           type: string
@@ -7684,7 +7816,7 @@ components:
           type: array
           items:
             type: string
-            example: Aperiam rerum at eveniet consectetur facilis autem.
+            example: Praesentium possimus id laudantium sed delectus.
           description: Additional pg_hba.conf entries for this particular node, one rule per array element. Prepended to the database-level pg_hba_conf entries, so node entries take first-match priority. Entries are inserted between control-plane's system-user rules and its catch-all, and cannot affect control-plane-internal connectivity.
           example:
             - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -7692,7 +7824,7 @@ components:
           type: array
           items:
             type: string
-            example: Voluptatem velit dolorem.
+            example: Ut distinctio expedita.
           description: Additional pg_ident.conf entries for this particular node, one mapping per array element. Prepended to the database-level pg_ident_conf entries.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -7723,26 +7855,6 @@ components:
       example:
         backup_config:
           repositories:
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
             - azure_account: pgedge-backups
               azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
               azure_endpoint: blob.core.usgovcloudapi.net
@@ -7831,7 +7943,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         patroni_port: 8888
         pg_hba_conf:
           - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -9134,6 +9246,26 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
+                  - azure_account: pgedge-backups
+                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    azure_endpoint: blob.core.usgovcloudapi.net
+                    azure_key: YXpLZXk=
+                    base_path: /backups
+                    custom_options:
+                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                      storage-upload-chunk-size: 5MiB
+                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    gcs_endpoint: localhost
+                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                    retention_full: 2
+                    retention_full_type: count
+                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    s3_endpoint: s3.us-east-1.amazonaws.com
+                    s3_key: AKIAIOSFODNN7EXAMPLE
+                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                    s3_region: us-east-1
+                    type: s3
                 schedules:
                   - cron_expression: 0 6 * * ?
                     id: daily-full-backup
@@ -9146,6 +9278,8 @@ components:
                     type: full
               cpus: 500m
               host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 500M
               name: n1
@@ -9180,132 +9314,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Necessitatibus excepturi reprehenderit.
-              patroni_port: 8888
-              pg_hba_conf:
-                - host example myapp_user 10.0.0.0/8 scram-sha-256
-              pg_ident_conf:
-                - ssl_users  CN=alice,O=example  alice
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                  image: Necessitatibus excepturi reprehenderit.
+                  image: Reprehenderit atque aliquid.
               patroni_port: 8888
               pg_hba_conf:
                 - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -9357,7 +9366,7 @@ components:
           type: array
           items:
             type: string
-            example: Fuga occaecati optio accusantium eos voluptatibus sunt.
+            example: Optio accusantium.
           description: Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.
           example:
             - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -9366,7 +9375,7 @@ components:
           type: array
           items:
             type: string
-            example: Sapiente doloribus.
+            example: Voluptatibus sunt deserunt sapiente doloribus est.
           description: Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -9412,7 +9421,6 @@ components:
                 target_session_attrs: primary
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
                 swarm:
@@ -9445,7 +9453,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Necessitatibus excepturi reprehenderit.
+                  image: Reprehenderit atque aliquid.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -9463,6 +9471,55 @@ components:
                 target_session_attrs: primary
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              memory: 512M
+              orchestrator_opts:
+                swarm:
+                  extra_labels:
+                    traefik.enable: "true"
+                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                  extra_networks:
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                  extra_volumes:
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                  image: Reprehenderit atque aliquid.
+              port: 0
+              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              service_type: rag
+              version: latest
+            - config:
+                llm_model: gpt-4
+                llm_provider: openai
+                openai_api_key: sk-...
+              connect_as: app
+              cpus: 500m
+              database_connection:
+                target_nodes:
+                  - n1
+                  - n2
+                target_session_attrs: primary
+              host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
@@ -9496,7 +9553,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Necessitatibus excepturi reprehenderit.
+                  image: Reprehenderit atque aliquid.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -9509,6 +9566,26 @@ components:
       example:
         backup_config:
           repositories:
+            - azure_account: pgedge-backups
+              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              azure_endpoint: blob.core.usgovcloudapi.net
+              azure_key: YXpLZXk=
+              base_path: /backups
+              custom_options:
+                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                storage-upload-chunk-size: 5MiB
+              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              gcs_endpoint: localhost
+              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              retention_full: 2
+              retention_full_type: count
+              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              s3_endpoint: s3.us-east-1.amazonaws.com
+              s3_key: AKIAIOSFODNN7EXAMPLE
+              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              s3_region: us-east-1
+              type: s3
             - azure_account: pgedge-backups
               azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
               azure_endpoint: blob.core.usgovcloudapi.net
@@ -9633,6 +9710,26 @@ components:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -9645,6 +9742,8 @@ components:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
             name: n1
@@ -9679,7 +9778,301 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Necessitatibus excepturi reprehenderit.
+                image: Reprehenderit atque aliquid.
+            patroni_port: 8888
+            pg_hba_conf:
+              - host example myapp_user 10.0.0.0/8 scram-sha-256
+            pg_ident_conf:
+              - ssl_users  CN=alice,O=example  alice
+            port: 5432
+            postgres_version: "17.6"
+            postgresql_conf:
+              max_connections: 1000
+            restore_config:
+              repository:
+                azure_account: pgedge-backups
+                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                azure_endpoint: blob.core.usgovcloudapi.net
+                azure_key: YXpLZXk=
+                base_path: /backups
+                custom_options:
+                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                gcs_endpoint: localhost
+                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                s3_endpoint: s3.us-east-1.amazonaws.com
+                s3_key: AKIAIOSFODNN7EXAMPLE
+                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                s3_region: us-east-1
+                type: s3
+              restore_options:
+                set: 20250505-153628F
+                target: "123456"
+                type: xid
+              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              source_database_name: northwind
+              source_node_name: n1
+            source_node: n1
+          - backup_config:
+              repositories:
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+              schedules:
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+            cpus: 500m
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 500M
+            name: n1
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                image: Reprehenderit atque aliquid.
+            patroni_port: 8888
+            pg_hba_conf:
+              - host example myapp_user 10.0.0.0/8 scram-sha-256
+            pg_ident_conf:
+              - ssl_users  CN=alice,O=example  alice
+            port: 5432
+            postgres_version: "17.6"
+            postgresql_conf:
+              max_connections: 1000
+            restore_config:
+              repository:
+                azure_account: pgedge-backups
+                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                azure_endpoint: blob.core.usgovcloudapi.net
+                azure_key: YXpLZXk=
+                base_path: /backups
+                custom_options:
+                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                gcs_endpoint: localhost
+                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                s3_endpoint: s3.us-east-1.amazonaws.com
+                s3_key: AKIAIOSFODNN7EXAMPLE
+                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                s3_region: us-east-1
+                type: s3
+              restore_options:
+                set: 20250505-153628F
+                target: "123456"
+                type: xid
+              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              source_database_name: northwind
+              source_node_name: n1
+            source_node: n1
+          - backup_config:
+              repositories:
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+              schedules:
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+            cpus: 500m
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 500M
+            name: n1
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                image: Reprehenderit atque aliquid.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -9747,7 +10140,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Necessitatibus excepturi reprehenderit.
+            image: Reprehenderit atque aliquid.
         patroni_port: 8888
         pg_hba_conf:
           - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -9807,7 +10200,6 @@ components:
               target_session_attrs: primary
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -9840,7 +10232,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Necessitatibus excepturi reprehenderit.
+                image: Reprehenderit atque aliquid.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -9858,7 +10250,6 @@ components:
               target_session_attrs: primary
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -9891,58 +10282,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Necessitatibus excepturi reprehenderit.
-            port: 0
-            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-            service_type: rag
-            version: latest
-          - config:
-              llm_model: gpt-4
-              llm_provider: openai
-              openai_api_key: sk-...
-            connect_as: app
-            cpus: 500m
-            database_connection:
-              target_nodes:
-                - n1
-                - n2
-              target_session_attrs: primary
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 512M
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                image: Necessitatibus excepturi reprehenderit.
+                image: Reprehenderit atque aliquid.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -9977,7 +10317,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -9986,7 +10326,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -9995,7 +10335,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -10054,26 +10394,6 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
                 schedules:
                   - cron_expression: 0 6 * * ?
                     id: daily-full-backup
@@ -10086,6 +10406,7 @@ components:
                     type: full
               cpus: 500m
               host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 500M
@@ -10121,7 +10442,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               patroni_port: 8888
               pg_hba_conf:
                 - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -10200,26 +10521,6 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
                 schedules:
                   - cron_expression: 0 6 * * ?
                     id: daily-full-backup
@@ -10232,6 +10533,7 @@ components:
                     type: full
               cpus: 500m
               host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 500M
@@ -10267,153 +10569,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
-              patroni_port: 8888
-              pg_hba_conf:
-                - host example myapp_user 10.0.0.0/8 scram-sha-256
-              pg_ident_conf:
-                - ssl_users  CN=alice,O=example  alice
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               patroni_port: 8888
               pg_hba_conf:
                 - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -10465,7 +10621,7 @@ components:
           type: array
           items:
             type: string
-            example: Eaque et.
+            example: Quo perferendis et qui.
           description: Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.
           example:
             - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -10474,7 +10630,7 @@ components:
           type: array
           items:
             type: string
-            example: Minima ipsum ut impedit quo.
+            example: Quaerat rem.
           description: Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -10521,7 +10677,6 @@ components:
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
                 swarm:
@@ -10554,7 +10709,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -10573,6 +10728,56 @@ components:
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              memory: 512M
+              orchestrator_opts:
+                swarm:
+                  extra_labels:
+                    traefik.enable: "true"
+                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                  extra_networks:
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                  extra_volumes:
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                  image: Incidunt in quas totam.
+              port: 0
+              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              service_type: rag
+              version: latest
+            - config:
+                llm_model: gpt-4
+                llm_provider: openai
+                openai_api_key: sk-...
+              connect_as: app
+              cpus: 500m
+              database_connection:
+                target_nodes:
+                  - n1
+                  - n2
+                target_session_attrs: primary
+              host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
@@ -10606,7 +10811,58 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
+              port: 0
+              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              service_type: rag
+              version: latest
+            - config:
+                llm_model: gpt-4
+                llm_provider: openai
+                openai_api_key: sk-...
+              connect_as: app
+              cpus: 500m
+              database_connection:
+                target_nodes:
+                  - n1
+                  - n2
+                target_session_attrs: primary
+              host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              memory: 512M
+              orchestrator_opts:
+                swarm:
+                  extra_labels:
+                    traefik.enable: "true"
+                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                  extra_networks:
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                  extra_volumes:
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                  image: Incidunt in quas totam.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -10619,26 +10875,6 @@ components:
       example:
         backup_config:
           repositories:
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
             - azure_account: pgedge-backups
               azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
               azure_endpoint: blob.core.usgovcloudapi.net
@@ -10696,7 +10932,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -10705,7 +10941,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -10714,7 +10950,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -10723,26 +10959,6 @@ components:
         nodes:
           - backup_config:
               repositories:
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
                 - azure_account: pgedge-backups
                   azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
                   azure_endpoint: blob.core.usgovcloudapi.net
@@ -10797,6 +11013,7 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
             name: n1
             orchestrator_opts:
@@ -10830,7 +11047,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -10909,26 +11126,6 @@ components:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -10941,6 +11138,7 @@ components:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
@@ -10976,7 +11174,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -11044,7 +11242,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         patroni_port: 8888
         pg_hba_conf:
           - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -11105,7 +11303,6 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -11138,7 +11335,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -11157,6 +11354,56 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 512M
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                image: Incidunt in quas totam.
+            port: 0
+            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            service_type: rag
+            version: latest
+          - config:
+              llm_model: gpt-4
+              llm_provider: openai
+              openai_api_key: sk-...
+            connect_as: app
+            cpus: 500m
+            database_connection:
+              target_nodes:
+                - n1
+                - n2
+              target_session_attrs: primary
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
@@ -11190,7 +11437,58 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
+            port: 0
+            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            service_type: rag
+            version: latest
+          - config:
+              llm_model: gpt-4
+              llm_provider: openai
+              openai_api_key: sk-...
+            connect_as: app
+            cpus: 500m
+            database_connection:
+              target_nodes:
+                - n1
+                - n2
+              target_session_attrs: primary
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 512M
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -11225,7 +11523,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -11234,7 +11532,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -11243,7 +11541,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -11302,26 +11600,6 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
                 schedules:
                   - cron_expression: 0 6 * * ?
                     id: daily-full-backup
@@ -11334,6 +11612,7 @@ components:
                     type: full
               cpus: 500m
               host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 500M
@@ -11369,7 +11648,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               patroni_port: 8888
               pg_hba_conf:
                 - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -11448,26 +11727,6 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
                 schedules:
                   - cron_expression: 0 6 * * ?
                     id: daily-full-backup
@@ -11480,6 +11739,7 @@ components:
                     type: full
               cpus: 500m
               host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 500M
@@ -11515,7 +11775,134 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
+              patroni_port: 8888
+              pg_hba_conf:
+                - host example myapp_user 10.0.0.0/8 scram-sha-256
+              pg_ident_conf:
+                - ssl_users  CN=alice,O=example  alice
+              port: 5432
+              postgres_version: "17.6"
+              postgresql_conf:
+                max_connections: 1000
+              restore_config:
+                repository:
+                  azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+                restore_options:
+                  set: 20250505-153628F
+                  target: "123456"
+                  type: xid
+                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                source_database_name: northwind
+                source_node_name: n1
+              source_node: n1
+            - backup_config:
+                repositories:
+                  - azure_account: pgedge-backups
+                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    azure_endpoint: blob.core.usgovcloudapi.net
+                    azure_key: YXpLZXk=
+                    base_path: /backups
+                    custom_options:
+                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                      storage-upload-chunk-size: 5MiB
+                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    gcs_endpoint: localhost
+                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                    retention_full: 2
+                    retention_full_type: count
+                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    s3_endpoint: s3.us-east-1.amazonaws.com
+                    s3_key: AKIAIOSFODNN7EXAMPLE
+                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                    s3_region: us-east-1
+                    type: s3
+                  - azure_account: pgedge-backups
+                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    azure_endpoint: blob.core.usgovcloudapi.net
+                    azure_key: YXpLZXk=
+                    base_path: /backups
+                    custom_options:
+                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                      storage-upload-chunk-size: 5MiB
+                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    gcs_endpoint: localhost
+                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                    retention_full: 2
+                    retention_full_type: count
+                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    s3_endpoint: s3.us-east-1.amazonaws.com
+                    s3_key: AKIAIOSFODNN7EXAMPLE
+                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                    s3_region: us-east-1
+                    type: s3
+                schedules:
+                  - cron_expression: 0 6 * * ?
+                    id: daily-full-backup
+                    type: full
+                  - cron_expression: 0 6 * * ?
+                    id: daily-full-backup
+                    type: full
+                  - cron_expression: 0 6 * * ?
+                    id: daily-full-backup
+                    type: full
+              cpus: 500m
+              host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              memory: 500M
+              name: n1
+              orchestrator_opts:
+                swarm:
+                  extra_labels:
+                    traefik.enable: "true"
+                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                  extra_networks:
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                  extra_volumes:
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                  image: Incidunt in quas totam.
               patroni_port: 8888
               pg_hba_conf:
                 - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -11567,7 +11954,7 @@ components:
           type: array
           items:
             type: string
-            example: Dolorum natus sunt harum magnam sunt.
+            example: Tempora in veniam officia ratione minus.
           description: Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.
           example:
             - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -11576,7 +11963,7 @@ components:
           type: array
           items:
             type: string
-            example: In veniam officia ratione.
+            example: Occaecati et et consequuntur.
           description: Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -11623,7 +12010,6 @@ components:
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
                 swarm:
@@ -11656,7 +12042,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -11675,6 +12061,56 @@ components:
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              memory: 512M
+              orchestrator_opts:
+                swarm:
+                  extra_labels:
+                    traefik.enable: "true"
+                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                  extra_networks:
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                  extra_volumes:
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                  image: Incidunt in quas totam.
+              port: 0
+              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              service_type: rag
+              version: latest
+            - config:
+                llm_model: gpt-4
+                llm_provider: openai
+                openai_api_key: sk-...
+              connect_as: app
+              cpus: 500m
+              database_connection:
+                target_nodes:
+                  - n1
+                  - n2
+                target_session_attrs: primary
+              host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
@@ -11708,7 +12144,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -11721,26 +12157,6 @@ components:
       example:
         backup_config:
           repositories:
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
             - azure_account: pgedge-backups
               azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
               azure_endpoint: blob.core.usgovcloudapi.net
@@ -11798,7 +12214,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -11807,7 +12223,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -11816,7 +12232,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -11865,26 +12281,6 @@ components:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -11897,6 +12293,7 @@ components:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
@@ -11932,7 +12329,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -12011,26 +12408,6 @@ components:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -12043,6 +12420,7 @@ components:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
@@ -12078,7 +12456,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -12157,26 +12535,6 @@ components:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -12189,6 +12547,7 @@ components:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
@@ -12224,7 +12583,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -12292,7 +12651,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         patroni_port: 8888
         pg_hba_conf:
           - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -12353,7 +12712,6 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -12386,7 +12744,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -12405,7 +12763,6 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -12438,7 +12795,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -12457,7 +12814,6 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -12490,7 +12846,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -12509,7 +12865,6 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -12542,7 +12897,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -12654,6 +13009,26 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
+                  - azure_account: pgedge-backups
+                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    azure_endpoint: blob.core.usgovcloudapi.net
+                    azure_key: YXpLZXk=
+                    base_path: /backups
+                    custom_options:
+                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                      storage-upload-chunk-size: 5MiB
+                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    gcs_endpoint: localhost
+                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                    retention_full: 2
+                    retention_full_type: count
+                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    s3_endpoint: s3.us-east-1.amazonaws.com
+                    s3_key: AKIAIOSFODNN7EXAMPLE
+                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                    s3_region: us-east-1
+                    type: s3
                 schedules:
                   - cron_expression: 0 6 * * ?
                     id: daily-full-backup
@@ -12666,6 +13041,7 @@ components:
                     type: full
               cpus: 500m
               host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 500M
               name: n1
@@ -12700,7 +13076,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Quia reiciendis et odio omnis itaque cum.
+                  image: Et odio.
               patroni_port: 8888
               pg_hba_conf:
                 - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -12779,6 +13155,26 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
+                  - azure_account: pgedge-backups
+                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    azure_endpoint: blob.core.usgovcloudapi.net
+                    azure_key: YXpLZXk=
+                    base_path: /backups
+                    custom_options:
+                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                      storage-upload-chunk-size: 5MiB
+                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    gcs_endpoint: localhost
+                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                    retention_full: 2
+                    retention_full_type: count
+                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    s3_endpoint: s3.us-east-1.amazonaws.com
+                    s3_key: AKIAIOSFODNN7EXAMPLE
+                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                    s3_region: us-east-1
+                    type: s3
                 schedules:
                   - cron_expression: 0 6 * * ?
                     id: daily-full-backup
@@ -12791,6 +13187,7 @@ components:
                     type: full
               cpus: 500m
               host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 500M
               name: n1
@@ -12825,132 +13222,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Quia reiciendis et odio omnis itaque cum.
-              patroni_port: 8888
-              pg_hba_conf:
-                - host example myapp_user 10.0.0.0/8 scram-sha-256
-              pg_ident_conf:
-                - ssl_users  CN=alice,O=example  alice
-              port: 5432
-              postgres_version: "17.6"
-              postgresql_conf:
-                max_connections: 1000
-              restore_config:
-                repository:
-                  azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
-                restore_options:
-                  set: 20250505-153628F
-                  target: "123456"
-                  type: xid
-                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                source_database_name: northwind
-                source_node_name: n1
-              source_node: n1
-            - backup_config:
-                repositories:
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
-                schedules:
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-                  - cron_expression: 0 6 * * ?
-                    id: daily-full-backup
-                    type: full
-              cpus: 500m
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 500M
-              name: n1
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                  image: Quia reiciendis et odio omnis itaque cum.
+                  image: Et odio.
               patroni_port: 8888
               pg_hba_conf:
                 - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -13002,7 +13274,7 @@ components:
           type: array
           items:
             type: string
-            example: Eveniet sit dignissimos ducimus reiciendis asperiores.
+            example: Iure molestiae.
           description: Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.
           example:
             - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -13011,7 +13283,7 @@ components:
           type: array
           items:
             type: string
-            example: Veritatis consequuntur molestiae architecto.
+            example: Nesciunt quia quis aut ducimus deserunt.
           description: Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -13090,7 +13362,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Quia reiciendis et odio omnis itaque cum.
+                  image: Et odio.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -13141,7 +13413,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Quia reiciendis et odio omnis itaque cum.
+                  image: Et odio.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -13192,58 +13464,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Quia reiciendis et odio omnis itaque cum.
-              port: 0
-              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              service_type: rag
-              version: latest
-            - config:
-                llm_model: gpt-4
-                llm_provider: openai
-                openai_api_key: sk-...
-              connect_as: app
-              cpus: 500m
-              database_connection:
-                target_nodes:
-                  - n1
-                  - n2
-                target_session_attrs: primary
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 512M
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                  image: Quia reiciendis et odio omnis itaque cum.
+                  image: Et odio.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -13256,6 +13477,26 @@ components:
       example:
         backup_config:
           repositories:
+            - azure_account: pgedge-backups
+              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              azure_endpoint: blob.core.usgovcloudapi.net
+              azure_key: YXpLZXk=
+              base_path: /backups
+              custom_options:
+                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                storage-upload-chunk-size: 5MiB
+              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              gcs_endpoint: localhost
+              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              retention_full: 2
+              retention_full_type: count
+              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+              s3_endpoint: s3.us-east-1.amazonaws.com
+              s3_key: AKIAIOSFODNN7EXAMPLE
+              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              s3_region: us-east-1
+              type: s3
             - azure_account: pgedge-backups
               azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
               azure_endpoint: blob.core.usgovcloudapi.net
@@ -13380,6 +13621,26 @@ components:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -13392,6 +13653,7 @@ components:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
             name: n1
@@ -13426,7 +13688,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Quia reiciendis et odio omnis itaque cum.
+                image: Et odio.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -13505,6 +13767,26 @@ components:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -13517,6 +13799,7 @@ components:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
             name: n1
@@ -13551,7 +13834,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Quia reiciendis et odio omnis itaque cum.
+                image: Et odio.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -13619,7 +13902,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Quia reiciendis et odio omnis itaque cum.
+            image: Et odio.
         patroni_port: 8888
         pg_hba_conf:
           - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -13712,7 +13995,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Quia reiciendis et odio omnis itaque cum.
+                image: Et odio.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -13763,7 +14046,109 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Quia reiciendis et odio omnis itaque cum.
+                image: Et odio.
+            port: 0
+            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            service_type: rag
+            version: latest
+          - config:
+              llm_model: gpt-4
+              llm_provider: openai
+              openai_api_key: sk-...
+            connect_as: app
+            cpus: 500m
+            database_connection:
+              target_nodes:
+                - n1
+                - n2
+              target_session_attrs: primary
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 512M
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                image: Et odio.
+            port: 0
+            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            service_type: rag
+            version: latest
+          - config:
+              llm_model: gpt-4
+              llm_provider: openai
+              openai_api_key: sk-...
+            connect_as: app
+            cpus: 500m
+            database_connection:
+              target_nodes:
+                - n1
+                - n2
+              target_session_attrs: primary
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 512M
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                image: Et odio.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -13798,7 +14183,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -13807,7 +14192,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -13816,7 +14201,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -13875,26 +14260,6 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
                 schedules:
                   - cron_expression: 0 6 * * ?
                     id: daily-full-backup
@@ -13907,6 +14272,7 @@ components:
                     type: full
               cpus: 500m
               host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 500M
@@ -13942,7 +14308,134 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
+              patroni_port: 8888
+              pg_hba_conf:
+                - host example myapp_user 10.0.0.0/8 scram-sha-256
+              pg_ident_conf:
+                - ssl_users  CN=alice,O=example  alice
+              port: 5432
+              postgres_version: "17.6"
+              postgresql_conf:
+                max_connections: 1000
+              restore_config:
+                repository:
+                  azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+                restore_options:
+                  set: 20250505-153628F
+                  target: "123456"
+                  type: xid
+                source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                source_database_name: northwind
+                source_node_name: n1
+              source_node: n1
+            - backup_config:
+                repositories:
+                  - azure_account: pgedge-backups
+                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    azure_endpoint: blob.core.usgovcloudapi.net
+                    azure_key: YXpLZXk=
+                    base_path: /backups
+                    custom_options:
+                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                      storage-upload-chunk-size: 5MiB
+                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    gcs_endpoint: localhost
+                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                    retention_full: 2
+                    retention_full_type: count
+                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    s3_endpoint: s3.us-east-1.amazonaws.com
+                    s3_key: AKIAIOSFODNN7EXAMPLE
+                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                    s3_region: us-east-1
+                    type: s3
+                  - azure_account: pgedge-backups
+                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    azure_endpoint: blob.core.usgovcloudapi.net
+                    azure_key: YXpLZXk=
+                    base_path: /backups
+                    custom_options:
+                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                      storage-upload-chunk-size: 5MiB
+                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    gcs_endpoint: localhost
+                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                    retention_full: 2
+                    retention_full_type: count
+                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                    s3_endpoint: s3.us-east-1.amazonaws.com
+                    s3_key: AKIAIOSFODNN7EXAMPLE
+                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                    s3_region: us-east-1
+                    type: s3
+                schedules:
+                  - cron_expression: 0 6 * * ?
+                    id: daily-full-backup
+                    type: full
+                  - cron_expression: 0 6 * * ?
+                    id: daily-full-backup
+                    type: full
+                  - cron_expression: 0 6 * * ?
+                    id: daily-full-backup
+                    type: full
+              cpus: 500m
+              host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              memory: 500M
+              name: n1
+              orchestrator_opts:
+                swarm:
+                  extra_labels:
+                    traefik.enable: "true"
+                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                  extra_networks:
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                    - aliases:
+                        - pg-db
+                        - db-alias
+                      driver_opts:
+                        com.docker.network.endpoint.expose: "true"
+                      id: traefik-public
+                  extra_volumes:
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                    - destination_path: /backups/container
+                      host_path: /Users/user/backups/host
+                  image: Incidunt in quas totam.
               patroni_port: 8888
               pg_hba_conf:
                 - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -13994,7 +14487,7 @@ components:
           type: array
           items:
             type: string
-            example: Quas iste dicta assumenda.
+            example: Modi facere est.
           description: Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.
           example:
             - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -14003,7 +14496,7 @@ components:
           type: array
           items:
             type: string
-            example: Vero dolorem aut.
+            example: Qui excepturi debitis aperiam rerum at.
           description: Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -14050,7 +14543,6 @@ components:
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
                 swarm:
@@ -14083,7 +14575,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -14102,7 +14594,6 @@ components:
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
                 swarm:
@@ -14135,7 +14626,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -14154,7 +14645,6 @@ components:
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
                 swarm:
@@ -14187,7 +14677,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -14206,7 +14696,6 @@ components:
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
                 swarm:
@@ -14239,7 +14728,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -14252,26 +14741,6 @@ components:
       example:
         backup_config:
           repositories:
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
             - azure_account: pgedge-backups
               azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
               azure_endpoint: blob.core.usgovcloudapi.net
@@ -14329,7 +14798,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -14338,7 +14807,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -14347,7 +14816,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -14356,26 +14825,6 @@ components:
         nodes:
           - backup_config:
               repositories:
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
                 - azure_account: pgedge-backups
                   azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
                   azure_endpoint: blob.core.usgovcloudapi.net
@@ -14430,6 +14879,7 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
             name: n1
             orchestrator_opts:
@@ -14463,7 +14913,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -14542,26 +14992,6 @@ components:
                   s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                   s3_region: us-east-1
                   type: s3
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
               schedules:
                 - cron_expression: 0 6 * * ?
                   id: daily-full-backup
@@ -14574,6 +15004,7 @@ components:
                   type: full
             cpus: 500m
             host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
@@ -14609,7 +15040,134 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
+            patroni_port: 8888
+            pg_hba_conf:
+              - host example myapp_user 10.0.0.0/8 scram-sha-256
+            pg_ident_conf:
+              - ssl_users  CN=alice,O=example  alice
+            port: 5432
+            postgres_version: "17.6"
+            postgresql_conf:
+              max_connections: 1000
+            restore_config:
+              repository:
+                azure_account: pgedge-backups
+                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                azure_endpoint: blob.core.usgovcloudapi.net
+                azure_key: YXpLZXk=
+                base_path: /backups
+                custom_options:
+                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                gcs_endpoint: localhost
+                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                s3_endpoint: s3.us-east-1.amazonaws.com
+                s3_key: AKIAIOSFODNN7EXAMPLE
+                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                s3_region: us-east-1
+                type: s3
+              restore_options:
+                set: 20250505-153628F
+                target: "123456"
+                type: xid
+              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              source_database_name: northwind
+              source_node_name: n1
+            source_node: n1
+          - backup_config:
+              repositories:
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+              schedules:
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+            cpus: 500m
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 500M
+            name: n1
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -14677,7 +15235,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         patroni_port: 8888
         pg_hba_conf:
           - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -14738,7 +15296,6 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -14771,7 +15328,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -14790,7 +15347,6 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -14823,111 +15379,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
-            port: 0
-            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-            service_type: rag
-            version: latest
-          - config:
-              llm_model: gpt-4
-              llm_provider: openai
-              openai_api_key: sk-...
-            connect_as: app
-            cpus: 500m
-            database_connection:
-              target_nodes:
-                - n1
-                - n2
-              target_session_attrs: primary
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 512M
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
-            port: 0
-            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-            service_type: rag
-            version: latest
-          - config:
-              llm_model: gpt-4
-              llm_provider: openai
-              openai_api_key: sk-...
-            connect_as: app
-            cpus: 500m
-            database_connection:
-              target_nodes:
-                - n1
-                - n2
-              target_session_attrs: primary
-            host_ids:
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
-            memory: 512M
-            orchestrator_opts:
-              swarm:
-                extra_labels:
-                  traefik.enable: "true"
-                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                extra_networks:
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                  - aliases:
-                      - pg-db
-                      - db-alias
-                    driver_opts:
-                      com.docker.network.endpoint.expose: "true"
-                    id: traefik-public
-                extra_volumes:
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                  - destination_path: /backups/container
-                    host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -14962,7 +15414,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -14971,7 +15423,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -14980,7 +15432,7 @@ components:
                 - LOGIN
                 - CREATEDB
                 - CREATEROLE
-              db_owner: true
+              db_owner: false
               password: secret
               roles:
                 - pgedge_superuser
@@ -15039,26 +15491,6 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
                 schedules:
                   - cron_expression: 0 6 * * ?
                     id: daily-full-backup
@@ -15071,6 +15503,7 @@ components:
                     type: full
               cpus: 500m
               host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 500M
@@ -15106,7 +15539,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               patroni_port: 8888
               pg_hba_conf:
                 - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -15185,26 +15618,6 @@ components:
                     s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
                     s3_region: us-east-1
                     type: s3
-                  - azure_account: pgedge-backups
-                    azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    azure_endpoint: blob.core.usgovcloudapi.net
-                    azure_key: YXpLZXk=
-                    base_path: /backups
-                    custom_options:
-                      s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                      storage-upload-chunk-size: 5MiB
-                    gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    gcs_endpoint: localhost
-                    gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                    id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                    retention_full: 2
-                    retention_full_type: count
-                    s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                    s3_endpoint: s3.us-east-1.amazonaws.com
-                    s3_key: AKIAIOSFODNN7EXAMPLE
-                    s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                    s3_region: us-east-1
-                    type: s3
                 schedules:
                   - cron_expression: 0 6 * * ?
                     id: daily-full-backup
@@ -15217,6 +15630,7 @@ components:
                     type: full
               cpus: 500m
               host_ids:
+                - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 500M
@@ -15252,7 +15666,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               patroni_port: 8888
               pg_hba_conf:
                 - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -15304,7 +15718,7 @@ components:
           type: array
           items:
             type: string
-            example: Laudantium sed delectus vel ut.
+            example: Possimus sit commodi in dolor unde.
           description: Additional pg_hba.conf entries, one rule per array element. Inserted between control-plane's system-user rules and its catch-all, so they cannot affect control-plane-internal connectivity (Patroni, replication, health checks). Node-level pg_hba_conf entries are prepended to these.
           example:
             - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -15313,7 +15727,7 @@ components:
           type: array
           items:
             type: string
-            example: Expedita maiores cumque esse.
+            example: Illo ut sint cumque quia non enim.
           description: Additional pg_ident.conf entries, one mapping per array element. Purely additive; control-plane writes no pg_ident entries of its own. The primary use case is cert auth with map= translating certificate CNs to PostgreSQL usernames.
           example:
             - ssl_users  CN=alice,O=example  alice
@@ -15360,7 +15774,6 @@ components:
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
                 swarm:
@@ -15393,7 +15806,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -15412,7 +15825,6 @@ components:
               host_ids:
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
                 - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
               memory: 512M
               orchestrator_opts:
                 swarm:
@@ -15445,111 +15857,7 @@ components:
                       host_path: /Users/user/backups/host
                     - destination_path: /backups/container
                       host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
-              port: 0
-              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              service_type: rag
-              version: latest
-            - config:
-                llm_model: gpt-4
-                llm_provider: openai
-                openai_api_key: sk-...
-              connect_as: app
-              cpus: 500m
-              database_connection:
-                target_nodes:
-                  - n1
-                  - n2
-                target_session_attrs: primary
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 512M
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
-              port: 0
-              service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              service_type: rag
-              version: latest
-            - config:
-                llm_model: gpt-4
-                llm_provider: openai
-                openai_api_key: sk-...
-              connect_as: app
-              cpus: 500m
-              database_connection:
-                target_nodes:
-                  - n1
-                  - n2
-                target_session_attrs: primary
-              host_ids:
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-                - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              memory: 512M
-              orchestrator_opts:
-                swarm:
-                  extra_labels:
-                    traefik.enable: "true"
-                    traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
-                  extra_networks:
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                    - aliases:
-                        - pg-db
-                        - db-alias
-                      driver_opts:
-                        com.docker.network.endpoint.expose: "true"
-                      id: traefik-public
-                  extra_volumes:
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                    - destination_path: /backups/container
-                      host_path: /Users/user/backups/host
-                  image: Dignissimos incidunt in quas totam eveniet possimus.
+                  image: Incidunt in quas totam.
               port: 0
               service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
               service_type: rag
@@ -15562,26 +15870,6 @@ components:
       example:
         backup_config:
           repositories:
-            - azure_account: pgedge-backups
-              azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              azure_endpoint: blob.core.usgovcloudapi.net
-              azure_key: YXpLZXk=
-              base_path: /backups
-              custom_options:
-                s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                storage-upload-chunk-size: 5MiB
-              gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              gcs_endpoint: localhost
-              gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-              id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-              retention_full: 2
-              retention_full_type: count
-              s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-              s3_endpoint: s3.us-east-1.amazonaws.com
-              s3_key: AKIAIOSFODNN7EXAMPLE
-              s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-              s3_region: us-east-1
-              type: s3
             - azure_account: pgedge-backups
               azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
               azure_endpoint: blob.core.usgovcloudapi.net
@@ -15639,7 +15927,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -15648,7 +15936,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -15657,7 +15945,7 @@ components:
               - LOGIN
               - CREATEDB
               - CREATEROLE
-            db_owner: true
+            db_owner: false
             password: secret
             roles:
               - pgedge_superuser
@@ -15666,26 +15954,6 @@ components:
         nodes:
           - backup_config:
               repositories:
-                - azure_account: pgedge-backups
-                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  azure_endpoint: blob.core.usgovcloudapi.net
-                  azure_key: YXpLZXk=
-                  base_path: /backups
-                  custom_options:
-                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
-                    storage-upload-chunk-size: 5MiB
-                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  gcs_endpoint: localhost
-                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
-                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
-                  retention_full: 2
-                  retention_full_type: count
-                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
-                  s3_endpoint: s3.us-east-1.amazonaws.com
-                  s3_key: AKIAIOSFODNN7EXAMPLE
-                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-                  s3_region: us-east-1
-                  type: s3
                 - azure_account: pgedge-backups
                   azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
                   azure_endpoint: blob.core.usgovcloudapi.net
@@ -15740,6 +16008,7 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 500M
             name: n1
             orchestrator_opts:
@@ -15773,7 +16042,261 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
+            patroni_port: 8888
+            pg_hba_conf:
+              - host example myapp_user 10.0.0.0/8 scram-sha-256
+            pg_ident_conf:
+              - ssl_users  CN=alice,O=example  alice
+            port: 5432
+            postgres_version: "17.6"
+            postgresql_conf:
+              max_connections: 1000
+            restore_config:
+              repository:
+                azure_account: pgedge-backups
+                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                azure_endpoint: blob.core.usgovcloudapi.net
+                azure_key: YXpLZXk=
+                base_path: /backups
+                custom_options:
+                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                gcs_endpoint: localhost
+                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                s3_endpoint: s3.us-east-1.amazonaws.com
+                s3_key: AKIAIOSFODNN7EXAMPLE
+                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                s3_region: us-east-1
+                type: s3
+              restore_options:
+                set: 20250505-153628F
+                target: "123456"
+                type: xid
+              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              source_database_name: northwind
+              source_node_name: n1
+            source_node: n1
+          - backup_config:
+              repositories:
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+              schedules:
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+            cpus: 500m
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 500M
+            name: n1
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                image: Incidunt in quas totam.
+            patroni_port: 8888
+            pg_hba_conf:
+              - host example myapp_user 10.0.0.0/8 scram-sha-256
+            pg_ident_conf:
+              - ssl_users  CN=alice,O=example  alice
+            port: 5432
+            postgres_version: "17.6"
+            postgresql_conf:
+              max_connections: 1000
+            restore_config:
+              repository:
+                azure_account: pgedge-backups
+                azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                azure_endpoint: blob.core.usgovcloudapi.net
+                azure_key: YXpLZXk=
+                base_path: /backups
+                custom_options:
+                  s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                gcs_endpoint: localhost
+                gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                s3_endpoint: s3.us-east-1.amazonaws.com
+                s3_key: AKIAIOSFODNN7EXAMPLE
+                s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                s3_region: us-east-1
+                type: s3
+              restore_options:
+                set: 20250505-153628F
+                target: "123456"
+                type: xid
+              source_database_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+              source_database_name: northwind
+              source_node_name: n1
+            source_node: n1
+          - backup_config:
+              repositories:
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+                - azure_account: pgedge-backups
+                  azure_container: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  azure_endpoint: blob.core.usgovcloudapi.net
+                  azure_key: YXpLZXk=
+                  base_path: /backups
+                  custom_options:
+                    s3-kms-key-id: 1234abcd-12ab-34cd-56ef-1234567890ab
+                    storage-upload-chunk-size: 5MiB
+                  gcs_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  gcs_endpoint: localhost
+                  gcs_key: ZXhhbXBsZSBnY3Mga2V5Cg==
+                  id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+                  retention_full: 2
+                  retention_full_type: count
+                  s3_bucket: pgedge-backups-9f81786f-373b-4ff2-afee-e054a06a96f1
+                  s3_endpoint: s3.us-east-1.amazonaws.com
+                  s3_key: AKIAIOSFODNN7EXAMPLE
+                  s3_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+                  s3_region: us-east-1
+                  type: s3
+              schedules:
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+                - cron_expression: 0 6 * * ?
+                  id: daily-full-backup
+                  type: full
+            cpus: 500m
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 500M
+            name: n1
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                image: Incidunt in quas totam.
             patroni_port: 8888
             pg_hba_conf:
               - host example myapp_user 10.0.0.0/8 scram-sha-256
@@ -15841,7 +16364,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         patroni_port: 8888
         pg_hba_conf:
           - hostssl all myapp_user 203.0.113.0/24 scram-sha-256
@@ -15902,7 +16425,6 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
-              - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
               swarm:
@@ -15935,7 +16457,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -15954,6 +16476,56 @@ components:
             host_ids:
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
+            memory: 512M
+            orchestrator_opts:
+              swarm:
+                extra_labels:
+                  traefik.enable: "true"
+                  traefik.tcp.routers.mydb.rule: HostSNI(`mydb.example.com`)
+                extra_networks:
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                  - aliases:
+                      - pg-db
+                      - db-alias
+                    driver_opts:
+                      com.docker.network.endpoint.expose: "true"
+                    id: traefik-public
+                extra_volumes:
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                  - destination_path: /backups/container
+                    host_path: /Users/user/backups/host
+                image: Incidunt in quas totam.
+            port: 0
+            service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
+            service_type: rag
+            version: latest
+          - config:
+              llm_model: gpt-4
+              llm_provider: openai
+              openai_api_key: sk-...
+            connect_as: app
+            cpus: 500m
+            database_connection:
+              target_nodes:
+                - n1
+                - n2
+              target_session_attrs: primary
+            host_ids:
+              - 76f9b8c0-4958-11f0-a489-3bb29577c696
               - 76f9b8c0-4958-11f0-a489-3bb29577c696
             memory: 512M
             orchestrator_opts:
@@ -15987,7 +16559,7 @@ components:
                     host_path: /Users/user/backups/host
                   - destination_path: /backups/container
                     host_path: /Users/user/backups/host
-                image: Dignissimos incidunt in quas totam eveniet possimus.
+                image: Incidunt in quas totam.
             port: 0
             service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
             service_type: rag
@@ -15999,6 +16571,21 @@ components:
     DatabaseSummary:
       type: object
       properties:
+        available_upgrades:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailableUpgrade'
+          description: Newer stable image versions available in the same Postgres major / Spock major bucket. Present only when ?include=available_upgrades is set.
+          example:
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
+            - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+              postgres_version: "17.10"
+              spock_version: "5"
         created_at:
           type: string
           description: The time that the database was created.
@@ -16106,6 +16693,16 @@ components:
           example: "2025-01-01T02:30:00Z"
           format: date-time
       example:
+        available_upgrades:
+          - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+            postgres_version: "17.10"
+            spock_version: "5"
+          - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+            postgres_version: "17.10"
+            spock_version: "5"
+          - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+            postgres_version: "17.10"
+            spock_version: "5"
         created_at: "2025-01-01T01:30:00Z"
         id: 02f1a7db-fca8-4521-b57a-2a375c1ced51
         instances:
@@ -16237,7 +16834,7 @@ components:
             state: modifying
             status_updated_at: "1976-03-01T20:13:25Z"
             updated_at: "1996-05-27T17:04:41Z"
-        state: restoring
+        state: available
         tenant_id: 8210ec10-2dca-406c-ac4a-0661d2189954
         updated_at: "2025-01-01T02:30:00Z"
       required:
@@ -16438,10 +17035,10 @@ components:
           type: boolean
           description: If true, skip the health validations that prevent running failover on a healthy cluster.
           default: false
-          example: false
+          example: true
       example:
         candidate_instance_id: 68f50878-44d2-4524-a823-e31bd478706d-n1-689qacsi
-        skip_validation: true
+        skip_validation: false
     FailoverDatabaseNodeResponse:
       type: object
       properties:
@@ -16929,14 +17526,6 @@ components:
               status: completed
               task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
               type: create
-            - completed_at: "2025-06-18T16:52:35Z"
-              created_at: "2025-06-18T16:52:05Z"
-              database_id: storefront
-              entity_id: storefront
-              scope: database
-              status: completed
-              task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
-              type: create
       example:
         tasks:
           - completed_at: "2025-06-18T17:54:36Z"
@@ -16983,7 +17572,20 @@ components:
             $ref: '#/components/schemas/DatabaseSummary'
           description: The databases managed by this cluster.
           example:
-            - created_at: "2025-01-01T01:30:00Z"
+            - available_upgrades:
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+              created_at: "2025-01-01T01:30:00Z"
               id: 02f1a7db-fca8-4521-b57a-2a375c1ced51
               instances:
                 - connection_info:
@@ -17050,42 +17652,23 @@ components:
                   state: modifying
                   status_updated_at: "1976-03-01T20:13:25Z"
                   updated_at: "1996-05-27T17:04:41Z"
-                - connection_info:
-                    addresses:
-                      - 10.24.34.2
-                      - i-0123456789abcdef.ec2.internal
-                    port: 5432
-                  created_at: "1984-01-30T10:40:13Z"
-                  error: 'failed to get patroni status: connection refused'
-                  host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-                  id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-                  node_name: n1
-                  postgres:
-                    patroni_paused: true
-                    patroni_state: unknown
-                    pending_restart: true
-                    role: primary
-                    version: "18.1"
-                  spock:
-                    read_only: "off"
-                    subscriptions:
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                    version: 4.10.0
-                  state: modifying
-                  status_updated_at: "1976-03-01T20:13:25Z"
-                  updated_at: "1996-05-27T17:04:41Z"
-              state: modifying
+              state: backing_up
               tenant_id: 8210ec10-2dca-406c-ac4a-0661d2189954
               updated_at: "2025-01-01T02:30:00Z"
-            - created_at: "2025-01-01T01:30:00Z"
+            - available_upgrades:
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+              created_at: "2025-01-01T01:30:00Z"
               id: 02f1a7db-fca8-4521-b57a-2a375c1ced51
               instances:
                 - connection_info:
@@ -17152,42 +17735,23 @@ components:
                   state: modifying
                   status_updated_at: "1976-03-01T20:13:25Z"
                   updated_at: "1996-05-27T17:04:41Z"
-                - connection_info:
-                    addresses:
-                      - 10.24.34.2
-                      - i-0123456789abcdef.ec2.internal
-                    port: 5432
-                  created_at: "1984-01-30T10:40:13Z"
-                  error: 'failed to get patroni status: connection refused'
-                  host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-                  id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-                  node_name: n1
-                  postgres:
-                    patroni_paused: true
-                    patroni_state: unknown
-                    pending_restart: true
-                    role: primary
-                    version: "18.1"
-                  spock:
-                    read_only: "off"
-                    subscriptions:
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                    version: 4.10.0
-                  state: modifying
-                  status_updated_at: "1976-03-01T20:13:25Z"
-                  updated_at: "1996-05-27T17:04:41Z"
-              state: modifying
+              state: backing_up
               tenant_id: 8210ec10-2dca-406c-ac4a-0661d2189954
               updated_at: "2025-01-01T02:30:00Z"
-            - created_at: "2025-01-01T01:30:00Z"
+            - available_upgrades:
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+                - image: ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1
+                  postgres_version: "17.10"
+                  spock_version: "5"
+              created_at: "2025-01-01T01:30:00Z"
               id: 02f1a7db-fca8-4521-b57a-2a375c1ced51
               instances:
                 - connection_info:
@@ -17254,141 +17818,7 @@ components:
                   state: modifying
                   status_updated_at: "1976-03-01T20:13:25Z"
                   updated_at: "1996-05-27T17:04:41Z"
-                - connection_info:
-                    addresses:
-                      - 10.24.34.2
-                      - i-0123456789abcdef.ec2.internal
-                    port: 5432
-                  created_at: "1984-01-30T10:40:13Z"
-                  error: 'failed to get patroni status: connection refused'
-                  host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-                  id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-                  node_name: n1
-                  postgres:
-                    patroni_paused: true
-                    patroni_state: unknown
-                    pending_restart: true
-                    role: primary
-                    version: "18.1"
-                  spock:
-                    read_only: "off"
-                    subscriptions:
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                    version: 4.10.0
-                  state: modifying
-                  status_updated_at: "1976-03-01T20:13:25Z"
-                  updated_at: "1996-05-27T17:04:41Z"
-              state: modifying
-              tenant_id: 8210ec10-2dca-406c-ac4a-0661d2189954
-              updated_at: "2025-01-01T02:30:00Z"
-            - created_at: "2025-01-01T01:30:00Z"
-              id: 02f1a7db-fca8-4521-b57a-2a375c1ced51
-              instances:
-                - connection_info:
-                    addresses:
-                      - 10.24.34.2
-                      - i-0123456789abcdef.ec2.internal
-                    port: 5432
-                  created_at: "1984-01-30T10:40:13Z"
-                  error: 'failed to get patroni status: connection refused'
-                  host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-                  id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-                  node_name: n1
-                  postgres:
-                    patroni_paused: true
-                    patroni_state: unknown
-                    pending_restart: true
-                    role: primary
-                    version: "18.1"
-                  spock:
-                    read_only: "off"
-                    subscriptions:
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                    version: 4.10.0
-                  state: modifying
-                  status_updated_at: "1976-03-01T20:13:25Z"
-                  updated_at: "1996-05-27T17:04:41Z"
-                - connection_info:
-                    addresses:
-                      - 10.24.34.2
-                      - i-0123456789abcdef.ec2.internal
-                    port: 5432
-                  created_at: "1984-01-30T10:40:13Z"
-                  error: 'failed to get patroni status: connection refused'
-                  host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-                  id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-                  node_name: n1
-                  postgres:
-                    patroni_paused: true
-                    patroni_state: unknown
-                    pending_restart: true
-                    role: primary
-                    version: "18.1"
-                  spock:
-                    read_only: "off"
-                    subscriptions:
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                    version: 4.10.0
-                  state: modifying
-                  status_updated_at: "1976-03-01T20:13:25Z"
-                  updated_at: "1996-05-27T17:04:41Z"
-                - connection_info:
-                    addresses:
-                      - 10.24.34.2
-                      - i-0123456789abcdef.ec2.internal
-                    port: 5432
-                  created_at: "1984-01-30T10:40:13Z"
-                  error: 'failed to get patroni status: connection refused'
-                  host_id: de3b1388-1f0c-42f1-a86c-59ab72f255ec
-                  id: a67cbb36-c3c3-49c9-8aac-f4a0438a883d
-                  node_name: n1
-                  postgres:
-                    patroni_paused: true
-                    patroni_state: unknown
-                    pending_restart: true
-                    role: primary
-                    version: "18.1"
-                  spock:
-                    read_only: "off"
-                    subscriptions:
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                      - name: sub_n1n2
-                        provider_node: n2
-                        status: down
-                    version: 4.10.0
-                  state: modifying
-                  status_updated_at: "1976-03-01T20:13:25Z"
-                  updated_at: "1996-05-27T17:04:41Z"
-              state: modifying
+              state: backing_up
               tenant_id: 8210ec10-2dca-406c-ac4a-0661d2189954
               updated_at: "2025-01-01T02:30:00Z"
       example:
@@ -17978,6 +18408,14 @@ components:
               status: completed
               task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
               type: create
+            - completed_at: "2025-06-18T16:52:35Z"
+              created_at: "2025-06-18T16:52:05Z"
+              database_id: storefront
+              entity_id: storefront
+              scope: database
+              status: completed
+              task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
+              type: create
       example:
         task:
           completed_at: "2025-06-18T16:52:35Z"
@@ -18302,14 +18740,6 @@ components:
             $ref: '#/components/schemas/Task'
           description: The tasks that will restore each database node.
           example:
-            - completed_at: "2025-06-18T16:52:35Z"
-              created_at: "2025-06-18T16:52:05Z"
-              database_id: storefront
-              entity_id: storefront
-              scope: database
-              status: completed
-              task_id: 019783f4-75f4-71e7-85a3-c9b96b345d77
-              type: create
             - completed_at: "2025-06-18T16:52:35Z"
               created_at: "2025-06-18T16:52:05Z"
               database_id: storefront
@@ -18693,7 +19123,7 @@ components:
           type: array
           items:
             type: string
-            example: Quis in sunt dignissimos occaecati cupiditate.
+            example: Dignissimos occaecati cupiditate.
           description: The addresses of the host that's running this service instance.
           example:
             - 10.24.34.2
@@ -18961,6 +19391,7 @@ components:
         host_ids:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
+          - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 512M
         orchestrator_opts:
           swarm:
@@ -18993,7 +19424,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Necessitatibus excepturi reprehenderit.
+            image: Reprehenderit atque aliquid.
         port: 0
         service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
         service_type: rag
@@ -19035,7 +19466,6 @@ components:
             maxLength: 36
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
         memory:
@@ -19118,7 +19548,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         port: 0
         service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
         service_type: rag
@@ -19243,7 +19673,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         port: 0
         service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
         service_type: rag
@@ -19285,7 +19715,6 @@ components:
             maxLength: 36
           description: The IDs of the hosts that should run this service. One service instance will be created per host.
           example:
-            - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
             - 76f9b8c0-4958-11f0-a489-3bb29577c696
           minItems: 1
@@ -19337,7 +19766,6 @@ components:
         host_ids:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
-          - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 512M
         orchestrator_opts:
           swarm:
@@ -19370,7 +19798,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Quia reiciendis et odio omnis itaque cum.
+            image: Et odio.
         port: 0
         service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
         service_type: rag
@@ -19462,6 +19890,8 @@ components:
           target_session_attrs: primary
         host_ids:
           - 76f9b8c0-4958-11f0-a489-3bb29577c696
+          - 76f9b8c0-4958-11f0-a489-3bb29577c696
+          - 76f9b8c0-4958-11f0-a489-3bb29577c696
         memory: 512M
         orchestrator_opts:
           swarm:
@@ -19494,7 +19924,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         port: 0
         service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
         service_type: rag
@@ -19617,7 +20047,7 @@ components:
                 host_path: /Users/user/backups/host
               - destination_path: /backups/container
                 host_path: /Users/user/backups/host
-            image: Dignissimos incidunt in quas totam eveniet possimus.
+            image: Incidunt in quas totam.
         port: 0
         service_id: 76f9b8c0-4958-11f0-a489-3bb29577c696
         service_type: rag

--- a/client/single.go
+++ b/client/single.go
@@ -115,7 +115,7 @@ func (c *SingleServerClient) RemoveHost(ctx context.Context, req *api.RemoveHost
 }
 
 func (c *SingleServerClient) ListDatabases(ctx context.Context) (*api.ListDatabasesResponse, error) {
-	resp, err := c.api.ListDatabases(ctx)
+	resp, err := c.api.ListDatabases(ctx, &api.ListDatabasesPayload{})
 	return resp, translateErr(err)
 }
 

--- a/server/internal/api/apiv1/convert.go
+++ b/server/internal/api/apiv1/convert.go
@@ -1196,3 +1196,26 @@ func parseScope(scopeStr string) (task.Scope, error) {
 		return "", fmt.Errorf("invalid scope %q", scopeStr)
 	}
 }
+
+// includesAvailableUpgrades reports whether the include list contains the
+// "available_upgrades" token.
+func includesAvailableUpgrades(include []string) bool {
+	return slices.Contains(include, "available_upgrades")
+}
+
+// availableUpgradesToAPI converts database-layer upgrade entries to their API
+// representation.
+func availableUpgradesToAPI(upgrades []*database.AvailableUpgrade) []*api.AvailableUpgrade {
+	if len(upgrades) == 0 {
+		return nil
+	}
+	out := make([]*api.AvailableUpgrade, len(upgrades))
+	for i, u := range upgrades {
+		out[i] = &api.AvailableUpgrade{
+			PostgresVersion: u.PostgresVersion,
+			SpockVersion:    u.SpockVersion,
+			Image:           u.Image,
+		}
+	}
+	return out
+}

--- a/server/internal/api/apiv1/post_init_handlers.go
+++ b/server/internal/api/apiv1/post_init_handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pgEdge/control-plane/server/internal/cluster"
 	"github.com/pgEdge/control-plane/server/internal/config"
 	"github.com/pgEdge/control-plane/server/internal/database"
+	"github.com/pgEdge/control-plane/server/internal/ds"
 	"github.com/pgEdge/control-plane/server/internal/etcd"
 	"github.com/pgEdge/control-plane/server/internal/host"
 	"github.com/pgEdge/control-plane/server/internal/pgbackrest"
@@ -268,7 +269,7 @@ func (s *PostInitHandlers) prepareDatabaseUpdates(ctx context.Context, hostID st
 }
 
 // ListDatabases fetches all databases from the database service and converts them to API format.
-func (s *PostInitHandlers) ListDatabases(ctx context.Context) (*api.ListDatabasesResponse, error) {
+func (s *PostInitHandlers) ListDatabases(ctx context.Context, req *api.ListDatabasesPayload) (*api.ListDatabasesResponse, error) {
 	// Fetch databases from the database service
 	databases, err := s.dbSvc.GetDatabases(ctx)
 	if err != nil {
@@ -287,7 +288,18 @@ func (s *PostInitHandlers) ListDatabases(ctx context.Context) (*api.ListDatabase
 	for _, db := range databases {
 		apiDB := databaseToSummaryAPI(db)
 		if apiDB != nil {
-			// Only append non-nil API databases
+			if includesAvailableUpgrades(req.Include) {
+				if version, err := ds.ParsePgEdgeVersion(db.Spec.PostgresVersion, db.Spec.SpockVersion); err == nil {
+					apiDB.AvailableUpgrades = availableUpgradesToAPI(s.dbSvc.AvailableUpgrades(version))
+				} else {
+					s.logger.Warn().
+						Str("database_id", db.DatabaseID).
+						Str("postgres_version", db.Spec.PostgresVersion).
+						Str("spock_version", db.Spec.SpockVersion).
+						Err(err).
+						Msg("could not parse database version for available_upgrades")
+				}
+			}
 			apiDatabases = append(apiDatabases, apiDB)
 		}
 	}
@@ -349,7 +361,20 @@ func (s *PostInitHandlers) GetDatabase(ctx context.Context, req *api.GetDatabase
 		return nil, apiErr(err)
 	}
 
-	return databaseToAPI(db), nil
+	result := databaseToAPI(db)
+	if includesAvailableUpgrades(req.Include) {
+		if version, err := ds.ParsePgEdgeVersion(db.Spec.PostgresVersion, db.Spec.SpockVersion); err == nil {
+			result.AvailableUpgrades = availableUpgradesToAPI(s.dbSvc.AvailableUpgrades(version))
+		} else {
+			s.logger.Warn().
+				Str("database_id", databaseID).
+				Str("postgres_version", db.Spec.PostgresVersion).
+				Str("spock_version", db.Spec.SpockVersion).
+				Err(err).
+				Msg("could not parse database version for available_upgrades")
+		}
+	}
+	return result, nil
 }
 
 func (s *PostInitHandlers) UpdateDatabase(ctx context.Context, req *api.UpdateDatabasePayload) (*api.UpdateDatabaseResponse, error) {

--- a/server/internal/api/apiv1/pre_init_handlers.go
+++ b/server/internal/api/apiv1/pre_init_handlers.go
@@ -193,7 +193,7 @@ func (s *PreInitHandlers) RemoveHost(ctx context.Context, req *api.RemoveHostPay
 	return nil, ErrUninitialized
 }
 
-func (s *PreInitHandlers) ListDatabases(ctx context.Context) (*api.ListDatabasesResponse, error) {
+func (s *PreInitHandlers) ListDatabases(ctx context.Context, _ *api.ListDatabasesPayload) (*api.ListDatabasesResponse, error) {
 	return nil, ErrUninitialized
 }
 

--- a/server/internal/database/orchestrator.go
+++ b/server/internal/database/orchestrator.go
@@ -190,4 +190,16 @@ type Orchestrator interface {
 	// reconciliation to resolve and pin the container image. old is nil when
 	// the service instance is being created for the first time.
 	ReconcileServiceInstanceSpec(old, new *ServiceInstanceSpec) error
+	// AvailableUpgrades returns newer stable manifest entries in the same
+	// (postgres_major, spock_major) bucket as current. Returns nil when
+	// upgrade discovery is not applicable (e.g. systemd orchestrator).
+	AvailableUpgrades(current *ds.PgEdgeVersion) []*AvailableUpgrade
+}
+
+// AvailableUpgrade describes a single candidate image upgrade available for a
+// database running in the same (postgres_major, spock_major) bucket.
+type AvailableUpgrade struct {
+	PostgresVersion string `json:"postgres_version"`
+	SpockVersion    string `json:"spock_version"`
+	Image           string `json:"image"`
 }

--- a/server/internal/database/service.go
+++ b/server/internal/database/service.go
@@ -747,6 +747,12 @@ func (s *Service) DeleteInstanceSpec(ctx context.Context, databaseID, instanceID
 	return nil
 }
 
+// AvailableUpgrades returns newer stable manifest entries in the same
+// (postgres_major, spock_major) bucket as the given version.
+func (s *Service) AvailableUpgrades(current *ds.PgEdgeVersion) []*AvailableUpgrade {
+	return s.orchestrator.AvailableUpgrades(current)
+}
+
 func (s *Service) ReconcileServiceInstanceSpec(ctx context.Context, spec *ServiceInstanceSpec) (*ServiceInstanceSpec, error) {
 	if s.cfg.HostID != spec.HostID {
 		return nil, fmt.Errorf("this service instance belongs to another host - this host='%s', service instance host='%s'", s.cfg.HostID, spec.HostID)

--- a/server/internal/orchestrator/swarm/available_upgrades_test.go
+++ b/server/internal/orchestrator/swarm/available_upgrades_test.go
@@ -1,0 +1,79 @@
+package swarm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pgEdge/control-plane/server/internal/config"
+	"github.com/pgEdge/control-plane/server/internal/ds"
+)
+
+func TestVersions_AvailableUpgrades(t *testing.T) {
+	cfg := config.Config{
+		DockerSwarm: config.DockerSwarm{
+			ImageRepositoryHost: "ghcr.io/pgedge",
+		},
+	}
+	v := NewVersions(cfg)
+
+	t.Run("returns newer entries in same bucket", func(t *testing.T) {
+		current := ds.MustParsePgEdgeVersion("17.9", "5")
+		upgrades := v.AvailableUpgrades(current)
+		assert.NotEmpty(t, upgrades)
+		for _, u := range upgrades {
+			assert.Equal(t, "17", ds.MustParseVersion(u.PostgresVersion).MajorVersion().String())
+			assert.Equal(t, "5", ds.MustParseVersion(u.SpockVersion).MajorVersion().String())
+			cmp := ds.MustParseVersion(u.PostgresVersion).Compare(current.PostgresVersion)
+			assert.Greater(t, cmp, 0, "upgrade %s must be newer than current 17.9", u.PostgresVersion)
+		}
+	})
+
+	t.Run("excludes entries from different postgres major", func(t *testing.T) {
+		current := ds.MustParsePgEdgeVersion("17.9", "5")
+		upgrades := v.AvailableUpgrades(current)
+		for _, u := range upgrades {
+			assert.NotContains(t, u.PostgresVersion, "16.", "should not include pg16 entries")
+			assert.NotContains(t, u.PostgresVersion, "18.", "should not include pg18 entries")
+		}
+	})
+
+	t.Run("returns nil when no newer entries exist (already at latest)", func(t *testing.T) {
+		// 18.4 is the newest in pg18 bucket — no upgrades available
+		current := ds.MustParsePgEdgeVersion("18.4", "5")
+		upgrades := v.AvailableUpgrades(current)
+		assert.Nil(t, upgrades)
+	})
+
+	t.Run("returns nil for nil current version", func(t *testing.T) {
+		assert.Nil(t, v.AvailableUpgrades(nil))
+	})
+
+	t.Run("dev stability entries are excluded", func(t *testing.T) {
+		devVersions := &Versions{
+			cfg:    cfg,
+			images: make(map[string]map[string]*Images),
+		}
+		devVersions.addImage(ds.MustParsePgEdgeVersion("17.9", "5"), &Images{
+			PgEdgeImage: "ghcr.io/pgedge/pgedge-postgres:17.9-spock5.0.6-standard-2",
+			Stability:   "stable",
+		})
+		devVersions.addImage(ds.MustParsePgEdgeVersion("17.10", "5"), &Images{
+			PgEdgeImage: "ghcr.io/pgedge/pgedge-postgres:17.10-rc1-spock5.0.7-dev-1",
+			Stability:   "dev",
+		})
+
+		current := ds.MustParsePgEdgeVersion("17.9", "5")
+		upgrades := devVersions.AvailableUpgrades(current)
+		assert.Nil(t, upgrades, "dev entries must not appear as available upgrades")
+	})
+
+	t.Run("image field is populated", func(t *testing.T) {
+		current := ds.MustParsePgEdgeVersion("17.9", "5")
+		upgrades := v.AvailableUpgrades(current)
+		for _, u := range upgrades {
+			assert.NotEmpty(t, u.Image, "upgrade entry must have an image")
+			assert.Contains(t, u.Image, "ghcr.io/pgedge")
+		}
+	})
+}

--- a/server/internal/orchestrator/swarm/images.go
+++ b/server/internal/orchestrator/swarm/images.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 
 	"github.com/pgEdge/control-plane/server/internal/config"
+	"github.com/pgEdge/control-plane/server/internal/database"
 	"github.com/pgEdge/control-plane/server/internal/ds"
 )
 
 type Images struct {
 	PgEdgeImage string
+	// Stability is "stable" or "dev". Empty string is treated as "stable".
+	Stability string
 }
 
 type Versions struct {
@@ -119,4 +122,49 @@ func (v Versions) GetImages(version *ds.PgEdgeVersion) (*Images, error) {
 
 func imageTag(cfg config.Config, tag string) string {
 	return fmt.Sprintf("%s/pgedge-postgres:%s", cfg.DockerSwarm.ImageRepositoryHost, tag)
+}
+
+// AvailableUpgrades returns all newer stable manifest entries in the same
+// (postgres_major, spock_major) bucket as current. Returns nil when current is
+// nil or no newer entries exist.
+func (v *Versions) AvailableUpgrades(current *ds.PgEdgeVersion) []*database.AvailableUpgrade {
+	if current == nil {
+		return nil
+	}
+	currentPGMajor, ok := current.PostgresVersion.Major()
+	if !ok {
+		return nil
+	}
+	currentSpockMajor, ok := current.SpockVersion.Major()
+	if !ok {
+		return nil
+	}
+
+	var upgrades []*database.AvailableUpgrade
+	for _, ver := range v.supportedVersions {
+		pgMajor, ok := ver.PostgresVersion.Major()
+		if !ok || pgMajor != currentPGMajor {
+			continue
+		}
+		spockMajor, ok := ver.SpockVersion.Major()
+		if !ok || spockMajor != currentSpockMajor {
+			continue
+		}
+		if ver.PostgresVersion.Compare(current.PostgresVersion) <= 0 {
+			continue
+		}
+		img, err := v.GetImages(ver)
+		if err != nil {
+			continue
+		}
+		if img.Stability != "" && img.Stability != "stable" {
+			continue
+		}
+		upgrades = append(upgrades, &database.AvailableUpgrade{
+			PostgresVersion: ver.PostgresVersion.String(),
+			SpockVersion:    ver.SpockVersion.String(),
+			Image:           img.PgEdgeImage,
+		})
+	}
+	return upgrades
 }

--- a/server/internal/orchestrator/swarm/orchestrator.go
+++ b/server/internal/orchestrator/swarm/orchestrator.go
@@ -306,6 +306,10 @@ func (o *Orchestrator) ReconcileServiceInstanceSpec(old, new *database.ServiceIn
 	return err
 }
 
+func (o *Orchestrator) AvailableUpgrades(current *ds.PgEdgeVersion) []*database.AvailableUpgrade {
+	return o.versions.AvailableUpgrades(current)
+}
+
 func (o *Orchestrator) instanceResources(spec *database.InstanceSpec, scripts database.Scripts) (*database.InstanceResource, []resource.Resource, []resource.Resource, error) {
 	images, err := o.resolveInstanceImages(spec)
 	if err != nil {

--- a/server/internal/orchestrator/systemd/orchestrator.go
+++ b/server/internal/orchestrator/systemd/orchestrator.go
@@ -155,6 +155,10 @@ func (o *Orchestrator) ReconcileServiceInstanceSpec(_, _ *database.ServiceInstan
 	return nil
 }
 
+func (o *Orchestrator) AvailableUpgrades(_ *ds.PgEdgeVersion) []*database.AvailableUpgrade {
+	return nil
+}
+
 func (o *Orchestrator) GenerateInstanceResources(spec *database.InstanceSpec, scripts database.Scripts) (*database.InstanceResources, error) {
 	paths, err := o.InstancePaths(spec.PgEdgeVersion.PostgresVersion, spec.InstanceID)
 	if err != nil {


### PR DESCRIPTION

## Summary
This PR adds support for the optional `?include=available_upgrades` query parameter to `GET /v1/databases/{id}` and `GET /v1/databases`. When specified, the response includes an `available_upgrades` field for each database, listing newer stable manifest versions available within the same `(postgres_major, spock_major)` compatibility bucket as the database's current version.


## Changes

- `orchestrator/swarm/images.go`: Added `Stability` field to `Images` struct; added `AvailableUpgrades()` method to `*Versions` that scans the manifest for newer stable entries in the same `(postgres_major, spock_major)` bucket using `ds.Version.Compare`
- `orchestrator/swarm/manifest_loader.go`: `buildVersions` now propagates `Stability` from manifest JSON into `Images.Stability`
- `database/orchestrator.go`: Added `AvailableUpgrade` struct and `AvailableUpgrades` method to the `Orchestrator` interface
- `orchestrator/swarm/orchestrator.go`: Implements `AvailableUpgrades` delegating to `o.versions`
- `orchestrator/systemd/orchestrator.go`: No-op `AvailableUpgrades` returning `nil`
- `database/service.go`: Exposes `AvailableUpgrades` so handlers don't need direct orchestrator access
- `api/apiv1/design/api.go` + `database.go`: Added `AvailableUpgrade` Goa type, `available_upgrades` field on `Database`/`DatabaseSummary`, `include` query param on both endpoints; regenerated API layer
- `api/apiv1/post_init_handlers.go`: Computes and sets `available_upgrades` when `include=available_upgrades` is present
- `api/apiv1/convert.go`: Added `includesAvailableUpgrades` and `availableUpgradesToAPI` helpers
- `client/single.go`: Passes empty payload to `ListDatabases` — client interface unchanged


## Testing
Verification:
1. Created Cluster
2. Created DB using 
` cp1-req create-database < ../demo/Images/create_db_for_upgrade.json `
3. Without the param: `available_upgrades` must be 
```
cp1-req get-database storefront | jq 'has("available_upgrades")'
# → false

false
```
4. With the param: upgrades list appears
```
cp1-req get-database storefront --rsh-query include=available_upgrades \
  | jq .available_upgrades

[
  {
    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.8-standard-1",
    "postgres_version": "17.10",
    "spock_version": "5"
  }
]
```
```
cp1-req list-databases --rsh-query include=available_upgrades \
  | jq '.databases[0].available_upgrades'

[
  {
    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.8-standard-1",
    "postgres_version": "17.10",
    "spock_version": "5"
  }
]
```
5. At latest version: empty list

```
cp1-req create-database < ../demo/Images/create_db_with_no_image.json   
HTTP/1.1 200 OK
Content-Length: 590
Content-Type: application/json
Date: Thu, 18 Jun 2026 14:19:46 GMT

{
  database: {
    created_at: "2026-06-18T14:19:46Z"
    id: "storefront-no-image"
    spec: {
      database_name: "storefront"
      database_users: [
        {
          attributes: ["SUPERUSER", "LOGIN"]
          db_owner: true
          username: "admin"
        }
      ]
      nodes: [
        {
          host_ids: ["host-1", "host-2", "host-3"]
          name: "n1"
        }
      ]
      postgres_version: "18.4"
      spock_version: "5"
    }
    state: "creating"
    updated_at: "2026-06-18T14:19:46Z"
  }
  task: {
    created_at: "2026-06-18T14:19:46Z"
    database_id: "storefront-no-image"
    entity_id: "storefront-no-image"
    scope: "database"
    status: "pending"
    task_id: "019edb1a-2ddd-709f-a8bc-7a3c615b9c90"
    type: "create"
  }
}
```

```
cp1-req list-databases --rsh-query include=available_upgrades \
  | jq '.databases[1].available_upgrades'

null
```

## Checklist

- [x] Tests added or updated (unit and/or e2e, as needed)

[PLAT-602](https://pgedge.atlassian.net/browse/PLAT-602)

[PLAT-602]: https://pgedge.atlassian.net/browse/PLAT-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ