### PR TITLE
chore: support IPv6 fallback in IP autodetection

### DIFF
--- a/server/internal/api/http.go
+++ b/server/internal/api/http.go
@@ -6,8 +6,10 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/pgEdge/control-plane/server/internal/config"
 	"github.com/rs/zerolog"
@@ -31,7 +33,7 @@ func newHTTPServer(
 		errCh:  make(chan error, 1),
 		server: &http.Server{
 			Handler: handler,
-			Addr:    fmt.Sprintf("%s:%d", cfg.BindAddr, cfg.Port),
+			Addr:    net.JoinHostPort(cfg.BindAddr, strconv.Itoa(cfg.Port)),
 		},
 	}
 }

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -433,12 +433,13 @@ func defaultAddresses() ([]string, error) {
 	return []string{ip.String()}, nil
 }
 
-// getFirstIP gets the first non-loopback IPv4 address
+// getFirstIP gets the first non-loopback IP address, preferring IPv4.
 func getFirstIP() (net.IP, error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {
 		return net.IPv4zero, fmt.Errorf("failed to list interfaces: %w", err)
 	}
+	var ipv6 net.IP
 	for _, iface := range interfaces {
 		// Skip loopback and down interfaces
 		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
@@ -448,7 +449,6 @@ func getFirstIP() (net.IP, error) {
 		if err != nil {
 			continue
 		}
-
 		for _, addr := range addrs {
 			var ip net.IP
 			switch v := addr.(type) {
@@ -458,20 +458,23 @@ func getFirstIP() (net.IP, error) {
 				ip = v.IP
 			}
 
-			// Check if it is a valid IPv4 address and not a loopback address
+			// Check if it is a valid address and not a loopback address
 			if ip == nil || ip.IsLoopback() {
 				continue
 			}
 
 			// To4() returns nil if the IP is not an IPv4 address
-			ip = ip.To4()
-			if ip == nil {
-				continue
+			if v4 := ip.To4(); v4 != nil {
+				return v4, nil
 			}
-
-			// Return the first valid IPv4 address found
-			return ip, nil
+			// Store first IPv6 address found, keep searching for IPv4
+			if ipv6 == nil {
+				ipv6 = ip.To16()
+			}
 		}
+	}
+	if ipv6 != nil {
+		return ipv6, nil
 	}
 
 	return net.IPv4zero, fmt.Errorf("could not find a valid network interface")

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -458,8 +458,8 @@ func getFirstIP() (net.IP, error) {
 				ip = v.IP
 			}
 
-			// Check if it is a valid address and not a loopback address
-			if ip == nil || ip.IsLoopback() {
+			// Check if it is a valid, routable address
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
 				continue
 			}
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -151,9 +151,6 @@ func (h HTTP) validate() []error {
 		return nil
 	}
 	var errs []error
-	if h.BindAddr == "" {
-		errs = append(errs, errors.New("bind_addr cannot be empty"))
-	}
 	if h.Port == 0 {
 		errs = append(errs, errors.New("port cannot be empty"))
 	}
@@ -161,9 +158,8 @@ func (h HTTP) validate() []error {
 }
 
 var httpDefault = HTTP{
-	Enabled:  true,
-	BindAddr: "0.0.0.0",
-	Port:     3000,
+	Enabled: true,
+	Port:    3000,
 }
 
 type EtcdServer struct {

--- a/server/internal/etcd/embedded.go
+++ b/server/internal/etcd/embedded.go
@@ -669,14 +669,12 @@ func embedConfig(cfg config.Config, logger zerolog.Logger) (*embed.Config, error
 
 	clientPort := cfg.EtcdServer.ClientPort
 	peerPort := cfg.EtcdServer.PeerPort
-	// Use :: on IPv6/dual-stack hosts (dual-stack socket via IPV6_V6ONLY=0 on Linux).
-	// Fall back to 0.0.0.0 on IPv4-only hosts where :: may not be available.
-	wildcard := "0.0.0.0"
-	if len(cfg.PeerAddresses) > 0 {
-		if ip := net.ParseIP(cfg.PeerAddresses[0]); ip != nil && ip.To4() == nil {
-			wildcard = "::"
-		}
+
+	wildcard, err := utils.GetBindAddr()
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect bind address: %w", err)
 	}
+
 	c.ListenClientUrls = []url.URL{
 		{Scheme: "https", Host: net.JoinHostPort(wildcard, strconv.Itoa(clientPort))},
 	}
@@ -724,11 +722,6 @@ func initializationConfig(cfg config.Config, logger zerolog.Logger) (*embed.Conf
 	clientPort := cfg.EtcdServer.ClientPort
 	peerPort := cfg.EtcdServer.PeerPort
 	loopback := "127.0.0.1"
-	if len(cfg.PeerAddresses) > 0 {
-		if ip := net.ParseIP(cfg.PeerAddresses[0]); ip != nil && ip.To4() == nil {
-			loopback = "::1"
-		}
-	}
 
 	c.ListenClientUrls = []url.URL{
 		{Scheme: "http", Host: net.JoinHostPort(loopback, strconv.Itoa(clientPort))},

--- a/server/internal/etcd/embedded.go
+++ b/server/internal/etcd/embedded.go
@@ -670,11 +670,14 @@ func embedConfig(cfg config.Config, logger zerolog.Logger) (*embed.Config, error
 	clientPort := cfg.EtcdServer.ClientPort
 	peerPort := cfg.EtcdServer.PeerPort
 	c.ListenClientUrls = []url.URL{
-		{Scheme: "https", Host: fmt.Sprintf("0.0.0.0:%d", clientPort)},
+		{Scheme: "https", Host: net.JoinHostPort("0.0.0.0", strconv.Itoa(clientPort))},
+		{Scheme: "https", Host: net.JoinHostPort("::", strconv.Itoa(clientPort))},
 	}
 	c.ListenPeerUrls = []url.URL{
-		{Scheme: "https", Host: fmt.Sprintf("0.0.0.0:%d", peerPort)},
+		{Scheme: "https", Host: net.JoinHostPort("0.0.0.0", strconv.Itoa(peerPort))},
+		{Scheme: "https", Host: net.JoinHostPort("::", strconv.Itoa(peerPort))},
 	}
+
 	clientURLs := make([]url.URL, len(cfg.PeerAddresses))
 	peerURLs := make([]url.URL, len(cfg.PeerAddresses))
 	for i, address := range cfg.PeerAddresses {
@@ -714,22 +717,30 @@ func initializationConfig(cfg config.Config, logger zerolog.Logger) (*embed.Conf
 	// Only bind/advertise localhost for initialization
 	clientPort := cfg.EtcdServer.ClientPort
 	peerPort := cfg.EtcdServer.PeerPort
+	loopback := "127.0.0.1"
+	if len(cfg.PeerAddresses) > 0 {
+		if ip := net.ParseIP(cfg.PeerAddresses[0]); ip != nil && ip.To4() == nil {
+			loopback = "::1"
+		}
+	}
+
 	c.ListenClientUrls = []url.URL{
-		{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", clientPort)},
+		{Scheme: "http", Host: net.JoinHostPort(loopback, strconv.Itoa(clientPort))},
 	}
 	c.AdvertiseClientUrls = []url.URL{
-		{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", clientPort)},
+		{Scheme: "http", Host: net.JoinHostPort(loopback, strconv.Itoa(clientPort))},
 	}
+
 	c.ListenPeerUrls = []url.URL{
-		{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", peerPort)},
+		{Scheme: "http", Host: net.JoinHostPort(loopback, strconv.Itoa(peerPort))},
 	}
 	c.AdvertisePeerUrls = []url.URL{
-		{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", peerPort)},
+		{Scheme: "http", Host: net.JoinHostPort(loopback, strconv.Itoa(peerPort))},
 	}
 	c.InitialCluster = fmt.Sprintf(
-		"%s=http://127.0.0.1:%d",
+		"%s=http://%s",
 		cfg.HostID,
-		cfg.EtcdServer.PeerPort,
+		net.JoinHostPort(loopback, strconv.Itoa(cfg.EtcdServer.PeerPort)),
 	)
 	c.QuotaBackendBytes = quotaBackendBytes
 

--- a/server/internal/etcd/embedded.go
+++ b/server/internal/etcd/embedded.go
@@ -669,13 +669,19 @@ func embedConfig(cfg config.Config, logger zerolog.Logger) (*embed.Config, error
 
 	clientPort := cfg.EtcdServer.ClientPort
 	peerPort := cfg.EtcdServer.PeerPort
+	// Use :: on IPv6/dual-stack hosts (dual-stack socket via IPV6_V6ONLY=0 on Linux).
+	// Fall back to 0.0.0.0 on IPv4-only hosts where :: may not be available.
+	wildcard := "0.0.0.0"
+	if len(cfg.PeerAddresses) > 0 {
+		if ip := net.ParseIP(cfg.PeerAddresses[0]); ip != nil && ip.To4() == nil {
+			wildcard = "::"
+		}
+	}
 	c.ListenClientUrls = []url.URL{
-		{Scheme: "https", Host: net.JoinHostPort("0.0.0.0", strconv.Itoa(clientPort))},
-		{Scheme: "https", Host: net.JoinHostPort("::", strconv.Itoa(clientPort))},
+		{Scheme: "https", Host: net.JoinHostPort(wildcard, strconv.Itoa(clientPort))},
 	}
 	c.ListenPeerUrls = []url.URL{
-		{Scheme: "https", Host: net.JoinHostPort("0.0.0.0", strconv.Itoa(peerPort))},
-		{Scheme: "https", Host: net.JoinHostPort("::", strconv.Itoa(peerPort))},
+		{Scheme: "https", Host: net.JoinHostPort(wildcard, strconv.Itoa(peerPort))},
 	}
 
 	clientURLs := make([]url.URL, len(cfg.PeerAddresses))

--- a/server/internal/etcd/rbac.go
+++ b/server/internal/etcd/rbac.go
@@ -365,7 +365,7 @@ func addEtcdServerCredentials(
 ) error {
 	// Ensure that localhost is included in the addresses
 	combined := ds.NewSet(addresses...)
-	combined.Add("127.0.0.1", "localhost")
+	combined.Add("127.0.0.1", "localhost", "::1")
 
 	// Create a cert for the peer server
 	serverPrincipal, err := certSvc.EtcdServer(ctx,

--- a/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/enable_fast_basebackup.yaml
+++ b/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/enable_fast_basebackup.yaml
@@ -115,7 +115,7 @@ postgresql:
   - checkpoint: fast
 restapi:
   connect_address: storefront-n1-689qacsi.storefront-database:8888
-  listen: 0.0.0.0:8888
+  listen: :8888
   allowlist:
   - 10.10.0.2
   - 10.10.0.3

--- a/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/in-place_restore.yaml
+++ b/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/in-place_restore.yaml
@@ -118,7 +118,7 @@ postgresql:
   remove_data_directory_on_diverged_timelines: true
 restapi:
   connect_address: storefront-n1-689qacsi.storefront-database:8888
-  listen: 0.0.0.0:8888
+  listen: :8888
   allowlist:
   - 172.17.0.1/32
   - 10.128.165.128/26

--- a/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/minimal_swarm.yaml
+++ b/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/minimal_swarm.yaml
@@ -113,7 +113,7 @@ postgresql:
   remove_data_directory_on_diverged_timelines: true
 restapi:
   connect_address: storefront-n1-689qacsi.storefront-database:8888
-  listen: 0.0.0.0:8888
+  listen: :8888
   allowlist:
   - 172.17.0.1/32
   - 10.128.165.128/26

--- a/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/minimal_systemd.yaml
+++ b/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/minimal_systemd.yaml
@@ -113,7 +113,7 @@ postgresql:
   remove_data_directory_on_diverged_timelines: true
 restapi:
   connect_address: storefront-n1-689qacsi.storefront-database:8888
-  listen: 0.0.0.0:8888
+  listen: :8888
   allowlist:
   - 10.10.0.2
   - 10.10.0.3

--- a/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/user_pg_hba_pg_ident_and_scram.yaml
+++ b/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/user_pg_hba_pg_ident_and_scram.yaml
@@ -115,7 +115,7 @@ postgresql:
   remove_data_directory_on_diverged_timelines: true
 restapi:
   connect_address: pghba-n1-689qacsi.pghba-database:8888
-  listen: 0.0.0.0:8888
+  listen: :8888
   allowlist:
   - 172.17.0.1/32
   - 10.128.165.128/26

--- a/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/with_backup_config.yaml
+++ b/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/with_backup_config.yaml
@@ -113,7 +113,7 @@ postgresql:
   remove_data_directory_on_diverged_timelines: true
 restapi:
   connect_address: storefront-n1-689qacsi.storefront-database:8888
-  listen: 0.0.0.0:8888
+  listen: :8888
   allowlist:
   - 172.17.0.1/32
   - 10.128.165.128/26

--- a/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/with_restore_config.yaml
+++ b/server/internal/orchestrator/common/golden_test/TestPatroniConfigGenerator/with_restore_config.yaml
@@ -118,7 +118,7 @@ postgresql:
   remove_data_directory_on_diverged_timelines: true
 restapi:
   connect_address: storefront-n1-689qacsi.storefront-database:8888
-  listen: 0.0.0.0:8888
+  listen: :8888
   allowlist:
   - 172.17.0.1/32
   - 10.128.165.128/26

--- a/server/internal/orchestrator/common/patroni_config_generator.go
+++ b/server/internal/orchestrator/common/patroni_config_generator.go
@@ -306,7 +306,7 @@ func (p *PatroniConfigGenerator) restAPI(systemAddresses []string) *patroni.Rest
 
 	return &patroni.RestAPI{
 		ConnectAddress: utils.PointerTo(net.JoinHostPort(p.FQDN, strconv.Itoa(p.PatroniPort))),
-		Listen:         utils.PointerTo(fmt.Sprintf("0.0.0.0:%d", p.PatroniPort)),
+		Listen:         utils.PointerTo(fmt.Sprintf(":%d", p.PatroniPort)),
 		Allowlist:      combined,
 	}
 }

--- a/server/internal/utils/utils.go
+++ b/server/internal/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net"
 	"path"
 	"regexp"
 	"slices"
@@ -153,6 +154,43 @@ func BuildOptionArgs(options map[string]string) []string {
 		res = append(res, prefix+k+"="+v)
 	}
 	return res
+}
+
+// GetBindAddr returns the wildcard address to bind listeners on this host.
+// Returns "::" when a routable IPv6 address is present otherwise "0.0.0.0".
+func GetBindAddr() (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", fmt.Errorf("failed to list interfaces: %w", err)
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+				continue
+			}
+			if ip.To4() == nil {
+				return "::", nil
+			}
+		}
+	}
+	return "0.0.0.0", nil
 }
 
 var idPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,34}[a-z0-9])?$`)

--- a/server/internal/utils/utils.go
+++ b/server/internal/utils/utils.go
@@ -185,7 +185,7 @@ func GetBindAddr() (string, error) {
 			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
 				continue
 			}
-			if ip.To4() == nil {
+			if ip.To4() == nil && ip.To16() != nil {
 				return "::", nil
 			}
 		}


### PR DESCRIPTION
## Summary

If no IPv4 address is found, fall back to the first available IPv6 address rather than returning an error.

## Changes

- Updated getFirstIP to fall back to the first routable IPv6 address if no IPv4 address is found
- Added GetBindAddr() utility that scans interfaces and returns the appropriate wildcard (:: for IPv6/dual-stack, 0.0.0.0 for IPv4-only)
- HTTP server address formatting now uses net.JoinHostPort, which correctly brackets IPv6 addresses in host:port strings
- etcd embedConfig uses GetBindAddr() to select a single wildcard listener, avoiding EADDRINUSE from conflicting dual-stack socket binds

## Testing

- Manual verification on a host with only IPv6 interfaces
