### PR TITLE
fix: needs_recreate behavior

### DIFF
--- a/e2e/postgrest_test.go
+++ b/e2e/postgrest_test.go
@@ -203,6 +203,18 @@ func TestPostgRESTPreflight_MissingSchema(t *testing.T) {
 	})
 	require.Error(t, err, "expected update task to fail due to missing schema")
 	assert.Contains(t, err.Error(), "nonexistent_schema", "error should mention the missing schema")
+
+	// It should succeed when we remove the nonexistent schema.
+	err = db.Update(ctx, UpdateOptions{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_preflight_schema",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, nil),
+			},
+		),
+	})
+	require.NoError(t, err)
 }
 
 // TestPostgRESTPreflight_MissingAnonRole verifies the preflight check rejects
@@ -236,6 +248,20 @@ func TestPostgRESTPreflight_MissingAnonRole(t *testing.T) {
 	})
 	require.Error(t, err, "expected update task to fail due to missing anon role")
 	assert.Contains(t, err.Error(), "nonexistent_role", "error should mention the missing role")
+
+	// It should succeed when we switch to an existing role.
+	err = db.Update(ctx, UpdateOptions{
+		Spec: postgrestBaseSpec(
+			"test_postgrest_preflight_role",
+			[]string{host1},
+			[]*controlplane.ServiceSpec{
+				postgrestSpec(host1, 0, map[string]any{
+					"db_anon_role": "anon",
+				}),
+			},
+		),
+	})
+	require.NoError(t, err)
 }
 
 // TestPostgRESTHealthCheck verifies the service responds to HTTP requests once running.

--- a/server/internal/database/operations/golden_test/TestUpdateDatabase/update_after_failed_service_deployment.json
+++ b/server/internal/database/operations/golden_test/TestUpdateDatabase/update_after_failed_service_deployment.json
@@ -1,0 +1,43 @@
+[
+  [
+    [
+      {
+        "type": "create",
+        "resource_id": "swarm.network::database-id",
+        "reason": "does_not_exist",
+        "diff": null
+      }
+    ],
+    [
+      {
+        "type": "create",
+        "resource_id": "swarm.service_instance_spec::database-id-test-svc-host-1-id",
+        "reason": "does_not_exist",
+        "diff": null
+      }
+    ],
+    [
+      {
+        "type": "create",
+        "resource_id": "swarm.service_instance::database-id-test-svc-host-1-id",
+        "reason": "does_not_exist",
+        "diff": null
+      }
+    ],
+    [
+      {
+        "type": "create",
+        "resource_id": "monitor.service_instance::database-id-test-svc-host-1-id",
+        "reason": "does_not_exist",
+        "diff": null
+      }
+    ],
+    [
+      {
+        "type": "delete",
+        "resource_id": "swarm.network::database-id-should-delete",
+        "diff": null
+      }
+    ]
+  ]
+]

--- a/server/internal/database/operations/update_database.go
+++ b/server/internal/database/operations/update_database.go
@@ -40,6 +40,9 @@ func UpdateDatabase(
 	nodes []*NodeResources,
 	services []*ServiceResources,
 ) ([]resource.Plan, error) {
+	// avoid modifying the caller's copy of the start state
+	start = start.Clone()
+
 	update, err := updateFunc(options)
 	if err != nil {
 		return nil, err
@@ -81,7 +84,7 @@ func UpdateDatabase(
 	}
 	// Mark resources not in the end state with PendingDeletion = true so that
 	// we skip updating them.
-	start.MarkPendingDeletion(end)
+	start.PreparePendingDeletesAndRecreates(end)
 
 	// The states produced by the *Nodes functions are just diffs. Here's where
 	// we create a sequence of incremental updates by iteratively applying those

--- a/server/internal/database/operations/update_database_test.go
+++ b/server/internal/database/operations/update_database_test.go
@@ -216,6 +216,35 @@ func TestUpdateDatabase(t *testing.T) {
 		),
 	)
 
+	failedService := makeServiceResources(t, "database-id", "test-svc", "host-1-id", nil)
+	// This first resource should have a planned delete since it won't be in the
+	// end state.
+	failedService.Resources[0].Identifier.ID += "-should-delete"
+	failedService.Resources[0].NeedsRecreate = true
+	// This resource should have a planned create since it is in the end state.
+	failedService.Resources[1].NeedsRecreate = true
+	failedServiceState := makeState(t,
+		[]resource.Resource{
+			n1Instance1.Instance,
+			makeMonitorResource(n1Instance1),
+			&database.NodeResource{
+				Name:              "n1",
+				PrimaryInstanceID: n1Instance1.InstanceID(),
+				InstanceIDs:       []string{n1Instance1.InstanceID()},
+			},
+			&database.PostgresDatabaseResource{
+				NodeName:     "n1",
+				DatabaseName: "test",
+			},
+		},
+		slices.Concat(
+			n1Instance1.InstanceDependencies,
+			// Only the first two resources got deployed, and both are marked
+			// with needs_recreate = true.
+			failedService.Resources[:2],
+		),
+	)
+
 	for _, tc := range []struct {
 		name        string
 		options     operations.UpdateDatabaseOptions
@@ -625,6 +654,19 @@ func TestUpdateDatabase(t *testing.T) {
 					DatabaseName:      "test",
 					NodeName:          "n1",
 					InstanceResources: []*database.InstanceResources{n1Instance1WithNewDependency},
+				},
+			},
+			services: []*operations.ServiceResources{svcRes},
+		},
+		{
+			name:    "update after failed service deployment",
+			options: operations.UpdateDatabaseOptions{},
+			start:   failedServiceState,
+			nodes: []*operations.NodeResources{
+				{
+					NodeName:          "n1",
+					InstanceResources: []*database.InstanceResources{n1Instance1},
+					DatabaseName:      "test",
 				},
 			},
 			services: []*operations.ServiceResources{svcRes},

--- a/server/internal/resource/state.go
+++ b/server/internal/resource/state.go
@@ -139,9 +139,11 @@ func (s *State) Merge(other *State) {
 	}
 }
 
-// MarkPendingDeletion takes an end state and marks all current resources that
-// aren't in the end state with PendingDeletion = true.
-func (s *State) MarkPendingDeletion(end *State) {
+// PreparePendingDeletesAndRecreates takes an end state and marks all current
+// resources that aren't in the end state with PendingDeletion = true. Resources
+// that need to be recreated and are in the end state are removed from this
+// state so that we can plan their creation in the appropriate phase.
+func (s *State) PreparePendingDeletesAndRecreates(end *State) {
 	for t, byType := range s.Resources {
 		endByType, ok := end.Resources[t]
 		if !ok {
@@ -153,6 +155,11 @@ func (s *State) MarkPendingDeletion(end *State) {
 		for id, resource := range byType {
 			if _, ok := endByType[id]; !ok {
 				resource.PendingDeletion = true
+			} else if resource.NeedsRecreate {
+				// This resource will be recreated since it's in the end state.
+				// Removing the old copy of it from the start state avoids an
+				// accidental create before it would normally occur.
+				delete(byType, id)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This commit modifies an existing process that handled pending deletions to remove resources that are pending recreation from the start state. This enables us to plan their creation at the appropriate phase.

I've included a golden test that demonstrates this behavior. I've also modified some existing PostgREST E2Es to test this behavior, since that's where we first noticed the issue.

### Background

Resources can sometimes fail partway through the creation process, leaving files or other traces behind on the host. An example of this scenario is when we can create a Swarm service, but it fails to start. Rather than roll back the creation with a delete, which could also be broken or dangerous, we record the resource into the state with the `needs_recreate` flag set to `true`. This way, if the user deletes the database or makes another update that would delete the resource, we know to run that resource's `Delete` method to ensure that it's removed from the host. 

Conversely, we know that we should run this resource's `Create` method again, rather than its `Update` method, if the user reattempts the operation. In this case, the intent was to call `Create` in whichever phase it would normally be recreated if it didn't exist. However, since our planning process only looks at differences between states, it sees resources that need to be recreated in the initial state, even if there aren't any diffs. This led to problems when the resource's normal phase was later in the update plan, such as when you fix a misconfigured supporting service resource.

## Changes

The core change is in `state.go`: modifying the existing `MarkPendingDeletion` to also handle pending recreations. Most of the rest of this PR is test code.

## Testing

```sh
# using a Swarm cluster
# create a database with a PostgREST instance with a misconfigured db_anon_role
cp1-req create-database <<EOF | cp-follow-task
{
  "id": "storefront",
  "spec": {
    "database_name": "storefront",
    "database_users": [
      {
        "username": "admin",
        "password": "password",
        "db_owner": true,
        "attributes": ["SUPERUSER", "LOGIN"]
      },
      {
        "username": "anon",
        "attributes": ["NOLOGIN"]
      }
    ],
    "port": 0,
    "nodes": [{ "name": "n1", "host_ids": ["host-1"] }],
    "services": [
      {
        "service_id": "api",
        "service_type": "postgrest",
        "version": "latest",
        "host_ids": ["host-1"],
        "port": 3100,
        "connect_as": "admin",
        "config": {
          "db_anon_role": "nonexistent"
        }
      }
    ]
  }
}
EOF

# this should fail while creating the swarm.postgrest_preflight and
# swarm.postgrest_authenticator resources

# now, update the database with a corrected db_anon_role
cp1-req update-database storefront <<EOF | cp-follow-task
{
  "id": "storefront",
  "spec": {
    "database_name": "storefront",
    "database_users": [
      {
        "username": "admin",
        "password": "password",
        "db_owner": true,
        "attributes": ["SUPERUSER", "LOGIN"]
      },
      {
        "username": "anon",
        "attributes": ["NOLOGIN"]
      }
    ],
    "port": 0,
    "nodes": [{ "name": "n1", "host_ids": ["host-1"] }],
    "services": [
      {
        "service_id": "api",
        "service_type": "postgrest",
        "version": "latest",
        "host_ids": ["host-1"],
        "port": 3100,
        "connect_as": "admin",
        "config": {
          "db_anon_role": "anon"
        }
      }
    ]
  }
}
EOF

# this update would fail on main, but should succeed on this branch
```

PLAT-668
