### PR TITLE
fix: reject KB path that points to a directory

### DIFF
--- a/server/internal/orchestrator/swarm/mcp_config_resource.go
+++ b/server/internal/orchestrator/swarm/mcp_config_resource.go
@@ -99,9 +99,9 @@ func (r *MCPConfigResource) Refresh(ctx context.Context, rc *resource.Context) e
 }
 
 // checkKBFileExists blocks deployment when kb_enabled is set but the host
-// KB file is missing. Called from Create and Update — not Refresh, because
-// Refresh is only invoked for resources already in state, so a check there
-// would not fire on first deploy.
+// KB file is missing or is not a regular file. Called from Create and Update —
+// not Refresh, because Refresh is only invoked for resources already in state,
+// so a check there would not fire on first deploy.
 func (r *MCPConfigResource) checkKBFileExists(fs afero.Fs) error {
 	if r.KBHostPath == "" {
 		return nil
@@ -112,6 +112,16 @@ func (r *MCPConfigResource) checkKBFileExists(fs afero.Fs) error {
 	}
 	if !exists {
 		return fmt.Errorf("KB database file not found at %s — stage the file on the host before deploying with kb_enabled: true", r.KBHostPath)
+	}
+	// A directory passes the existence check above but cannot be opened as a
+	// SQLite database, which would only surface as a confusing error at query
+	// time. Reject it here so the failure is clear at deploy time.
+	isDir, err := afero.IsDir(fs, r.KBHostPath)
+	if err != nil {
+		return fmt.Errorf("failed to check KB database file at %s: %w", r.KBHostPath, err)
+	}
+	if isDir {
+		return fmt.Errorf("KB database path %s is a directory, not a file — kb_database_host_path must point to the KB SQLite file", r.KBHostPath)
 	}
 	return nil
 }

--- a/server/internal/orchestrator/swarm/mcp_config_resource_test.go
+++ b/server/internal/orchestrator/swarm/mcp_config_resource_test.go
@@ -141,6 +141,30 @@ func TestMCPConfigResource_Create_KBFileMissing(t *testing.T) {
 	assert.False(t, errors.Is(err, resource.ErrNotFound), "missing KB file must not return ErrNotFound")
 }
 
+func TestMCPConfigResource_Create_KBPathIsDirectory(t *testing.T) {
+	// KBHostPath points to a directory → blocked at deploy time, since a
+	// directory cannot be opened as a SQLite database. Without this check the
+	// error would only surface as a confusing failure at query time.
+	dirID := "inst-data"
+	dirPath := "/var/lib/pgedge/services/inst-kb-dir"
+	kbPath := "/var/lib/pgedge/kb" // a directory, not a file
+	rc, fs := mcpRCAndFs(t, dirID, dirPath)
+
+	require.NoError(t, fs.MkdirAll(kbPath, 0o700))
+
+	r := &MCPConfigResource{
+		ServiceInstanceID: "inst-kb-dir",
+		HostID:            "host-1",
+		DirResourceID:     dirID,
+		Config:            &database.MCPServiceConfig{},
+		KBHostPath:        kbPath,
+	}
+	err := r.Create(context.Background(), rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is a directory")
+	assert.False(t, errors.Is(err, resource.ErrNotFound), "a directory KB path must not return ErrNotFound")
+}
+
 func TestMCPConfigResource_Update_KBFileMissing(t *testing.T) {
 	// KBHostPath set but file does not exist on the update path → blocked.
 	dirID := "inst-data"


### PR DESCRIPTION

The MCP knowledgebase config has a `kb_database_host_path` field that should point to the KB SQLite file. If you accidentally pointed it at a directory, the Control Plane didn't catch it — the deploy succeeded and the service only failed later when you ran a search ("unable to open database file").

This adds a check at deploy time: if `kb_database_host_path` is a directory, the deploy now fails right away with a clear message telling you it must point to the KB file. Added a test for it.

[plat-662](https://pgedge.atlassian.net/browse/PLAT-662)