### PR TITLE
fix: prevent subscription breakage on rolling updates

### DIFF
--- a/e2e/minor_version_upgrade_test.go
+++ b/e2e/minor_version_upgrade_test.go
@@ -14,6 +14,174 @@ import (
 	controlplane "github.com/pgEdge/control-plane/api/apiv1/gen/control_plane"
 )
 
+// TestRollingUpdatePreservesReplication verifies that Spock subscriptions
+// remain functional after a rolling update on a multi-node database with
+// replica instances (PLAT-665). It writes data before and after the update
+// and asserts that both directions of replication still work.
+func TestRollingUpdatePreservesReplication(t *testing.T) {
+	t.Parallel()
+
+	fixture.SkipIfUpgradesUnsupported(t)
+
+	host1 := fixture.HostIDs()[0]
+	host2 := fixture.HostIDs()[1]
+	host3 := fixture.HostIDs()[2]
+	host4 := fixture.HostIDs()[3]
+
+	username := "admin"
+	password := "password"
+
+	fromVersion := "18.3"
+	toVersion := "18.4"
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	t.Log("creating two-node database with replicas")
+
+	db := fixture.NewDatabaseFixture(t.Context(), t, &controlplane.CreateDatabaseRequest{
+		Spec: &controlplane.DatabaseSpec{
+			DatabaseName:    "repl_test",
+			PostgresVersion: &fromVersion,
+			Port:            pointerTo(0),
+			PatroniPort:     pointerTo(0),
+			DatabaseUsers: []*controlplane.DatabaseUserSpec{
+				{
+					Username:   username,
+					Password:   pointerTo(password),
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+			},
+			Nodes: []*controlplane.DatabaseNodeSpec{
+				{Name: "n1", HostIds: []controlplane.Identifier{
+					controlplane.Identifier(host1),
+					controlplane.Identifier(host2),
+				}},
+				{Name: "n2", HostIds: []controlplane.Identifier{
+					controlplane.Identifier(host3),
+					controlplane.Identifier(host4),
+				}},
+			},
+		},
+	})
+
+	n1Opts := ConnectionOptions{Matcher: And(WithNode("n1"), WithRole("primary")), Username: username, Password: password}
+	n2Opts := ConnectionOptions{Matcher: And(WithNode("n2"), WithRole("primary")), Username: username, Password: password}
+
+	// Write a row on n1 and wait for it to replicate to n2 before the update.
+	t.Log("writing pre-update data to n1")
+
+	var preLSN string
+	db.WithConnection(ctx, n1Opts, t, func(conn *pgx.Conn) {
+		_, err := conn.Exec(ctx, "CREATE TABLE items (id INT PRIMARY KEY, data TEXT);")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "INSERT INTO items VALUES (1, 'before-update');")
+		require.NoError(t, err)
+
+		require.NoError(t, conn.QueryRow(ctx, "SELECT spock.sync_event();").Scan(&preLSN))
+	})
+
+	t.Log("waiting for pre-update row to replicate to n2")
+
+	db.WithConnection(ctx, n2Opts, t, func(conn *pgx.Conn) {
+		var synced bool
+		require.NoError(t, conn.QueryRow(ctx,
+			"CALL spock.wait_for_sync_event(true, $1, $2::pg_lsn, 30);", "n1", preLSN,
+		).Scan(&synced))
+		require.True(t, synced, "pre-update row did not replicate to n2 before update")
+
+		var data string
+		require.NoError(t, conn.QueryRow(ctx, "SELECT data FROM items WHERE id = 1;").Scan(&data))
+		assert.Equal(t, "before-update", data)
+	})
+
+	// Perform the rolling update — version bump changes the image, which
+	// triggers a container restart on each instance.
+	t.Logf("performing rolling update from %s to %s", fromVersion, toVersion)
+
+	err := db.Update(ctx, UpdateOptions{
+		Spec: &controlplane.DatabaseSpec{
+			DatabaseName:    "repl_test",
+			PostgresVersion: &toVersion,
+			Port:            pointerTo(0),
+			PatroniPort:     pointerTo(0),
+			DatabaseUsers: []*controlplane.DatabaseUserSpec{
+				{
+					Username:   username,
+					Password:   pointerTo(password),
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+			},
+			Nodes: []*controlplane.DatabaseNodeSpec{
+				{Name: "n1", HostIds: []controlplane.Identifier{
+					controlplane.Identifier(host1),
+					controlplane.Identifier(host2),
+				}},
+				{Name: "n2", HostIds: []controlplane.Identifier{
+					controlplane.Identifier(host3),
+					controlplane.Identifier(host4),
+				}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	t.Log("asserting both nodes have an active primary after update")
+	require.NotNil(t, db.GetInstance(And(WithNode("n1"), WithRole("primary"))))
+	require.NotNil(t, db.GetInstance(And(WithNode("n2"), WithRole("primary"))))
+
+	// Write a new row on n1 after the update and verify it reaches n2.
+	// This is the core regression check: if the second switchover broke the
+	// n1→n2 subscription, this insert will never replicate.
+	t.Log("writing post-update data to n1, verifying replication to n2")
+
+	var postLSN string
+	db.WithConnection(ctx, n1Opts, t, func(conn *pgx.Conn) {
+		_, err := conn.Exec(ctx, "INSERT INTO items VALUES (2, 'after-update');")
+		require.NoError(t, err)
+
+		require.NoError(t, conn.QueryRow(ctx, "SELECT spock.sync_event();").Scan(&postLSN))
+	})
+
+	db.WithConnection(ctx, n2Opts, t, func(conn *pgx.Conn) {
+		var synced bool
+		require.NoError(t, conn.QueryRow(ctx,
+			"CALL spock.wait_for_sync_event(true, $1, $2::pg_lsn, 30);", "n1", postLSN,
+		).Scan(&synced))
+		require.True(t, synced, "post-update row did not replicate n1→n2")
+
+		var data string
+		require.NoError(t, conn.QueryRow(ctx, "SELECT data FROM items WHERE id = 2;").Scan(&data))
+		assert.Equal(t, "after-update", data)
+	})
+
+	// Also verify the reverse direction: n2→n1.
+	t.Log("writing post-update data to n2, verifying replication to n1")
+
+	var reverseLSN string
+	db.WithConnection(ctx, n2Opts, t, func(conn *pgx.Conn) {
+		_, err := conn.Exec(ctx, "INSERT INTO items VALUES (3, 'after-update-n2');")
+		require.NoError(t, err)
+
+		require.NoError(t, conn.QueryRow(ctx, "SELECT spock.sync_event();").Scan(&reverseLSN))
+	})
+
+	db.WithConnection(ctx, n1Opts, t, func(conn *pgx.Conn) {
+		var synced bool
+		require.NoError(t, conn.QueryRow(ctx,
+			"CALL spock.wait_for_sync_event(true, $1, $2::pg_lsn, 30);", "n2", reverseLSN,
+		).Scan(&synced))
+		require.True(t, synced, "post-update row did not replicate n2→n1")
+
+		var data string
+		require.NoError(t, conn.QueryRow(ctx, "SELECT data FROM items WHERE id = 3;").Scan(&data))
+		assert.Equal(t, "after-update-n2", data)
+	})
+}
+
 func TestMinorVersionUpgrade(t *testing.T) {
 	t.Parallel()
 
@@ -21,6 +189,8 @@ func TestMinorVersionUpgrade(t *testing.T) {
 
 	host1 := fixture.HostIDs()[0]
 	host2 := fixture.HostIDs()[1]
+	host3 := fixture.HostIDs()[2]
+	host4 := fixture.HostIDs()[3]
 
 	username := "admin"
 	password := "password"
@@ -54,15 +224,20 @@ func TestMinorVersionUpgrade(t *testing.T) {
 						controlplane.Identifier(host2),
 					},
 				},
+				{
+					Name: "n2", HostIds: []controlplane.Identifier{
+						controlplane.Identifier(host3),
+						controlplane.Identifier(host4),
+					},
+				},
 			},
 		},
 	})
 
 	t.Log("asserting that the primary is running on the first host")
 
-	// Assert that the primary is running on the first host in the host_ids
-	// list.
-	primary := db.GetInstance(WithRole("primary"))
+	// Assert that the primary is running on the first host in the host_ids list.
+	primary := db.GetInstance(And(WithNode("n1"), WithRole("primary")))
 	require.NotNil(t, primary)
 	assert.Equal(t, host1, primary.HostID)
 
@@ -107,18 +282,33 @@ func TestMinorVersionUpgrade(t *testing.T) {
 						controlplane.Identifier(host2),
 					},
 				},
+				{
+					Name: "n2", HostIds: []controlplane.Identifier{
+						controlplane.Identifier(host3),
+						controlplane.Identifier(host4),
+					},
+				},
 			},
 		},
 	})
 	require.NoError(t, err)
 
-	t.Log("asserting that the primary hasn't changed")
+	t.Log("asserting that both nodes have an active primary after update")
 
-	// Assert that the primary hasn't changed
-	updated := db.GetInstance(WithRole("primary"))
-	require.NotNil(t, updated)
-	assert.Equal(t, primary.ID, updated.ID)
-	assert.Equal(t, primary.HostID, updated.HostID)
+	// The primary may have moved to a different host during the rolling update.
+	// Rolling updates no longer force a switchover back to the original primary
+	// (PLAT-665), so we only assert that each node has some primary.
+	updatedN1 := db.GetInstance(And(WithNode("n1"), WithRole("primary")))
+	require.NotNil(t, updatedN1)
+	updatedN2 := db.GetInstance(And(WithNode("n2"), WithRole("primary")))
+	require.NotNil(t, updatedN2)
+
+	// Use the current n1 primary for the version check.
+	opts = ConnectionOptions{
+		InstanceID: updatedN1.ID,
+		Username:   username,
+		Password:   password,
+	}
 
 	t.Logf("validating that the version is updated to %s", toVersion)
 

--- a/server/internal/database/instance_resource.go
+++ b/server/internal/database/instance_resource.go
@@ -204,6 +204,12 @@ func (r *InstanceResource) initializeInstance(ctx context.Context, rc *resource.
 	}
 
 	if r.Spec.InstanceID != r.PrimaryInstanceID {
+		// Spock 5.x takes up to 60 s to create failover replication slots after a
+		// switchover. Wait for them before marking this replica available so that
+		// subscribers connected to this node do not lose their slots.
+		if err := r.waitForReplicationSlots(ctx, rc); err != nil {
+			return r.recordError(ctx, rc, err)
+		}
 		err := r.updateInstanceRecord(ctx, rc, &InstanceUpdateOptions{State: InstanceStateAvailable})
 		if err != nil {
 			return r.recordError(ctx, rc, err)
@@ -243,6 +249,53 @@ func (r *InstanceResource) initializeInstance(ctx context.Context, rc *resource.
 		return r.recordError(ctx, rc, err)
 	}
 
+	return nil
+}
+
+// waitForReplicationSlots polls pg_replication_slots on this instance until the
+// replication slot for every subscription where this node is the provider exists.
+// In Spock 5.x the worker process on a replica takes up to 60 s to create
+// failover slots after a switchover; this blocks until they are ready.
+func (r *InstanceResource) waitForReplicationSlots(ctx context.Context, rc *resource.Context) error {
+	subs, err := resource.AllFromContext[*SubscriptionResource](rc, ResourceTypeSubscription)
+	if err != nil {
+		return fmt.Errorf("failed to list subscriptions: %w", err)
+	}
+
+	var relevant []*SubscriptionResource
+	for _, sub := range subs {
+		if sub.ProviderNode == r.Spec.NodeName {
+			relevant = append(relevant, sub)
+		}
+	}
+	if len(relevant) == 0 {
+		return nil
+	}
+
+	conn, err := r.Connection(ctx, rc, r.Spec.DatabaseName)
+	if err != nil {
+		return fmt.Errorf("failed to connect for replication slot check: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	const pollInterval = 2 * time.Second
+	for _, sub := range relevant {
+		for {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			exists, err := postgres.ReplicationSlotExists(sub.DatabaseName, sub.ProviderNode, sub.SubscriberNode).
+				Scalar(ctx, conn)
+			if err != nil {
+				return fmt.Errorf("failed to check replication slot for %s→%s: %w",
+					sub.ProviderNode, sub.SubscriberNode, err)
+			}
+			if exists {
+				break
+			}
+			time.Sleep(pollInterval)
+		}
+	}
 	return nil
 }
 

--- a/server/internal/database/instance_resource.go
+++ b/server/internal/database/instance_resource.go
@@ -278,12 +278,15 @@ func (r *InstanceResource) waitForReplicationSlots(ctx context.Context, rc *reso
 	}
 	defer conn.Close(ctx)
 
-	const pollInterval = 2 * time.Second
+	const (
+		pollInterval    = 2 * time.Second
+		slotWaitTimeout = 2 * time.Minute
+	)
+	ctx, cancel := context.WithTimeout(ctx, slotWaitTimeout)
+	defer cancel()
+
 	for _, sub := range relevant {
 		for {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
 			exists, err := postgres.ReplicationSlotExists(sub.DatabaseName, sub.ProviderNode, sub.SubscriberNode).
 				Scalar(ctx, conn)
 			if err != nil {
@@ -294,10 +297,10 @@ func (r *InstanceResource) waitForReplicationSlots(ctx context.Context, rc *reso
 				break
 			}
 			select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case <-time.After(pollInterval):
-				}
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(pollInterval):
+			}
 		}
 	}
 	return nil

--- a/server/internal/database/instance_resource.go
+++ b/server/internal/database/instance_resource.go
@@ -293,7 +293,11 @@ func (r *InstanceResource) waitForReplicationSlots(ctx context.Context, rc *reso
 			if exists {
 				break
 			}
-			time.Sleep(pollInterval)
+			select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(pollInterval):
+				}
 		}
 	}
 	return nil

--- a/server/internal/database/operations/common.go
+++ b/server/internal/database/operations/common.go
@@ -20,15 +20,6 @@ type NodeResources struct {
 	Scripts           database.Scripts
 }
 
-func (n *NodeResources) primaryInstance() *database.InstanceResources {
-	for _, instance := range n.InstanceResources {
-		if instance.InstanceID() == n.PrimaryInstanceID {
-			return instance
-		}
-	}
-
-	return nil
-}
 
 func (n *NodeResources) nodeResourceState() (*resource.State, error) {
 	var instanceIDs []string

--- a/server/internal/database/operations/end.go
+++ b/server/internal/database/operations/end.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/pgEdge/control-plane/server/internal/database"
-	"github.com/pgEdge/control-plane/server/internal/patroni"
 	"github.com/pgEdge/control-plane/server/internal/resource"
 )
 
@@ -35,20 +34,29 @@ func EndState(nodes []*NodeResources, services []*ServiceResources) (*resource.S
 		}
 		end.Merge(databaseState)
 
-		if len(node.InstanceResources) > 1 {
-			primary := node.primaryInstance()
-			if primary != nil {
-				// Primary will be non-nil for existing nodes. Adding the
-				// switchover resource to the end state prevents "permadrift"
-				// where this resource is created and deleted even if the update
-				// is a no-op.
-				resources = append(resources, &database.SwitchoverResource{
-					HostID:     primary.HostID(),
-					InstanceID: primary.InstanceID(),
-					TargetRole: patroni.InstanceRolePrimary,
-				})
-			}
-		}
+		// TODO(PLAT-665): Commented out to fix rolling update failures caused by
+		// the Spock 5.x replication slot race condition. The end-state
+		// switchover that restores the original primary runs before Spock's
+		// worker has had time to create failover slots (~60 s), breaking all
+		// subscriptions to that node. Re-enable this block to restore
+		// "retain primary" behavior once the race is fully resolved. When
+		// re-enabling, verify that the "patroni" import is present and that
+		// SwitchoverResource is also re-enabled in update_nodes.go.
+		//
+		// if len(node.InstanceResources) > 1 {
+		// 	primary := node.primaryInstance()
+		// 	if primary != nil {
+		// 		// Primary will be non-nil for existing nodes. Adding the
+		// 		// switchover resource to the end state prevents "permadrift"
+		// 		// where this resource is created and deleted even if the
+		// 		// update is a no-op.
+		// 		resources = append(resources, &database.SwitchoverResource{
+		// 			HostID:     primary.HostID(),
+		// 			InstanceID: primary.InstanceID(),
+		// 			TargetRole: patroni.InstanceRolePrimary,
+		// 		})
+		// 	}
+		// }
 
 		for _, peer := range nodes {
 			if peer.NodeName == node.NodeName {

--- a/server/internal/database/operations/end.go
+++ b/server/internal/database/operations/end.go
@@ -34,30 +34,6 @@ func EndState(nodes []*NodeResources, services []*ServiceResources) (*resource.S
 		}
 		end.Merge(databaseState)
 
-		// TODO(PLAT-665): Commented out to fix rolling update failures caused by
-		// the Spock 5.x replication slot race condition. The end-state
-		// switchover that restores the original primary runs before Spock's
-		// worker has had time to create failover slots (~60 s), breaking all
-		// subscriptions to that node. Re-enable this block to restore
-		// "retain primary" behavior once the race is fully resolved. When
-		// re-enabling, verify that the "patroni" import is present and that
-		// SwitchoverResource is also re-enabled in update_nodes.go.
-		//
-		// if len(node.InstanceResources) > 1 {
-		// 	primary := node.primaryInstance()
-		// 	if primary != nil {
-		// 		// Primary will be non-nil for existing nodes. Adding the
-		// 		// switchover resource to the end state prevents "permadrift"
-		// 		// where this resource is created and deleted even if the
-		// 		// update is a no-op.
-		// 		resources = append(resources, &database.SwitchoverResource{
-		// 			HostID:     primary.HostID(),
-		// 			InstanceID: primary.InstanceID(),
-		// 			TargetRole: patroni.InstanceRolePrimary,
-		// 		})
-		// 	}
-		// }
-
 		for _, peer := range nodes {
 			if peer.NodeName == node.NodeName {
 				continue

--- a/server/internal/database/operations/golden_test/TestRestoreDatabase/single_node_restore_in_two-node_db_with_replica.json
+++ b/server/internal/database/operations/golden_test/TestRestoreDatabase/single_node_restore_in_two-node_db_with_replica.json
@@ -187,14 +187,6 @@
         "reason": "does_not_exist",
         "diff": null
       }
-    ],
-    [
-      {
-        "type": "create",
-        "resource_id": "database.switchover::n1-instance-1-id",
-        "reason": "does_not_exist",
-        "diff": null
-      }
     ]
   ]
 ]

--- a/server/internal/database/operations/golden_test/TestUpdateDatabase/adding_a_replica.json
+++ b/server/internal/database/operations/golden_test/TestUpdateDatabase/adding_a_replica.json
@@ -63,14 +63,6 @@
         "reason": "does_not_exist",
         "diff": null
       }
-    ],
-    [
-      {
-        "type": "create",
-        "resource_id": "database.switchover::n1-instance-1-id",
-        "reason": "does_not_exist",
-        "diff": null
-      }
     ]
   ]
 ]

--- a/server/internal/database/operations/golden_test/TestUpdateDatabase/adding_a_replica_with_primary_update.json
+++ b/server/internal/database/operations/golden_test/TestUpdateDatabase/adding_a_replica_with_primary_update.json
@@ -125,14 +125,6 @@
         "reason": "does_not_exist",
         "diff": null
       }
-    ],
-    [
-      {
-        "type": "create",
-        "resource_id": "database.switchover::n1-instance-1-id",
-        "reason": "does_not_exist",
-        "diff": null
-      }
     ]
   ]
 ]

--- a/server/internal/database/operations/golden_test/TestUpdateDatabase/adding_multiple_replicas_concurrent.json
+++ b/server/internal/database/operations/golden_test/TestUpdateDatabase/adding_multiple_replicas_concurrent.json
@@ -99,20 +99,6 @@
         "reason": "does_not_exist",
         "diff": null
       }
-    ],
-    [
-      {
-        "type": "create",
-        "resource_id": "database.switchover::n1-instance-1-id",
-        "reason": "does_not_exist",
-        "diff": null
-      },
-      {
-        "type": "create",
-        "resource_id": "database.switchover::n2-instance-1-id",
-        "reason": "does_not_exist",
-        "diff": null
-      }
     ]
   ]
 ]

--- a/server/internal/database/operations/golden_test/TestUpdateDatabase/adding_multiple_replicas_rolling.json
+++ b/server/internal/database/operations/golden_test/TestUpdateDatabase/adding_multiple_replicas_rolling.json
@@ -125,20 +125,6 @@
         "reason": "does_not_exist",
         "diff": null
       }
-    ],
-    [
-      {
-        "type": "create",
-        "resource_id": "database.switchover::n1-instance-1-id",
-        "reason": "does_not_exist",
-        "diff": null
-      },
-      {
-        "type": "create",
-        "resource_id": "database.switchover::n2-instance-1-id",
-        "reason": "does_not_exist",
-        "diff": null
-      }
     ]
   ]
 ]

--- a/server/internal/database/operations/update_nodes.go
+++ b/server/internal/database/operations/update_nodes.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/pgEdge/control-plane/server/internal/database"
-	"github.com/pgEdge/control-plane/server/internal/patroni"
 	"github.com/pgEdge/control-plane/server/internal/resource"
 )
 
@@ -16,7 +14,6 @@ import (
 func UpdateNode(start *resource.State, node *NodeResources) ([]*resource.State, error) {
 	var primary *resource.State
 	var replicaUpdates, replicaAdds []*resource.State
-	var primaryHostID string
 
 	for _, inst := range node.InstanceResources {
 		state, err := inst.InstanceState()
@@ -30,7 +27,6 @@ func UpdateNode(start *resource.State, node *NodeResources) ([]*resource.State, 
 				return nil, fmt.Errorf("invalid state: node %s exists, but its primary instance '%s' hasn't been created yet", node.NodeName, node.PrimaryInstanceID)
 			}
 			primary = state
-			primaryHostID = inst.HostID()
 		case start.HasResources(inst.Instance.Identifier()):
 			replicaUpdates = append(replicaUpdates, state)
 		default:
@@ -46,18 +42,23 @@ func UpdateNode(start *resource.State, node *NodeResources) ([]*resource.State, 
 		return nil, fmt.Errorf("node %s has no primary instance", node.NodeName)
 	}
 
-	// This condition is true when we have existing replicas
-	if len(replicaUpdates) != 0 {
-		// Ensure that we always switch back to the original primary
-		err := primary.AddResource(&database.SwitchoverResource{
-			HostID:     primaryHostID,
-			InstanceID: node.PrimaryInstanceID,
-			TargetRole: patroni.InstanceRolePrimary,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to add switchover resource to replica state: %w", err)
-		}
-	}
+	// TODO(PLAT-665): Commented out to fix rolling update failures caused by
+	// the Spock 5.x replication slot race condition. The second switchover that
+	// restores the original primary runs before Spock's worker has had time to
+	// create failover slots (~60 s), breaking all subscriptions to that node.
+	// Re-enable this block to restore "retain primary" behavior once the race
+	// is fully resolved.
+	//
+	// if len(replicaUpdates) != 0 {
+	// 	err := primary.AddResource(&database.SwitchoverResource{
+	// 		HostID:     primaryHostID,
+	// 		InstanceID: node.PrimaryInstanceID,
+	// 		TargetRole: patroni.InstanceRolePrimary,
+	// 	})
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf("failed to add switchover resource to replica state: %w", err)
+	// 	}
+	// }
 
 	// Existing replicas should be updated first and new replicas should be
 	// added last.

--- a/server/internal/database/operations/update_nodes.go
+++ b/server/internal/database/operations/update_nodes.go
@@ -42,24 +42,6 @@ func UpdateNode(start *resource.State, node *NodeResources) ([]*resource.State, 
 		return nil, fmt.Errorf("node %s has no primary instance", node.NodeName)
 	}
 
-	// TODO(PLAT-665): Commented out to fix rolling update failures caused by
-	// the Spock 5.x replication slot race condition. The second switchover that
-	// restores the original primary runs before Spock's worker has had time to
-	// create failover slots (~60 s), breaking all subscriptions to that node.
-	// Re-enable this block to restore "retain primary" behavior once the race
-	// is fully resolved.
-	//
-	// if len(replicaUpdates) != 0 {
-	// 	err := primary.AddResource(&database.SwitchoverResource{
-	// 		HostID:     primaryHostID,
-	// 		InstanceID: node.PrimaryInstanceID,
-	// 		TargetRole: patroni.InstanceRolePrimary,
-	// 	})
-	// 	if err != nil {
-	// 		return nil, fmt.Errorf("failed to add switchover resource to replica state: %w", err)
-	// 	}
-	// }
-
 	// Existing replicas should be updated first and new replicas should be
 	// added last.
 	states := slices.Concat(replicaUpdates, []*resource.State{primary}, replicaAdds)

--- a/server/internal/database/operations/update_nodes_test.go
+++ b/server/internal/database/operations/update_nodes_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pgEdge/control-plane/server/internal/database"
 	"github.com/pgEdge/control-plane/server/internal/database/operations"
-	"github.com/pgEdge/control-plane/server/internal/patroni"
 	"github.com/pgEdge/control-plane/server/internal/resource"
 )
 
@@ -105,11 +104,6 @@ func TestUpdateNode(t *testing.T) {
 								instance2.InstanceID(),
 							},
 						},
-						&database.SwitchoverResource{
-							HostID:     instance1.HostID(),
-							InstanceID: instance1.InstanceID(),
-							TargetRole: patroni.InstanceRolePrimary,
-						},
 					},
 					instance1.InstanceDependencies,
 				),
@@ -172,11 +166,6 @@ func TestUpdateNode(t *testing.T) {
 								instance2.InstanceID(),
 								instance3.InstanceID(),
 							},
-						},
-						&database.SwitchoverResource{
-							HostID:     instance1.HostID(),
-							InstanceID: instance1.InstanceID(),
-							TargetRole: patroni.InstanceRolePrimary,
 						},
 					},
 					instance1.InstanceDependencies,
@@ -438,11 +427,6 @@ func TestRollingUpdateNodes(t *testing.T) {
 								n1Instance2.InstanceID(),
 							},
 						},
-						&database.SwitchoverResource{
-							HostID:     n1Instance1.HostID(),
-							InstanceID: n1Instance1.InstanceID(),
-							TargetRole: patroni.InstanceRolePrimary,
-						},
 					},
 					n1Instance1.InstanceDependencies,
 				),
@@ -527,11 +511,6 @@ func TestRollingUpdateNodes(t *testing.T) {
 								n1Instance2.InstanceID(),
 							},
 						},
-						&database.SwitchoverResource{
-							HostID:     n1Instance1.HostID(),
-							InstanceID: n1Instance1.InstanceID(),
-							TargetRole: patroni.InstanceRolePrimary,
-						},
 					},
 					n1Instance1.InstanceDependencies,
 				),
@@ -550,11 +529,6 @@ func TestRollingUpdateNodes(t *testing.T) {
 								n2Instance1.InstanceID(),
 								n2Instance2.InstanceID(),
 							},
-						},
-						&database.SwitchoverResource{
-							HostID:     n2Instance1.HostID(),
-							InstanceID: n2Instance1.InstanceID(),
-							TargetRole: patroni.InstanceRolePrimary,
 						},
 					},
 					n2Instance1.InstanceDependencies,
@@ -820,11 +794,6 @@ func TestConcurrentUpdateNodes(t *testing.T) {
 								n1Instance2.InstanceID(),
 							},
 						},
-						&database.SwitchoverResource{
-							HostID:     n1Instance1.HostID(),
-							InstanceID: n1Instance1.InstanceID(),
-							TargetRole: patroni.InstanceRolePrimary,
-						},
 					},
 					n1Instance1.InstanceDependencies,
 				),
@@ -910,16 +879,6 @@ func TestConcurrentUpdateNodes(t *testing.T) {
 								n2Instance1.InstanceID(),
 								n2Instance2.InstanceID(),
 							},
-						},
-						&database.SwitchoverResource{
-							HostID:     n1Instance1.HostID(),
-							InstanceID: n1Instance1.InstanceID(),
-							TargetRole: patroni.InstanceRolePrimary,
-						},
-						&database.SwitchoverResource{
-							HostID:     n2Instance1.HostID(),
-							InstanceID: n2Instance1.InstanceID(),
-							TargetRole: patroni.InstanceRolePrimary,
 						},
 					},
 					slices.Concat(

--- a/server/internal/postgres/create_db.go
+++ b/server/internal/postgres/create_db.go
@@ -366,6 +366,19 @@ func IsReplicationSlotActive(databaseName, providerNode, subscriberNode string) 
 	}
 }
 
+// ReplicationSlotExists checks whether the replication slot for the given
+// subscription exists. Used to poll for Spock 5.x failover slot creation after
+// a switchover, which can take up to 60 seconds.
+func ReplicationSlotExists(databaseName, providerNode, subscriberNode string) Query[bool] {
+	slotName := ReplicationSlotName(databaseName, providerNode, subscriberNode)
+	return Query[bool]{
+		SQL: "SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = @slot_name);",
+		Args: pgx.NamedArgs{
+			"slot_name": slotName,
+		},
+	}
+}
+
 func GetReplicationSlotLSNFromCommitTS(databaseName, providerNode, subscriberNode string, commitTS time.Time) Query[string] {
 	slotName := ReplicationSlotName(databaseName, providerNode, subscriberNode)
 


### PR DESCRIPTION
## Summary
This PR fixes rolling database updates failing on multi-node databases with replica instances.

## Changes
- **`instance_resource.go`** — Add `waitForReplicationSlots` helper. When
  `initializeInstance` runs on a replica instance, it now polls
  `pg_replication_slots` for every subscription where this node is the
  provider, blocking until each slot exists before marking the instance
  available. Addresses the Spock 5.x race where the worker takes up to
  60 s to create failover slots after a switchover.
- **`postgres/create_db.go`** — Add `ReplicationSlotExists` query used by
  the helper above.
- **`operations/update_nodes.go`** — Comment out the `SwitchoverResource`
  addition that forced a second Patroni switchover to restore the original
  primary after a rolling update. This second switchover was the trigger for
  the subscription breakage. The `SwitchoverResource` type is kept so
  "retain primary" behaviour can be re-enabled later.
- **`update_nodes_test.go`** — Remove `SwitchoverResource` from all
  expected states to match the new behaviour.


## Testing

Verification:
1. Created a cluster 
2. Created DB 
```
cp1-req create-database < ../demo/Images/create_db_lower_image.json | cp-follow-task
{
  "database": {
    "created_at": "2026-07-08T11:42:11Z",
    "id": "storefront",
    "spec": {
      "database_name": "storefront",
      "database_users": [
        {
          "attributes": [
            "SUPERUSER",
            "LOGIN"
          ],
          "db_owner": true,
          "username": "admin"
        }
      ],
      "nodes": [
        {
          "host_ids": [
            "host-1",
            "host-2"
          ],
          "name": "n1"
        },
        {
          "host_ids": [
            "host-3",
            "host-4"
          ],
          "name": "n2"
        }
      ],
      "postgres_version": "17.9",
      "spock_version": "5"
    },
    "state": "creating",
    "updated_at": "2026-07-08T11:42:11Z"
  },
  "task": {
    "created_at": "2026-07-08T11:42:11Z",
    "database_id": "storefront",
    "entity_id": "storefront",
    "scope": "database",
    "status": "pending",
    "task_id": "019f4189-16d3-714a-b7d7-318de3dc1aed",
    "type": "create"
  }
}
[2026-07-08T11:42:12Z] refreshing current state
[2026-07-08T11:42:12Z] finished refreshing current state (took 189.450625ms)
[2026-07-08T11:42:15Z] creating resource common.patroni_cluster::n1
[2026-07-08T11:42:15Z] finished creating resource common.patroni_cluster::n1 (took 24.458µs)
[2026-07-08T11:42:15Z] creating resource common.patroni_cluster::n2
[2026-07-08T11:42:15Z] finished creating resource common.patroni_cluster::n2 (took 7.625µs)
[2026-07-08T11:42:15Z] creating resource swarm.network::storefront-database
[2026-07-08T11:42:15Z] finished creating resource swarm.network::storefront-database (took 6.642167ms)
[2026-07-08T11:42:15Z] creating resource filesystem.dir::storefront-n2-ant97dj4-instance
[2026-07-08T11:42:15Z] finished creating resource filesystem.dir::storefront-n2-ant97dj4-instance (took 635.792µs)
[2026-07-08T11:42:15Z] creating resource filesystem.dir::storefront-n1-689qacsi-instance
[2026-07-08T11:42:15Z] finished creating resource filesystem.dir::storefront-n1-689qacsi-instance (took 696.583µs)
[2026-07-08T11:42:15Z] creating resource common.patroni_member::storefront-n1-689qacsi
[2026-07-08T11:42:15Z] finished creating resource common.patroni_member::storefront-n1-689qacsi (took 37.125µs)
[2026-07-08T11:42:15Z] creating resource common.patroni_member::storefront-n2-ant97dj4
[2026-07-08T11:42:15Z] finished creating resource common.patroni_member::storefront-n2-ant97dj4 (took 13.292µs)
[2026-07-08T11:42:15Z] creating resource filesystem.dir::storefront-n2-ant97dj4-configs
[2026-07-08T11:42:15Z] finished creating resource filesystem.dir::storefront-n2-ant97dj4-configs (took 749.417µs)
[2026-07-08T11:42:15Z] creating resource filesystem.dir::storefront-n2-ant97dj4-data
[2026-07-08T11:42:15Z] finished creating resource filesystem.dir::storefront-n2-ant97dj4-data (took 488.791µs)
[2026-07-08T11:42:15Z] creating resource filesystem.dir::storefront-n2-ant97dj4-certificates
[2026-07-08T11:42:15Z] finished creating resource filesystem.dir::storefront-n2-ant97dj4-certificates (took 689.583µs)
[2026-07-08T11:42:15Z] creating resource filesystem.dir::storefront-n1-689qacsi-configs
[2026-07-08T11:42:15Z] finished creating resource filesystem.dir::storefront-n1-689qacsi-configs (took 1.097916ms)
[2026-07-08T11:42:15Z] creating resource filesystem.dir::storefront-n1-689qacsi-data
[2026-07-08T11:42:15Z] finished creating resource filesystem.dir::storefront-n1-689qacsi-data (took 669µs)
[2026-07-08T11:42:15Z] creating resource filesystem.dir::storefront-n1-689qacsi-certificates
[2026-07-08T11:42:15Z] finished creating resource filesystem.dir::storefront-n1-689qacsi-certificates (took 402.083µs)
[2026-07-08T11:42:16Z] creating resource common.etcd_creds::storefront-n2-ant97dj4
[2026-07-08T11:42:16Z] creating resource common.postgres_certs::storefront-n2-ant97dj4
[2026-07-08T11:42:16Z] finished creating resource common.postgres_certs::storefront-n2-ant97dj4 (took 10.922959ms)
[2026-07-08T11:42:16Z] creating resource common.etcd_creds::storefront-n1-689qacsi
[2026-07-08T11:42:16Z] finished creating resource common.etcd_creds::storefront-n2-ant97dj4 (took 80.764875ms)
[2026-07-08T11:42:16Z] finished creating resource common.etcd_creds::storefront-n1-689qacsi (took 64.586625ms)
[2026-07-08T11:42:16Z] creating resource common.postgres_certs::storefront-n1-689qacsi
[2026-07-08T11:42:16Z] finished creating resource common.postgres_certs::storefront-n1-689qacsi (took 6.720583ms)
[2026-07-08T11:42:16Z] creating resource swarm.patroni_config::storefront-n2-ant97dj4
[2026-07-08T11:42:16Z] finished creating resource swarm.patroni_config::storefront-n2-ant97dj4 (took 3.551083ms)
[2026-07-08T11:42:16Z] creating resource swarm.patroni_config::storefront-n1-689qacsi
[2026-07-08T11:42:16Z] finished creating resource swarm.patroni_config::storefront-n1-689qacsi (took 2.931875ms)
[2026-07-08T11:42:17Z] creating resource swarm.postgres_service_spec::storefront-n2-ant97dj4
[2026-07-08T11:42:17Z] finished creating resource swarm.postgres_service_spec::storefront-n2-ant97dj4 (took 170.459µs)
[2026-07-08T11:42:17Z] creating resource swarm.postgres_service_spec::storefront-n1-689qacsi
[2026-07-08T11:42:17Z] finished creating resource swarm.postgres_service_spec::storefront-n1-689qacsi (took 172µs)
[2026-07-08T11:42:17Z] creating resource swarm.check_will_restart::storefront-n1-689qacsi
[2026-07-08T11:42:17Z] finished creating resource swarm.check_will_restart::storefront-n1-689qacsi (took 3.801125ms)
[2026-07-08T11:42:17Z] creating resource swarm.check_will_restart::storefront-n2-ant97dj4
[2026-07-08T11:42:17Z] finished creating resource swarm.check_will_restart::storefront-n2-ant97dj4 (took 1.643333ms)
[2026-07-08T11:42:17Z] creating resource swarm.switchover::storefront-n2-ant97dj4
[2026-07-08T11:42:17Z] finished creating resource swarm.switchover::storefront-n2-ant97dj4 (took 16.458µs)
[2026-07-08T11:42:17Z] creating resource swarm.switchover::storefront-n1-689qacsi
[2026-07-08T11:42:17Z] finished creating resource swarm.switchover::storefront-n1-689qacsi (took 16.292µs)
[2026-07-08T11:42:18Z] creating resource swarm.postgres_service::storefront-n2-ant97dj4
[2026-07-08T11:42:18Z] creating resource swarm.postgres_service::storefront-n1-689qacsi
[2026-07-08T11:42:33Z] finished creating resource swarm.postgres_service::storefront-n2-ant97dj4 (took 15.014274591s)
[2026-07-08T11:42:33Z] finished creating resource swarm.postgres_service::storefront-n1-689qacsi (took 15.010869007s)
[2026-07-08T11:42:33Z] creating resource database.instance::storefront-n2-ant97dj4
[2026-07-08T11:42:33Z] creating resource database.instance::storefront-n1-689qacsi
[2026-07-08T11:42:43Z] finished creating resource database.instance::storefront-n2-ant97dj4 (took 10.050499463s)
[2026-07-08T11:42:43Z] finished creating resource database.instance::storefront-n1-689qacsi (took 10.037279463s)
[2026-07-08T11:42:43Z] creating resource filesystem.dir::storefront-n1-9ptayhma-instance
[2026-07-08T11:42:43Z] finished creating resource filesystem.dir::storefront-n1-9ptayhma-instance (took 826µs)
[2026-07-08T11:42:43Z] creating resource filesystem.dir::storefront-n2-2kqnsx2a-instance
[2026-07-08T11:42:43Z] finished creating resource filesystem.dir::storefront-n2-2kqnsx2a-instance (took 664.792µs)
[2026-07-08T11:42:44Z] creating resource common.patroni_member::storefront-n2-2kqnsx2a
[2026-07-08T11:42:44Z] finished creating resource common.patroni_member::storefront-n2-2kqnsx2a (took 10.792µs)
[2026-07-08T11:42:44Z] creating resource common.patroni_member::storefront-n1-9ptayhma
[2026-07-08T11:42:44Z] finished creating resource common.patroni_member::storefront-n1-9ptayhma (took 9.542µs)
[2026-07-08T11:42:44Z] creating resource filesystem.dir::storefront-n1-9ptayhma-configs
[2026-07-08T11:42:44Z] finished creating resource filesystem.dir::storefront-n1-9ptayhma-configs (took 464.833µs)
[2026-07-08T11:42:44Z] creating resource filesystem.dir::storefront-n1-9ptayhma-certificates
[2026-07-08T11:42:44Z] finished creating resource filesystem.dir::storefront-n1-9ptayhma-certificates (took 452.167µs)
[2026-07-08T11:42:44Z] creating resource filesystem.dir::storefront-n1-9ptayhma-data
[2026-07-08T11:42:44Z] finished creating resource filesystem.dir::storefront-n1-9ptayhma-data (took 412.875µs)
[2026-07-08T11:42:44Z] creating resource filesystem.dir::storefront-n2-2kqnsx2a-data
[2026-07-08T11:42:44Z] finished creating resource filesystem.dir::storefront-n2-2kqnsx2a-data (took 452.083µs)
[2026-07-08T11:42:44Z] creating resource filesystem.dir::storefront-n2-2kqnsx2a-configs
[2026-07-08T11:42:44Z] finished creating resource filesystem.dir::storefront-n2-2kqnsx2a-configs (took 364.833µs)
[2026-07-08T11:42:44Z] creating resource filesystem.dir::storefront-n2-2kqnsx2a-certificates
[2026-07-08T11:42:44Z] finished creating resource filesystem.dir::storefront-n2-2kqnsx2a-certificates (took 651µs)
[2026-07-08T11:42:44Z] creating resource common.etcd_creds::storefront-n1-9ptayhma
[2026-07-08T11:42:44Z] creating resource common.postgres_certs::storefront-n1-9ptayhma
[2026-07-08T11:42:44Z] finished creating resource common.postgres_certs::storefront-n1-9ptayhma (took 9.192333ms)
[2026-07-08T11:42:44Z] creating resource common.postgres_certs::storefront-n2-2kqnsx2a
[2026-07-08T11:42:44Z] creating resource common.etcd_creds::storefront-n2-2kqnsx2a
[2026-07-08T11:42:44Z] finished creating resource common.postgres_certs::storefront-n2-2kqnsx2a (took 13.296375ms)
[2026-07-08T11:42:44Z] finished creating resource common.etcd_creds::storefront-n1-9ptayhma (took 76.868125ms)
[2026-07-08T11:42:44Z] finished creating resource common.etcd_creds::storefront-n2-2kqnsx2a (took 65.79975ms)
[2026-07-08T11:42:45Z] creating resource swarm.patroni_config::storefront-n1-9ptayhma
[2026-07-08T11:42:45Z] finished creating resource swarm.patroni_config::storefront-n1-9ptayhma (took 2.532167ms)
[2026-07-08T11:42:45Z] creating resource swarm.patroni_config::storefront-n2-2kqnsx2a
[2026-07-08T11:42:45Z] finished creating resource swarm.patroni_config::storefront-n2-2kqnsx2a (took 3.031666ms)
[2026-07-08T11:42:45Z] creating resource swarm.postgres_service_spec::storefront-n1-9ptayhma
[2026-07-08T11:42:45Z] finished creating resource swarm.postgres_service_spec::storefront-n1-9ptayhma (took 127.334µs)
[2026-07-08T11:42:45Z] creating resource swarm.postgres_service_spec::storefront-n2-2kqnsx2a
[2026-07-08T11:42:45Z] finished creating resource swarm.postgres_service_spec::storefront-n2-2kqnsx2a (took 129.375µs)
[2026-07-08T11:42:45Z] creating resource swarm.check_will_restart::storefront-n1-9ptayhma
[2026-07-08T11:42:45Z] finished creating resource swarm.check_will_restart::storefront-n1-9ptayhma (took 1.688708ms)
[2026-07-08T11:42:45Z] creating resource swarm.check_will_restart::storefront-n2-2kqnsx2a
[2026-07-08T11:42:45Z] finished creating resource swarm.check_will_restart::storefront-n2-2kqnsx2a (took 1.408667ms)
[2026-07-08T11:42:46Z] creating resource swarm.switchover::storefront-n1-9ptayhma
[2026-07-08T11:42:46Z] finished creating resource swarm.switchover::storefront-n1-9ptayhma (took 13.75µs)
[2026-07-08T11:42:46Z] creating resource swarm.switchover::storefront-n2-2kqnsx2a
[2026-07-08T11:42:46Z] finished creating resource swarm.switchover::storefront-n2-2kqnsx2a (took 14µs)
[2026-07-08T11:42:46Z] creating resource swarm.postgres_service::storefront-n1-9ptayhma
[2026-07-08T11:42:46Z] creating resource swarm.postgres_service::storefront-n2-2kqnsx2a
[2026-07-08T11:42:56Z] finished creating resource swarm.postgres_service::storefront-n1-9ptayhma (took 10.012425213s)
[2026-07-08T11:42:56Z] finished creating resource swarm.postgres_service::storefront-n2-2kqnsx2a (took 10.010445172s)
[2026-07-08T11:42:56Z] creating resource database.instance::storefront-n1-9ptayhma
[2026-07-08T11:42:56Z] creating resource database.instance::storefront-n2-2kqnsx2a
[2026-07-08T11:43:06Z] finished creating resource database.instance::storefront-n1-9ptayhma (took 10.02312963s)
[2026-07-08T11:43:06Z] finished creating resource database.instance::storefront-n2-2kqnsx2a (took 10.019455046s)
[2026-07-08T11:43:07Z] creating resource database.node::n2
[2026-07-08T11:43:07Z] finished creating resource database.node::n2 (took 106.084µs)
[2026-07-08T11:43:07Z] creating resource database.node::n1
[2026-07-08T11:43:07Z] finished creating resource database.node::n1 (took 74.459µs)
[2026-07-08T11:43:07Z] creating resource monitor.instance::storefront-n2-ant97dj4
[2026-07-08T11:43:07Z] finished creating resource monitor.instance::storefront-n2-ant97dj4 (took 12.093583ms)
[2026-07-08T11:43:07Z] creating resource monitor.instance::storefront-n1-9ptayhma
[2026-07-08T11:43:07Z] finished creating resource monitor.instance::storefront-n1-9ptayhma (took 11.915667ms)
[2026-07-08T11:43:07Z] creating resource monitor.instance::storefront-n1-689qacsi
[2026-07-08T11:43:07Z] creating resource monitor.instance::storefront-n2-2kqnsx2a
[2026-07-08T11:43:07Z] finished creating resource monitor.instance::storefront-n1-689qacsi (took 19.870291ms)
[2026-07-08T11:43:07Z] finished creating resource monitor.instance::storefront-n2-2kqnsx2a (took 13.436292ms)
[2026-07-08T11:43:07Z] creating resource database.postgres_database::n2:storefront
[2026-07-08T11:43:07Z] creating resource database.postgres_database::n1:storefront
[2026-07-08T11:43:08Z] finished creating resource database.postgres_database::n2:storefront (took 397.428417ms)
[2026-07-08T11:43:08Z] finished creating resource database.postgres_database::n1:storefront (took 408.602209ms)
[2026-07-08T11:43:08Z] creating resource database.replication_slot::n2:n1:storefront
[2026-07-08T11:43:08Z] finished creating resource database.replication_slot::n2:n1:storefront (took 26.708µs)
[2026-07-08T11:43:08Z] creating resource database.replication_slot::n1:n2:storefront
[2026-07-08T11:43:08Z] finished creating resource database.replication_slot::n1:n2:storefront (took 10.375µs)
[2026-07-08T11:43:08Z] creating resource database.subscription::n1:n2:storefront
[2026-07-08T11:43:08Z] finished creating resource database.subscription::n1:n2:storefront (took 30.142958ms)
[2026-07-08T11:43:08Z] creating resource database.subscription::n2:n1:storefront
[2026-07-08T11:43:08Z] finished creating resource database.subscription::n2:n1:storefront (took 19.272708ms)

database entity storefront task 019f4189-16d3-714a-b7d7-318de3dc1aed completed

```
3. Insert data and verify 
4. Update database
```
➜  control-plane git:(PLAT-665-rolling-database-update-fails-on-multi-replica-nodes) cp1-req update-database storefront  < ../demo/Images/create_db_for_upgrade.json | cp-follow-task 
{
  "database": {
    "created_at": "2026-07-08T11:42:11Z",
    "id": "storefront",
    "instances": [
      {
        "created_at": "2026-07-08T11:42:15Z",
        "host_id": "host-1",
        "id": "storefront-n1-689qacsi",
        "node_name": "n1",
        "postgres": {
          "patroni_state": "running",
          "role": "primary",
          "version": "17.9"
        },
        "spock": {
          "read_only": "off",
          "subscriptions": [
            {
              "name": "sub_n2_n1",
              "provider_node": "n2",
              "status": "replicating"
            }
          ],
          "version": "5.0.6"
        },
        "state": "available",
        "status_updated_at": "2026-07-08T12:23:13Z",
        "updated_at": "2026-07-08T12:17:58Z"
      },
      {
        "created_at": "2026-07-08T11:42:43Z",
        "host_id": "host-2",
        "id": "storefront-n1-9ptayhma",
        "node_name": "n1",
        "postgres": {
          "patroni_state": "running",
          "role": "replica",
          "version": "17.9"
        },
        "state": "available",
        "status_updated_at": "2026-07-08T12:23:12Z",
        "updated_at": "2026-07-08T12:17:58Z"
      },
      {
        "created_at": "2026-07-08T11:42:43Z",
        "host_id": "host-4",
        "id": "storefront-n2-2kqnsx2a",
        "node_name": "n2",
        "postgres": {
          "patroni_state": "running",
          "role": "replica",
          "version": "17.9"
        },
        "state": "available",
        "status_updated_at": "2026-07-08T12:23:13Z",
        "updated_at": "2026-07-08T12:17:58Z"
      },
      {
        "created_at": "2026-07-08T11:42:15Z",
        "host_id": "host-3",
        "id": "storefront-n2-ant97dj4",
        "node_name": "n2",
        "postgres": {
          "patroni_state": "running",
          "role": "primary",
          "version": "17.9"
        },
        "spock": {
          "read_only": "off",
          "subscriptions": [
            {
              "name": "sub_n1_n2",
              "provider_node": "n1",
              "status": "replicating"
            }
          ],
          "version": "5.0.6"
        },
        "state": "available",
        "status_updated_at": "2026-07-08T12:23:12Z",
        "updated_at": "2026-07-08T12:17:57Z"
      }
    ],
    "spec": {
      "database_name": "storefront",
      "database_users": [
        {
          "attributes": [
            "SUPERUSER",
            "LOGIN"
          ],
          "db_owner": true,
          "username": "admin"
        }
      ],
      "nodes": [
        {
          "host_ids": [
            "host-1",
            "host-2"
          ],
          "name": "n1"
        },
        {
          "host_ids": [
            "host-3",
            "host-4"
          ],
          "name": "n2"
        }
      ],
      "postgres_version": "17.10",
      "spock_version": "5"
    },
    "state": "modifying",
    "updated_at": "2026-07-08T12:23:13Z"
  },
  "task": {
    "created_at": "2026-07-08T12:23:13Z",
    "database_id": "storefront",
    "entity_id": "storefront",
    "scope": "database",
    "status": "pending",
    "task_id": "019f41ae-a8ba-713f-b799-fbb735219d69",
    "type": "update"
  }
}
[2026-07-08T12:23:15Z] refreshing current state
[2026-07-08T12:23:24Z] finished refreshing current state (took 9.593077462s)
[2026-07-08T12:23:26Z] updating resource swarm.postgres_service_spec::storefront-n1-9ptayhma
[2026-07-08T12:23:26Z] finished updating resource swarm.postgres_service_spec::storefront-n1-9ptayhma (took 123.875µs)
[2026-07-08T12:23:27Z] updating resource swarm.check_will_restart::storefront-n1-9ptayhma
[2026-07-08T12:23:27Z] finished updating resource swarm.check_will_restart::storefront-n1-9ptayhma (took 5.80075ms)
[2026-07-08T12:23:27Z] updating resource swarm.switchover::storefront-n1-9ptayhma
[2026-07-08T12:23:27Z] finished updating resource swarm.switchover::storefront-n1-9ptayhma (took 1.362458ms)
[2026-07-08T12:23:27Z] updating resource swarm.postgres_service::storefront-n1-9ptayhma
[2026-07-08T12:23:52Z] finished updating resource swarm.postgres_service::storefront-n1-9ptayhma (took 25.019166929s)
[2026-07-08T12:23:52Z] updating resource database.instance::storefront-n1-9ptayhma
[2026-07-08T12:24:02Z] finished updating resource database.instance::storefront-n1-9ptayhma (took 10.028921255s)
[2026-07-08T12:24:02Z] updating resource database.node::n1
[2026-07-08T12:24:02Z] finished updating resource database.node::n1 (took 81.875µs)
[2026-07-08T12:24:02Z] updating resource monitor.instance::storefront-n1-9ptayhma
[2026-07-08T12:24:02Z] finished updating resource monitor.instance::storefront-n1-9ptayhma (took 13.568416ms)
[2026-07-08T12:24:03Z] updating resource database.postgres_database::n1:storefront
[2026-07-08T12:24:03Z] finished updating resource database.postgres_database::n1:storefront (took 19.99825ms)
[2026-07-08T12:24:03Z] updating resource database.replication_slot::n1:n2:storefront
[2026-07-08T12:24:03Z] finished updating resource database.replication_slot::n1:n2:storefront (took 16.042µs)
[2026-07-08T12:24:03Z] updating resource database.subscription::n1:n2:storefront
[2026-07-08T12:24:03Z] finished updating resource database.subscription::n1:n2:storefront (took 6.880584ms)
[2026-07-08T12:24:04Z] updating resource database.subscription::n2:n1:storefront
[2026-07-08T12:24:04Z] finished updating resource database.subscription::n2:n1:storefront (took 10.561083ms)
[2026-07-08T12:24:04Z] updating resource swarm.postgres_service_spec::storefront-n1-689qacsi
[2026-07-08T12:24:04Z] finished updating resource swarm.postgres_service_spec::storefront-n1-689qacsi (took 123.084µs)
[2026-07-08T12:24:04Z] updating resource swarm.check_will_restart::storefront-n1-689qacsi
[2026-07-08T12:24:04Z] finished updating resource swarm.check_will_restart::storefront-n1-689qacsi (took 4.192042ms)
[2026-07-08T12:24:05Z] updating resource swarm.switchover::storefront-n1-689qacsi
[2026-07-08T12:24:17Z] finished updating resource swarm.switchover::storefront-n1-689qacsi (took 12.067031089s)
[2026-07-08T12:24:17Z] updating resource swarm.postgres_service::storefront-n1-689qacsi
[2026-07-08T12:24:42Z] finished updating resource swarm.postgres_service::storefront-n1-689qacsi (took 25.012601427s)
[2026-07-08T12:24:42Z] updating resource database.instance::storefront-n1-689qacsi
[2026-07-08T12:24:52Z] finished updating resource database.instance::storefront-n1-689qacsi (took 10.028515255s)
[2026-07-08T12:24:53Z] updating resource database.node::n1
[2026-07-08T12:24:53Z] finished updating resource database.node::n1 (took 84µs)
[2026-07-08T12:24:53Z] updating resource monitor.instance::storefront-n1-689qacsi
[2026-07-08T12:24:53Z] finished updating resource monitor.instance::storefront-n1-689qacsi (took 13.058833ms)
[2026-07-08T12:24:53Z] updating resource database.postgres_database::n1:storefront
[2026-07-08T12:24:53Z] finished updating resource database.postgres_database::n1:storefront (took 33.26725ms)
[2026-07-08T12:24:53Z] updating resource database.replication_slot::n1:n2:storefront
[2026-07-08T12:24:53Z] finished updating resource database.replication_slot::n1:n2:storefront (took 30.167µs)
[2026-07-08T12:24:53Z] updating resource database.subscription::n1:n2:storefront
[2026-07-08T12:24:53Z] finished updating resource database.subscription::n1:n2:storefront (took 11.128916ms)
[2026-07-08T12:24:53Z] updating resource database.subscription::n2:n1:storefront
[2026-07-08T12:24:53Z] finished updating resource database.subscription::n2:n1:storefront (took 6.446542ms)
[2026-07-08T12:24:54Z] updating resource swarm.postgres_service_spec::storefront-n2-2kqnsx2a
[2026-07-08T12:24:54Z] finished updating resource swarm.postgres_service_spec::storefront-n2-2kqnsx2a (took 135.166µs)
[2026-07-08T12:24:54Z] updating resource swarm.check_will_restart::storefront-n2-2kqnsx2a
[2026-07-08T12:24:54Z] finished updating resource swarm.check_will_restart::storefront-n2-2kqnsx2a (took 4.440834ms)
[2026-07-08T12:24:55Z] updating resource swarm.switchover::storefront-n2-2kqnsx2a
[2026-07-08T12:24:55Z] finished updating resource swarm.switchover::storefront-n2-2kqnsx2a (took 1.111ms)
[2026-07-08T12:24:55Z] updating resource swarm.postgres_service::storefront-n2-2kqnsx2a
[2026-07-08T12:25:20Z] finished updating resource swarm.postgres_service::storefront-n2-2kqnsx2a (took 25.015156845s)
[2026-07-08T12:25:20Z] updating resource database.instance::storefront-n2-2kqnsx2a
[2026-07-08T12:25:30Z] finished updating resource database.instance::storefront-n2-2kqnsx2a (took 10.029629754s)
[2026-07-08T12:25:30Z] updating resource database.node::n2
[2026-07-08T12:25:30Z] finished updating resource database.node::n2 (took 78.792µs)
[2026-07-08T12:25:31Z] updating resource monitor.instance::storefront-n2-2kqnsx2a
[2026-07-08T12:25:31Z] finished updating resource monitor.instance::storefront-n2-2kqnsx2a (took 15.29325ms)
[2026-07-08T12:25:31Z] updating resource database.postgres_database::n2:storefront
[2026-07-08T12:25:31Z] finished updating resource database.postgres_database::n2:storefront (took 24.493583ms)
[2026-07-08T12:25:31Z] updating resource database.replication_slot::n2:n1:storefront
[2026-07-08T12:25:31Z] finished updating resource database.replication_slot::n2:n1:storefront (took 12.75µs)
[2026-07-08T12:25:31Z] updating resource database.subscription::n1:n2:storefront
[2026-07-08T12:25:31Z] finished updating resource database.subscription::n1:n2:storefront (took 10.84625ms)
[2026-07-08T12:25:31Z] updating resource database.subscription::n2:n1:storefront
[2026-07-08T12:25:31Z] finished updating resource database.subscription::n2:n1:storefront (took 5.976583ms)
[2026-07-08T12:25:32Z] updating resource swarm.postgres_service_spec::storefront-n2-ant97dj4
[2026-07-08T12:25:32Z] finished updating resource swarm.postgres_service_spec::storefront-n2-ant97dj4 (took 138.25µs)
[2026-07-08T12:25:32Z] updating resource swarm.check_will_restart::storefront-n2-ant97dj4
[2026-07-08T12:25:32Z] finished updating resource swarm.check_will_restart::storefront-n2-ant97dj4 (took 4.294417ms)
[2026-07-08T12:25:32Z] updating resource swarm.switchover::storefront-n2-ant97dj4
[2026-07-08T12:25:44Z] finished updating resource swarm.switchover::storefront-n2-ant97dj4 (took 12.060070589s)
[2026-07-08T12:25:44Z] updating resource swarm.postgres_service::storefront-n2-ant97dj4
[2026-07-08T12:26:09Z] finished updating resource swarm.postgres_service::storefront-n2-ant97dj4 (took 25.015293054s)
[2026-07-08T12:26:10Z] updating resource database.instance::storefront-n2-ant97dj4
[2026-07-08T12:26:20Z] finished updating resource database.instance::storefront-n2-ant97dj4 (took 10.030142338s)
[2026-07-08T12:26:20Z] updating resource database.node::n2
[2026-07-08T12:26:20Z] finished updating resource database.node::n2 (took 76.167µs)
[2026-07-08T12:26:20Z] updating resource monitor.instance::storefront-n2-ant97dj4
[2026-07-08T12:26:20Z] finished updating resource monitor.instance::storefront-n2-ant97dj4 (took 12.799042ms)
[2026-07-08T12:26:20Z] updating resource database.postgres_database::n2:storefront
[2026-07-08T12:26:20Z] finished updating resource database.postgres_database::n2:storefront (took 32.182791ms)
[2026-07-08T12:26:21Z] updating resource database.replication_slot::n2:n1:storefront
[2026-07-08T12:26:21Z] finished updating resource database.replication_slot::n2:n1:storefront (took 30.292µs)
[2026-07-08T12:26:21Z] updating resource database.subscription::n2:n1:storefront
[2026-07-08T12:26:21Z] finished updating resource database.subscription::n2:n1:storefront (took 12.909584ms)
[2026-07-08T12:26:21Z] updating resource database.subscription::n1:n2:storefront
[2026-07-08T12:26:21Z] finished updating resource database.subscription::n1:n2:storefront (took 9.79975ms)
[2026-07-08T12:26:21Z] creating resource database.switchover::storefront-n2-ant97dj4
[2026-07-08T12:26:22Z] creating resource database.switchover::storefront-n1-689qacsi
[2026-07-08T12:26:37Z] finished creating resource database.switchover::storefront-n2-ant97dj4 (took 15.064995922s)
[2026-07-08T12:26:40Z] finished creating resource database.switchover::storefront-n1-689qacsi (took 18.067677758s)

database entity storefront task 019f41ae-a8ba-713f-b799-fbb735219d69 completed

```
5. Insert some data and verify 

## Checklist

- [x] Tests added or updated (unit and/or e2e)


[PLAT-665](https://pgedge.atlassian.net/browse/PLAT-665)

[PLAT-665]: https://pgedge.atlassian.net/browse/PLAT-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ