### PR TITLE
chore: update default manifest URL to production endpoint

### DIFF
--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -109,8 +109,7 @@ func (d DockerSwarm) validate() []error {
 }
 
 // DefaultManifestURL is the pgEdge CDN URL used when no manifest_url is configured.
-// TODO(PLAT-598): Replace with the real URL once the hosting location is confirmed.
-const DefaultManifestURL = "https://download.pgedge.com/manifests/version-manifest.json"
+const DefaultManifestURL = "https://downloads.pgedge.com/manifests/release/control-plane/version-manifest.json"
 
 var defaultDockerSwarm = DockerSwarm{
 	ImageRepositoryHost: "ghcr.io/pgedge",


### PR DESCRIPTION
## Summary
This PR sets the production pgEdge URL as the default endpoint for version manifest discovery.

## Changes

- Updated `DefaultManifestURL` in `server/internal/config/config.go` to use the production version manifest endpoint: `https://downloads.pgedge.com/manifests/release/control-plane/version-manifest.json`

## Testing
Verification:
1. Created a cluster
2. Created DB with lower version of image
```
cp1-req create-database < ../demo/Images/create_db_lower_image.json | cp-follow-task 
{
  "database": {
    "created_at": "2026-07-03T14:05:00Z",
    "id": "storefront",
    "spec": {
      "database_name": "storefront",
      "database_users": [
        {
          "attributes": [
            "SUPERUSER",
            "LOGIN"
          ],
          "db_owner": true,
          "username": "admin"
        }
      ],
      "nodes": [
        {
          "host_ids": [
            "host-1",
            "host-2",
            "host-3"
          ],
          "name": "n1"
        }
      ],
      "postgres_version": "17.9",
      "spock_version": "5"
    },
    "state": "creating",
    "updated_at": "2026-07-03T14:05:00Z"
  },
  "task": {
    "created_at": "2026-07-03T14:05:00Z",
    "database_id": "storefront",
    "entity_id": "storefront",
    "scope": "database",
    "status": "pending",
    "task_id": "019f284c-0d82-75b2-8ce6-c53771bd9369",
    "type": "create"
  }
}
[2026-07-03T14:05:01Z] refreshing current state
[2026-07-03T14:05:02Z] finished refreshing current state (took 203.731625ms)
[2026-07-03T14:05:04Z] creating resource common.patroni_cluster::n1
[2026-07-03T14:05:04Z] finished creating resource common.patroni_cluster::n1 (took 30.666µs)
[2026-07-03T14:05:04Z] creating resource swarm.network::storefront-database
[2026-07-03T14:05:04Z] finished creating resource swarm.network::storefront-database (took 7.733791ms)
[2026-07-03T14:05:04Z] creating resource filesystem.dir::storefront-n1-689qacsi-instance
[2026-07-03T14:05:04Z] finished creating resource filesystem.dir::storefront-n1-689qacsi-instance (took 1.244916ms)
[2026-07-03T14:05:04Z] creating resource common.patroni_member::storefront-n1-689qacsi
[2026-07-03T14:05:04Z] finished creating resource common.patroni_member::storefront-n1-689qacsi (took 36.875µs)
[2026-07-03T14:05:04Z] creating resource filesystem.dir::storefront-n1-689qacsi-data
[2026-07-03T14:05:04Z] finished creating resource filesystem.dir::storefront-n1-689qacsi-data (took 1.880875ms)
[2026-07-03T14:05:04Z] creating resource filesystem.dir::storefront-n1-689qacsi-configs
[2026-07-03T14:05:04Z] finished creating resource filesystem.dir::storefront-n1-689qacsi-configs (took 1.226708ms)
[2026-07-03T14:05:04Z] creating resource filesystem.dir::storefront-n1-689qacsi-certificates
[2026-07-03T14:05:04Z] finished creating resource filesystem.dir::storefront-n1-689qacsi-certificates (took 689.333µs)
[2026-07-03T14:05:05Z] creating resource common.etcd_creds::storefront-n1-689qacsi
[2026-07-03T14:05:05Z] finished creating resource common.etcd_creds::storefront-n1-689qacsi (took 78.33275ms)
[2026-07-03T14:05:05Z] creating resource common.postgres_certs::storefront-n1-689qacsi
[2026-07-03T14:05:05Z] finished creating resource common.postgres_certs::storefront-n1-689qacsi (took 6.205708ms)
[2026-07-03T14:05:05Z] creating resource swarm.patroni_config::storefront-n1-689qacsi
[2026-07-03T14:05:05Z] finished creating resource swarm.patroni_config::storefront-n1-689qacsi (took 3.672375ms)
[2026-07-03T14:05:06Z] creating resource swarm.postgres_service_spec::storefront-n1-689qacsi
[2026-07-03T14:05:06Z] finished creating resource swarm.postgres_service_spec::storefront-n1-689qacsi (took 166.917µs)
[2026-07-03T14:05:06Z] creating resource swarm.check_will_restart::storefront-n1-689qacsi
[2026-07-03T14:05:06Z] finished creating resource swarm.check_will_restart::storefront-n1-689qacsi (took 2.426833ms)
[2026-07-03T14:05:06Z] creating resource swarm.switchover::storefront-n1-689qacsi
[2026-07-03T14:05:06Z] finished creating resource swarm.switchover::storefront-n1-689qacsi (took 17.917µs)
[2026-07-03T14:05:06Z] creating resource swarm.postgres_service::storefront-n1-689qacsi
[2026-07-03T14:05:16Z] finished creating resource swarm.postgres_service::storefront-n1-689qacsi (took 10.017740837s)
[2026-07-03T14:05:17Z] creating resource database.instance::storefront-n1-689qacsi
[2026-07-03T14:05:27Z] finished creating resource database.instance::storefront-n1-689qacsi (took 10.051439713s)
[2026-07-03T14:05:27Z] creating resource filesystem.dir::storefront-n1-9ptayhma-instance
[2026-07-03T14:05:27Z] finished creating resource filesystem.dir::storefront-n1-9ptayhma-instance (took 836.167µs)
[2026-07-03T14:05:27Z] creating resource filesystem.dir::storefront-n1-ant97dj4-instance
[2026-07-03T14:05:27Z] finished creating resource filesystem.dir::storefront-n1-ant97dj4-instance (took 861.666µs)
[2026-07-03T14:05:28Z] creating resource common.patroni_member::storefront-n1-9ptayhma
[2026-07-03T14:05:28Z] finished creating resource common.patroni_member::storefront-n1-9ptayhma (took 24.75µs)
[2026-07-03T14:05:28Z] creating resource common.patroni_member::storefront-n1-ant97dj4
[2026-07-03T14:05:28Z] finished creating resource common.patroni_member::storefront-n1-ant97dj4 (took 11.25µs)
[2026-07-03T14:05:28Z] creating resource filesystem.dir::storefront-n1-9ptayhma-data
[2026-07-03T14:05:28Z] finished creating resource filesystem.dir::storefront-n1-9ptayhma-data (took 551µs)
[2026-07-03T14:05:28Z] creating resource filesystem.dir::storefront-n1-9ptayhma-certificates
[2026-07-03T14:05:28Z] finished creating resource filesystem.dir::storefront-n1-9ptayhma-certificates (took 400.5µs)
[2026-07-03T14:05:28Z] creating resource filesystem.dir::storefront-n1-9ptayhma-configs
[2026-07-03T14:05:28Z] finished creating resource filesystem.dir::storefront-n1-9ptayhma-configs (took 443.542µs)
[2026-07-03T14:05:28Z] creating resource filesystem.dir::storefront-n1-ant97dj4-certificates
[2026-07-03T14:05:28Z] finished creating resource filesystem.dir::storefront-n1-ant97dj4-certificates (took 788.208µs)
[2026-07-03T14:05:28Z] creating resource filesystem.dir::storefront-n1-ant97dj4-data
[2026-07-03T14:05:28Z] finished creating resource filesystem.dir::storefront-n1-ant97dj4-data (took 403.042µs)
[2026-07-03T14:05:28Z] creating resource filesystem.dir::storefront-n1-ant97dj4-configs
[2026-07-03T14:05:28Z] finished creating resource filesystem.dir::storefront-n1-ant97dj4-configs (took 545µs)
[2026-07-03T14:05:28Z] creating resource common.postgres_certs::storefront-n1-9ptayhma
[2026-07-03T14:05:28Z] creating resource common.etcd_creds::storefront-n1-9ptayhma
[2026-07-03T14:05:28Z] finished creating resource common.postgres_certs::storefront-n1-9ptayhma (took 16.576542ms)
[2026-07-03T14:05:28Z] finished creating resource common.etcd_creds::storefront-n1-9ptayhma (took 66.807959ms)
[2026-07-03T14:05:28Z] creating resource common.etcd_creds::storefront-n1-ant97dj4
[2026-07-03T14:05:28Z] finished creating resource common.etcd_creds::storefront-n1-ant97dj4 (took 67.675625ms)
[2026-07-03T14:05:28Z] creating resource common.postgres_certs::storefront-n1-ant97dj4
[2026-07-03T14:05:28Z] finished creating resource common.postgres_certs::storefront-n1-ant97dj4 (took 8.522625ms)
[2026-07-03T14:05:29Z] creating resource swarm.patroni_config::storefront-n1-9ptayhma
[2026-07-03T14:05:29Z] finished creating resource swarm.patroni_config::storefront-n1-9ptayhma (took 2.288458ms)
[2026-07-03T14:05:29Z] creating resource swarm.patroni_config::storefront-n1-ant97dj4
[2026-07-03T14:05:29Z] finished creating resource swarm.patroni_config::storefront-n1-ant97dj4 (took 5.5105ms)
[2026-07-03T14:05:29Z] creating resource swarm.postgres_service_spec::storefront-n1-9ptayhma
[2026-07-03T14:05:29Z] finished creating resource swarm.postgres_service_spec::storefront-n1-9ptayhma (took 133.791µs)
[2026-07-03T14:05:29Z] creating resource swarm.postgres_service_spec::storefront-n1-ant97dj4
[2026-07-03T14:05:29Z] finished creating resource swarm.postgres_service_spec::storefront-n1-ant97dj4 (took 128.833µs)
[2026-07-03T14:05:29Z] creating resource swarm.check_will_restart::storefront-n1-ant97dj4
[2026-07-03T14:05:29Z] finished creating resource swarm.check_will_restart::storefront-n1-ant97dj4 (took 3.731208ms)
[2026-07-03T14:05:29Z] creating resource swarm.check_will_restart::storefront-n1-9ptayhma
[2026-07-03T14:05:29Z] finished creating resource swarm.check_will_restart::storefront-n1-9ptayhma (took 1.415584ms)
[2026-07-03T14:05:30Z] creating resource swarm.switchover::storefront-n1-9ptayhma
[2026-07-03T14:05:30Z] finished creating resource swarm.switchover::storefront-n1-9ptayhma (took 14µs)
[2026-07-03T14:05:30Z] creating resource swarm.switchover::storefront-n1-ant97dj4
[2026-07-03T14:05:30Z] finished creating resource swarm.switchover::storefront-n1-ant97dj4 (took 16.5µs)
[2026-07-03T14:05:30Z] creating resource swarm.postgres_service::storefront-n1-9ptayhma
[2026-07-03T14:05:30Z] creating resource swarm.postgres_service::storefront-n1-ant97dj4
[2026-07-03T14:05:40Z] finished creating resource swarm.postgres_service::storefront-n1-9ptayhma (took 10.011903546s)
[2026-07-03T14:05:40Z] finished creating resource swarm.postgres_service::storefront-n1-ant97dj4 (took 10.009235713s)
[2026-07-03T14:05:40Z] creating resource database.instance::storefront-n1-9ptayhma
[2026-07-03T14:05:40Z] creating resource database.instance::storefront-n1-ant97dj4
[2026-07-03T14:05:50Z] finished creating resource database.instance::storefront-n1-9ptayhma (took 10.026782254s)
[2026-07-03T14:05:50Z] finished creating resource database.instance::storefront-n1-ant97dj4 (took 10.028279254s)
[2026-07-03T14:05:51Z] creating resource database.node::n1
[2026-07-03T14:05:51Z] finished creating resource database.node::n1 (took 129.583µs)
[2026-07-03T14:05:51Z] creating resource monitor.instance::storefront-n1-9ptayhma
[2026-07-03T14:05:51Z] finished creating resource monitor.instance::storefront-n1-9ptayhma (took 12.065833ms)
[2026-07-03T14:05:51Z] creating resource monitor.instance::storefront-n1-ant97dj4
[2026-07-03T14:05:51Z] creating resource monitor.instance::storefront-n1-689qacsi
[2026-07-03T14:05:51Z] finished creating resource monitor.instance::storefront-n1-ant97dj4 (took 17.960542ms)
[2026-07-03T14:05:51Z] finished creating resource monitor.instance::storefront-n1-689qacsi (took 12.124833ms)
[2026-07-03T14:05:51Z] creating resource database.postgres_database::n1:storefront
[2026-07-03T14:05:52Z] finished creating resource database.postgres_database::n1:storefront (took 324.651584ms)

database entity storefront task 019f284c-0d82-75b2-8ce6-c53771bd9369 completed
```

3. Confirm the versions
```
cp1-req get-database storefront | jq '{state, version: .spec.postgres_version}'
{
  "state": "available",
  "version": "17.9"
}
```
4. Get available_upgrades
```
 cp1-req get-database storefront --rsh-query include=available_upgrades \
  | jq .available_upgrades
[
  {
    "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1",
    "postgres_version": "17.10",
    "spock_version": "5"
  }
]
```
5. Apply upgrade
```
cp1-req apply-upgrade storefront \
  image: "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1" | cp-follow-task
{
  "database": {
    "created_at": "2026-07-03T14:05:00Z",
    "id": "storefront",
    "instances": [
      {
        "created_at": "2026-07-03T14:05:03Z",
        "host_id": "host-1",
        "id": "storefront-n1-689qacsi",
        "node_name": "n1",
        "postgres": {
          "patroni_state": "running",
          "role": "primary",
          "version": "17.9"
        },
        "spock": {
          "read_only": "off",
          "version": "5.0.6"
        },
        "state": "available",
        "status_updated_at": "2026-07-03T14:24:26Z",
        "updated_at": "2026-07-03T14:05:27Z"
      },
      {
        "created_at": "2026-07-03T14:05:27Z",
        "host_id": "host-2",
        "id": "storefront-n1-9ptayhma",
        "node_name": "n1",
        "postgres": {
          "patroni_state": "running",
          "role": "replica",
          "version": "17.9"
        },
        "state": "available",
        "status_updated_at": "2026-07-03T14:24:26Z",
        "updated_at": "2026-07-03T14:05:50Z"
      },
      {
        "created_at": "2026-07-03T14:05:27Z",
        "host_id": "host-3",
        "id": "storefront-n1-ant97dj4",
        "node_name": "n1",
        "postgres": {
          "patroni_state": "running",
          "role": "replica",
          "version": "17.9"
        },
        "state": "available",
        "status_updated_at": "2026-07-03T14:24:26Z",
        "updated_at": "2026-07-03T14:05:50Z"
      }
    ],
    "spec": {
      "database_name": "storefront",
      "database_users": [
        {
          "attributes": [
            "SUPERUSER",
            "LOGIN"
          ],
          "db_owner": true,
          "username": "admin"
        }
      ],
      "nodes": [
        {
          "host_ids": [
            "host-1",
            "host-2",
            "host-3"
          ],
          "name": "n1"
        }
      ],
      "postgres_version": "17.10",
      "spock_version": "5"
    },
    "state": "modifying",
    "updated_at": "2026-07-03T14:24:26Z"
  },
  "task": {
    "created_at": "2026-07-03T14:24:26Z",
    "database_id": "storefront",
    "entity_id": "storefront",
    "scope": "database",
    "status": "pending",
    "task_id": "019f285d-d817-7446-aeab-6f2d82abad73",
    "type": "upgrade"
  }
}
[2026-07-03T14:24:28Z] refreshing current state
[2026-07-03T14:24:36Z] finished refreshing current state (took 8.195770296s)
[2026-07-03T14:24:38Z] updating resource swarm.postgres_service_spec::storefront-n1-9ptayhma
[2026-07-03T14:24:38Z] finished updating resource swarm.postgres_service_spec::storefront-n1-9ptayhma (took 139.459µs)
[2026-07-03T14:24:38Z] updating resource swarm.check_will_restart::storefront-n1-9ptayhma
[2026-07-03T14:24:38Z] finished updating resource swarm.check_will_restart::storefront-n1-9ptayhma (took 4.219208ms)
[2026-07-03T14:24:38Z] updating resource swarm.switchover::storefront-n1-9ptayhma
[2026-07-03T14:24:38Z] finished updating resource swarm.switchover::storefront-n1-9ptayhma (took 1.250875ms)
[2026-07-03T14:24:38Z] updating resource swarm.postgres_service::storefront-n1-9ptayhma
[2026-07-03T14:24:54Z] finished updating resource swarm.postgres_service::storefront-n1-9ptayhma (took 15.017446215s)
[2026-07-03T14:24:54Z] updating resource database.instance::storefront-n1-9ptayhma
[2026-07-03T14:25:04Z] finished updating resource database.instance::storefront-n1-9ptayhma (took 10.014655672s)
[2026-07-03T14:25:04Z] updating resource database.node::n1
[2026-07-03T14:25:04Z] finished updating resource database.node::n1 (took 107.166µs)
[2026-07-03T14:25:04Z] updating resource monitor.instance::storefront-n1-9ptayhma
[2026-07-03T14:25:04Z] finished updating resource monitor.instance::storefront-n1-9ptayhma (took 13.058541ms)
[2026-07-03T14:25:04Z] updating resource database.postgres_database::n1:storefront
[2026-07-03T14:25:04Z] finished updating resource database.postgres_database::n1:storefront (took 25.941333ms)
[2026-07-03T14:25:05Z] updating resource swarm.postgres_service_spec::storefront-n1-ant97dj4
[2026-07-03T14:25:05Z] finished updating resource swarm.postgres_service_spec::storefront-n1-ant97dj4 (took 158.292µs)
[2026-07-03T14:25:05Z] updating resource swarm.check_will_restart::storefront-n1-ant97dj4
[2026-07-03T14:25:05Z] finished updating resource swarm.check_will_restart::storefront-n1-ant97dj4 (took 4.235459ms)
[2026-07-03T14:25:05Z] updating resource swarm.switchover::storefront-n1-ant97dj4
[2026-07-03T14:25:05Z] finished updating resource swarm.switchover::storefront-n1-ant97dj4 (took 1.468916ms)
[2026-07-03T14:25:06Z] updating resource swarm.postgres_service::storefront-n1-ant97dj4
[2026-07-03T14:25:21Z] finished updating resource swarm.postgres_service::storefront-n1-ant97dj4 (took 15.017512798s)
[2026-07-03T14:25:21Z] updating resource database.instance::storefront-n1-ant97dj4
[2026-07-03T14:25:31Z] finished updating resource database.instance::storefront-n1-ant97dj4 (took 10.013872755s)
[2026-07-03T14:25:31Z] updating resource database.node::n1
[2026-07-03T14:25:31Z] finished updating resource database.node::n1 (took 104.208µs)
[2026-07-03T14:25:31Z] updating resource monitor.instance::storefront-n1-ant97dj4
[2026-07-03T14:25:31Z] finished updating resource monitor.instance::storefront-n1-ant97dj4 (took 14.768334ms)
[2026-07-03T14:25:32Z] updating resource database.postgres_database::n1:storefront
[2026-07-03T14:25:32Z] finished updating resource database.postgres_database::n1:storefront (took 35.748875ms)
[2026-07-03T14:25:32Z] updating resource swarm.postgres_service_spec::storefront-n1-689qacsi
[2026-07-03T14:25:32Z] finished updating resource swarm.postgres_service_spec::storefront-n1-689qacsi (took 92.333µs)
[2026-07-03T14:25:33Z] updating resource swarm.check_will_restart::storefront-n1-689qacsi
[2026-07-03T14:25:33Z] finished updating resource swarm.check_will_restart::storefront-n1-689qacsi (took 5.16975ms)
[2026-07-03T14:25:33Z] updating resource swarm.switchover::storefront-n1-689qacsi
[2026-07-03T14:25:45Z] finished updating resource swarm.switchover::storefront-n1-689qacsi (took 12.105401171s)
[2026-07-03T14:25:45Z] updating resource swarm.postgres_service::storefront-n1-689qacsi
[2026-07-03T14:26:00Z] finished updating resource swarm.postgres_service::storefront-n1-689qacsi (took 15.011809132s)
[2026-07-03T14:26:01Z] updating resource database.instance::storefront-n1-689qacsi
[2026-07-03T14:26:11Z] finished updating resource database.instance::storefront-n1-689qacsi (took 10.011263547s)
[2026-07-03T14:26:11Z] updating resource database.node::n1
[2026-07-03T14:26:11Z] finished updating resource database.node::n1 (took 124.208µs)
[2026-07-03T14:26:11Z] updating resource monitor.instance::storefront-n1-689qacsi
[2026-07-03T14:26:11Z] finished updating resource monitor.instance::storefront-n1-689qacsi (took 13.299208ms)
[2026-07-03T14:26:11Z] updating resource database.postgres_database::n1:storefront
[2026-07-03T14:26:11Z] finished updating resource database.postgres_database::n1:storefront (took 34.65ms)
[2026-07-03T14:26:12Z] creating resource database.switchover::storefront-n1-689qacsi
[2026-07-03T14:26:28Z] finished creating resource database.switchover::storefront-n1-689qacsi (took 16.069652216s)

database entity storefront task 019f285d-d817-7446-aeab-6f2d82abad73 completed
```
6. Verify upgrade & confirm no updates available
```
cp1-req get-database storefront --rsh-query include=available_upgrades \
  | jq '{postgres_version: .spec.postgres_version, available_upgrades: .available_upgrades}'

{
  "postgres_version": "17.10",
  "available_upgrades": null
}
```

## Checklist

- [x] Tests added 

[PLAT-661](https://pgedge.atlassian.net/browse/PLAT-661)

[PLAT-661]: https://pgedge.atlassian.net/browse/PLAT-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ