### PR TITLE
feat: enforce version-aware tag format for custom images

### DIFF
--- a/server/internal/database/orchestrator.go
+++ b/server/internal/database/orchestrator.go
@@ -134,7 +134,7 @@ type ValidationResult struct {
 	HostID     string   `json:"host_id"`
 	NodeName   string   `json:"node_name"`
 	Valid      bool     `json:"valid"`
-	Errors     []string `json:"errors"`
+	Errors []string `json:"errors"`
 }
 
 type ConnectionInfo struct {

--- a/server/internal/orchestrator/swarm/image_tag.go
+++ b/server/internal/orchestrator/swarm/image_tag.go
@@ -1,0 +1,50 @@
+package swarm
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/pgEdge/control-plane/server/internal/ds"
+)
+
+// imageTagRegexp matches the pgEdge image tag format:
+// {pgver}-spock{spockver}-{variant}-{build}
+// e.g. 17.9-spock5.0.6-standard-2
+var imageTagRegexp = regexp.MustCompile(`^(\d+\.\d+(?:\.\d+)?)-spock(\d+\.\d+(?:\.\d+)?)-`)
+
+// parseImageTag extracts the Postgres and Spock versions from an image
+// reference following the pgEdge tag format. Returns ok=false if the tag
+// does not match the expected format (e.g. a dev build tag like "my-build").
+func parseImageTag(image string) (pgVer, spockVer *ds.Version, ok bool) {
+	tag := image
+	if idx := strings.LastIndex(image, ":"); idx >= 0 {
+		tag = image[idx+1:]
+	}
+	m := imageTagRegexp.FindStringSubmatch(tag)
+	if m == nil {
+		return nil, nil, false
+	}
+	pg, err := ds.ParseVersion(m[1])
+	if err != nil {
+		return nil, nil, false
+	}
+	spock, err := ds.ParseVersion(m[2])
+	if err != nil {
+		return nil, nil, false
+	}
+	return pg, spock, true
+}
+
+// versionHasPrefix reports whether tagVer starts with all components of specVer.
+// Allows a spec declaring "5" to match a tag version of "5.0.6".
+func versionHasPrefix(tagVer, specVer *ds.Version) bool {
+	if len(tagVer.Components) < len(specVer.Components) {
+		return false
+	}
+	for i, c := range specVer.Components {
+		if tagVer.Components[i] != c {
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/orchestrator/swarm/image_tag.go
+++ b/server/internal/orchestrator/swarm/image_tag.go
@@ -9,8 +9,10 @@ import (
 
 // imageTagRegexp matches the pgEdge image tag format:
 // {pgver}-spock{spockver}-{variant}[-{build}]
-// e.g. 17.9-spock5.0.6-standard-2, 17-spock5-standard
-var imageTagRegexp = regexp.MustCompile(`^(\d+(?:\.\d+){0,2})-spock(\d+(?:\.\d+){0,2})-`)
+// e.g. 17.9-spock5.0.6-standard-2, 17.10-spock5-standard
+// The Postgres version requires at least major.minor; the Spock version may be
+// major-only (e.g. spock5) to support mutable channel tags.
+var imageTagRegexp = regexp.MustCompile(`^(\d+\.\d+(?:\.\d+)?)-spock(\d+(?:\.\d+){0,2})-`)
 
 // parseImageTag extracts the Postgres and Spock versions from an image
 // reference following the pgEdge tag format. Returns ok=false if the tag

--- a/server/internal/orchestrator/swarm/image_tag.go
+++ b/server/internal/orchestrator/swarm/image_tag.go
@@ -8,14 +8,19 @@ import (
 )
 
 // imageTagRegexp matches the pgEdge image tag format:
-// {pgver}-spock{spockver}-{variant}-{build}
-// e.g. 17.9-spock5.0.6-standard-2
-var imageTagRegexp = regexp.MustCompile(`^(\d+\.\d+(?:\.\d+)?)-spock(\d+\.\d+(?:\.\d+)?)-`)
+// {pgver}-spock{spockver}-{variant}[-{build}]
+// e.g. 17.9-spock5.0.6-standard-2, 17-spock5-standard
+var imageTagRegexp = regexp.MustCompile(`^(\d+(?:\.\d+){0,2})-spock(\d+(?:\.\d+){0,2})-`)
 
 // parseImageTag extracts the Postgres and Spock versions from an image
 // reference following the pgEdge tag format. Returns ok=false if the tag
 // does not match the expected format (e.g. a dev build tag like "my-build").
+// Digest suffixes (e.g. @sha256:…) are stripped before parsing.
 func parseImageTag(image string) (pgVer, spockVer *ds.Version, ok bool) {
+	// Strip any digest suffix before extracting the tag.
+	if idx := strings.Index(image, "@"); idx >= 0 {
+		image = image[:idx]
+	}
 	tag := image
 	if idx := strings.LastIndex(image, ":"); idx >= 0 {
 		tag = image[idx+1:]

--- a/server/internal/orchestrator/swarm/image_tag_test.go
+++ b/server/internal/orchestrator/swarm/image_tag_test.go
@@ -24,7 +24,7 @@ func TestParseImageTag(t *testing.T) {
 		{"custom registry", "registry.example.com/postgres:17.9-spock5.0.6-standard-2", "17.9", "5.0.6", true},
 		{"no build number", "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.10-standard", "17.10", "5.0.10", true},
 		{"major-only spock", "ghcr.io/pgedge/pgedge-postgres:17.10-spock5-standard", "17.10", "5", true},
-		{"major-only pg and spock", "ghcr.io/pgedge/pgedge-postgres:17-spock5-standard", "17", "5", true},
+		{"unrecognizable: major-only pg", "ghcr.io/pgedge/pgedge-postgres:17-spock5-standard", "", "", false},
 		{"digest-pinned with tag", "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1@sha256:abc123", "17.10", "5.0.9", true},
 		{"unrecognizable: dev tag", "ghcr.io/pgedge/pgedge-postgres:my-custom-image", "", "", false},
 		{"unrecognizable: latest", "ghcr.io/pgedge/pgedge-postgres:latest", "", "", false},

--- a/server/internal/orchestrator/swarm/image_tag_test.go
+++ b/server/internal/orchestrator/swarm/image_tag_test.go
@@ -22,10 +22,15 @@ func TestParseImageTag(t *testing.T) {
 		{"two-digit patch", "ghcr.io/pgedge/pgedge-postgres:17.9-spock5.0.10-standard-1", "17.9", "5.0.10", true},
 		{"pg18", "ghcr.io/pgedge/pgedge-postgres:18.3-spock5.0.6-standard-2", "18.3", "5.0.6", true},
 		{"custom registry", "registry.example.com/postgres:17.9-spock5.0.6-standard-2", "17.9", "5.0.6", true},
+		{"no build number", "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.10-standard", "17.10", "5.0.10", true},
+		{"major-only spock", "ghcr.io/pgedge/pgedge-postgres:17.10-spock5-standard", "17.10", "5", true},
+		{"major-only pg and spock", "ghcr.io/pgedge/pgedge-postgres:17-spock5-standard", "17", "5", true},
+		{"digest-pinned with tag", "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1@sha256:abc123", "17.10", "5.0.9", true},
 		{"unrecognizable: dev tag", "ghcr.io/pgedge/pgedge-postgres:my-custom-image", "", "", false},
 		{"unrecognizable: latest", "ghcr.io/pgedge/pgedge-postgres:latest", "", "", false},
 		{"unrecognizable: semver only", "ghcr.io/pgedge/pgedge-postgres:17.9", "", "", false},
 		{"unrecognizable: missing spock", "ghcr.io/pgedge/pgedge-postgres:17.9-standard-2", "", "", false},
+		{"unrecognizable: digest only, no tag", "ghcr.io/pgedge/pgedge-postgres@sha256:abc123", "", "", false},
 	}
 
 	for _, tc := range cases {

--- a/server/internal/orchestrator/swarm/image_tag_test.go
+++ b/server/internal/orchestrator/swarm/image_tag_test.go
@@ -1,0 +1,71 @@
+package swarm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pgEdge/control-plane/server/internal/ds"
+)
+
+func TestParseImageTag(t *testing.T) {
+	cases := []struct {
+		name      string
+		image     string
+		wantPg    string
+		wantSpock string
+		wantOk    bool
+	}{
+		{"standard tag", "ghcr.io/pgedge/pgedge-postgres:17.9-spock5.0.6-standard-2", "17.9", "5.0.6", true},
+		{"two-digit minor", "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.6-standard-1", "17.10", "5.0.6", true},
+		{"two-digit patch", "ghcr.io/pgedge/pgedge-postgres:17.9-spock5.0.10-standard-1", "17.9", "5.0.10", true},
+		{"pg18", "ghcr.io/pgedge/pgedge-postgres:18.3-spock5.0.6-standard-2", "18.3", "5.0.6", true},
+		{"custom registry", "registry.example.com/postgres:17.9-spock5.0.6-standard-2", "17.9", "5.0.6", true},
+		{"unrecognizable: dev tag", "ghcr.io/pgedge/pgedge-postgres:my-custom-image", "", "", false},
+		{"unrecognizable: latest", "ghcr.io/pgedge/pgedge-postgres:latest", "", "", false},
+		{"unrecognizable: semver only", "ghcr.io/pgedge/pgedge-postgres:17.9", "", "", false},
+		{"unrecognizable: missing spock", "ghcr.io/pgedge/pgedge-postgres:17.9-standard-2", "", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pg, spock, ok := parseImageTag(tc.image)
+			assert.Equal(t, tc.wantOk, ok)
+			if tc.wantOk {
+				require.NotNil(t, pg)
+				require.NotNil(t, spock)
+				assert.Equal(t, tc.wantPg, pg.String())
+				assert.Equal(t, tc.wantSpock, spock.String())
+			}
+		})
+	}
+}
+
+func TestVersionHasPrefix(t *testing.T) {
+	cases := []struct {
+		name    string
+		tagVer  string
+		specVer string
+		want    bool
+	}{
+		{"exact match", "5.0.6", "5.0.6", true},
+		{"spec is major only", "5.0.6", "5", true},
+		{"spec is major.minor", "5.0.6", "5.0", true},
+		{"tag shorter than spec", "5.0", "5.0.6", false},
+		{"major mismatch", "4.0.6", "5", false},
+		{"minor mismatch", "5.1.0", "5.0", false},
+		{"patch mismatch with full spec", "5.0.7", "5.0.6", false},
+		{"pg exact match", "17.9", "17.9", true},
+		{"pg major only spec", "17.9", "17", true},
+		{"pg major mismatch", "18.3", "17", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tagVer := ds.MustParseVersion(tc.tagVer)
+			specVer := ds.MustParseVersion(tc.specVer)
+			assert.Equal(t, tc.want, versionHasPrefix(tagVer, specVer))
+		})
+	}
+}

--- a/server/internal/orchestrator/swarm/orchestrator.go
+++ b/server/internal/orchestrator/swarm/orchestrator.go
@@ -1131,27 +1131,28 @@ func (o *Orchestrator) ValidateInstanceSpecs(ctx context.Context, changes []*dat
 				// If the tag follows the pgEdge format, validate that the
 				// versions encoded in the tag match the spec. Unrecognizable
 				// tags (e.g. dev builds) skip version validation and are accepted.
-				if pgTagVer, spockTagVer, ok := parseImageTag(userImage); ok &&
-					cur.PgEdgeVersion != nil &&
-					cur.PgEdgeVersion.PostgresVersion != nil &&
-					cur.PgEdgeVersion.SpockVersion != nil {
-					var errs []string
-					if !versionHasPrefix(pgTagVer, cur.PgEdgeVersion.PostgresVersion) {
-						errs = append(errs, fmt.Sprintf("image tag postgres version %s does not match spec version %s",
-							pgTagVer, cur.PgEdgeVersion.PostgresVersion))
-					}
-					if !versionHasPrefix(spockTagVer, cur.PgEdgeVersion.SpockVersion) {
-						errs = append(errs, fmt.Sprintf("image tag spock version %s does not match spec version %s",
-							spockTagVer, cur.PgEdgeVersion.SpockVersion))
-					}
-					if len(errs) > 0 {
-						results = append(results, &database.ValidationResult{
-							Valid:    false,
-							NodeName: cur.NodeName,
-							HostID:   cur.HostID,
-							Errors:   errs,
-						})
-						continue
+				if pgTagVer, spockTagVer, ok := parseImageTag(userImage); ok {
+					if cur.PgEdgeVersion != nil &&
+						cur.PgEdgeVersion.PostgresVersion != nil &&
+						cur.PgEdgeVersion.SpockVersion != nil {
+						var errs []string
+						if !versionHasPrefix(pgTagVer, cur.PgEdgeVersion.PostgresVersion) {
+							errs = append(errs, fmt.Sprintf("image tag postgres version %s does not match spec version %s",
+								pgTagVer, cur.PgEdgeVersion.PostgresVersion))
+						}
+						if !versionHasPrefix(spockTagVer, cur.PgEdgeVersion.SpockVersion) {
+							errs = append(errs, fmt.Sprintf("image tag spock version %s does not match spec version %s",
+								spockTagVer, cur.PgEdgeVersion.SpockVersion))
+						}
+						if len(errs) > 0 {
+							results = append(results, &database.ValidationResult{
+								Valid:    false,
+								NodeName: cur.NodeName,
+								HostID:   cur.HostID,
+								Errors:   errs,
+							})
+							continue
+						}
 					}
 				}
 			}

--- a/server/internal/orchestrator/swarm/orchestrator.go
+++ b/server/internal/orchestrator/swarm/orchestrator.go
@@ -1127,6 +1127,30 @@ func (o *Orchestrator) ValidateInstanceSpecs(ctx context.Context, changes []*dat
 						continue
 					}
 				}
+
+				// If the tag follows the pgEdge format, validate that the
+				// versions encoded in the tag match the spec. Unrecognizable
+				// tags (e.g. dev builds) skip version validation and are accepted.
+				if pgTagVer, spockTagVer, ok := parseImageTag(userImage); ok && cur.PgEdgeVersion != nil {
+					var errs []string
+					if !versionHasPrefix(pgTagVer, cur.PgEdgeVersion.PostgresVersion) {
+						errs = append(errs, fmt.Sprintf("image tag postgres version %s does not match spec version %s",
+							pgTagVer, cur.PgEdgeVersion.PostgresVersion))
+					}
+					if !versionHasPrefix(spockTagVer, cur.PgEdgeVersion.SpockVersion) {
+						errs = append(errs, fmt.Sprintf("image tag spock version %s does not match spec version %s",
+							spockTagVer, cur.PgEdgeVersion.SpockVersion))
+					}
+					if len(errs) > 0 {
+						results = append(results, &database.ValidationResult{
+							Valid:    false,
+							NodeName: cur.NodeName,
+							HostID:   cur.HostID,
+							Errors:   errs,
+						})
+						continue
+					}
+				}
 			}
 		}
 

--- a/server/internal/orchestrator/swarm/orchestrator.go
+++ b/server/internal/orchestrator/swarm/orchestrator.go
@@ -1131,7 +1131,10 @@ func (o *Orchestrator) ValidateInstanceSpecs(ctx context.Context, changes []*dat
 				// If the tag follows the pgEdge format, validate that the
 				// versions encoded in the tag match the spec. Unrecognizable
 				// tags (e.g. dev builds) skip version validation and are accepted.
-				if pgTagVer, spockTagVer, ok := parseImageTag(userImage); ok && cur.PgEdgeVersion != nil {
+				if pgTagVer, spockTagVer, ok := parseImageTag(userImage); ok &&
+					cur.PgEdgeVersion != nil &&
+					cur.PgEdgeVersion.PostgresVersion != nil &&
+					cur.PgEdgeVersion.SpockVersion != nil {
 					var errs []string
 					if !versionHasPrefix(pgTagVer, cur.PgEdgeVersion.PostgresVersion) {
 						errs = append(errs, fmt.Sprintf("image tag postgres version %s does not match spec version %s",

--- a/server/internal/orchestrator/swarm/rag_instance_resources_test.go
+++ b/server/internal/orchestrator/swarm/rag_instance_resources_test.go
@@ -57,7 +57,7 @@ func TestGenerateRAGInstanceResources_ResourceList(t *testing.T) {
 		ServiceSpec: &database.ServiceSpec{
 			ServiceID:   "rag",
 			ServiceType: "rag",
-			Version:     "latest",
+			Version:     "1.0.0",
 			Config:      minimalRAGConfig(),
 			ConnectAs:   "app_read_only",
 		},
@@ -95,7 +95,7 @@ func TestGenerateRAGInstanceResources_MultiNode(t *testing.T) {
 		ServiceSpec: &database.ServiceSpec{
 			ServiceID:   "rag",
 			ServiceType: "rag",
-			Version:     "latest",
+			Version:     "1.0.0",
 			Config:      minimalRAGConfig(),
 			ConnectAs:   "app_read_only",
 		},
@@ -133,7 +133,7 @@ func TestGenerateServiceInstanceResources_RAGDispatch(t *testing.T) {
 		ServiceSpec: &database.ServiceSpec{
 			ServiceID:   "rag",
 			ServiceType: "rag",
-			Version:     "latest",
+			Version:     "1.0.0",
 			Config:      minimalRAGConfig(),
 			ConnectAs:   "app_read_only",
 		},
@@ -176,7 +176,7 @@ func TestGenerateRAGInstanceResources_ConnectAs_CredentialsPopulated(t *testing.
 		ServiceSpec: &database.ServiceSpec{
 			ServiceID:   "rag",
 			ServiceType: "rag",
-			Version:     "latest",
+			Version:     "1.0.0",
 			Config:      minimalRAGConfig(),
 			ConnectAs:   "app_read_only",
 		},
@@ -206,8 +206,8 @@ func TestGenerateRAGInstanceResources_ConnectAs_CredentialsPopulated(t *testing.
 func TestGenerateRAGInstanceResources_IncompatibleVersion(t *testing.T) {
 	o := newTestOrchestrator(t)
 	// Override the "rag/latest" image with a constraint requiring PG >= 18.
-	o.serviceVersions.addServiceImage("rag", "latest", &ServiceImage{
-		Tag: "rag-server:latest",
+	o.serviceVersions.addServiceImage("rag", "1.0.0", &ServiceImage{
+		Tag: "rag-server:1.0.0",
 		PostgresConstraint: &ds.VersionConstraint{
 			Min: ds.MustParseVersion("18"),
 		},
@@ -218,7 +218,7 @@ func TestGenerateRAGInstanceResources_IncompatibleVersion(t *testing.T) {
 		ServiceSpec: &database.ServiceSpec{
 			ServiceID:   "rag",
 			ServiceType: "rag",
-			Version:     "latest",
+			Version:     "1.0.0",
 			Config:      minimalRAGConfig(),
 			ConnectAs:   "app_read_only",
 		},

--- a/server/internal/orchestrator/swarm/rag_service_keys_resource_test.go
+++ b/server/internal/orchestrator/swarm/rag_service_keys_resource_test.go
@@ -240,7 +240,7 @@ func TestGenerateRAGInstanceResources_IncludesKeysResource(t *testing.T) {
 		ServiceSpec: &database.ServiceSpec{
 			ServiceID:   "rag",
 			ServiceType: "rag",
-			Version:     "latest",
+			Version:     "1.0.0",
 			Config: map[string]any{
 				"pipelines": []any{
 					map[string]any{

--- a/server/internal/orchestrator/swarm/resolve_service_image_test.go
+++ b/server/internal/orchestrator/swarm/resolve_service_image_test.go
@@ -35,12 +35,12 @@ func serviceSpecWith(serviceType, version string, swarm *database.SwarmOpts) *da
 func TestResolveServiceImage(t *testing.T) {
 	o := newTestServiceOrchestrator(t)
 
-	manifestImage, err := o.serviceVersions.GetServiceImage("mcp", "latest")
+	manifestImage, err := o.serviceVersions.GetServiceImage("mcp", "1.0.0")
 	require.NoError(t, err)
 	pinnedTag := manifestImage.Tag
 
 	t.Run("Image override used directly, manifest not consulted", func(t *testing.T) {
-		spec := serviceSpecWith("mcp", "latest", &database.SwarmOpts{Image: "my-registry/mcp:dev"})
+		spec := serviceSpecWith("mcp", "1.0.0", &database.SwarmOpts{Image: "my-registry/mcp:dev"})
 
 		img, err := o.resolveServiceImage(spec)
 		require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestResolveServiceImage(t *testing.T) {
 	})
 
 	t.Run("Image takes precedence over ResolvedImage", func(t *testing.T) {
-		spec := serviceSpecWith("mcp", "latest", &database.SwarmOpts{
+		spec := serviceSpecWith("mcp", "1.0.0", &database.SwarmOpts{
 			Image:         "custom-override:latest",
 			ResolvedImage: "previously-resolved:tag",
 		})
@@ -71,7 +71,7 @@ func TestResolveServiceImage(t *testing.T) {
 	})
 
 	t.Run("ResolvedImage used when Image is empty", func(t *testing.T) {
-		spec := serviceSpecWith("mcp", "latest", &database.SwarmOpts{ResolvedImage: "registry.example.com/pgedge:pinned"})
+		spec := serviceSpecWith("mcp", "1.0.0", &database.SwarmOpts{ResolvedImage: "registry.example.com/pgedge:pinned"})
 
 		img, err := o.resolveServiceImage(spec)
 		require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestResolveServiceImage(t *testing.T) {
 	})
 
 	t.Run("lazy backfill: resolves from manifest and writes ResolvedImage", func(t *testing.T) {
-		spec := serviceSpecWith("mcp", "latest", nil)
+		spec := serviceSpecWith("mcp", "1.0.0", nil)
 
 		img, err := o.resolveServiceImage(spec)
 		require.NoError(t, err)
@@ -109,12 +109,12 @@ func TestResolveServiceImage(t *testing.T) {
 func TestReconcileServiceInstanceSpec(t *testing.T) {
 	o := newTestServiceOrchestrator(t)
 
-	manifestImage, err := o.serviceVersions.GetServiceImage("mcp", "latest")
+	manifestImage, err := o.serviceVersions.GetServiceImage("mcp", "1.0.0")
 	require.NoError(t, err)
 	pinnedTag := manifestImage.Tag
 
 	t.Run("first creation: old nil, ResolvedImage written from manifest", func(t *testing.T) {
-		spec := serviceSpecWith("mcp", "latest", nil)
+		spec := serviceSpecWith("mcp", "1.0.0", nil)
 		require.NoError(t, o.ReconcileServiceInstanceSpec(nil, spec))
 		require.NotNil(t, spec.ServiceSpec.OrchestratorOpts)
 		require.NotNil(t, spec.ServiceSpec.OrchestratorOpts.Swarm)
@@ -122,8 +122,8 @@ func TestReconcileServiceInstanceSpec(t *testing.T) {
 	})
 
 	t.Run("same version: old.ResolvedImage carried forward, manifest not re-consulted", func(t *testing.T) {
-		old := serviceSpecWith("mcp", "latest", &database.SwarmOpts{ResolvedImage: "registry.example.com/pgedge:pinned-mcp"})
-		newSpec := serviceSpecWith("mcp", "latest", nil)
+		old := serviceSpecWith("mcp", "1.0.0", &database.SwarmOpts{ResolvedImage: "registry.example.com/pgedge:pinned-mcp"})
+		newSpec := serviceSpecWith("mcp", "1.0.0", nil)
 
 		require.NoError(t, o.ReconcileServiceInstanceSpec(old, newSpec))
 		require.NotNil(t, newSpec.ServiceSpec.OrchestratorOpts)
@@ -132,8 +132,8 @@ func TestReconcileServiceInstanceSpec(t *testing.T) {
 	})
 
 	t.Run("same version, old has no ResolvedImage: manifest lookup runs", func(t *testing.T) {
-		old := serviceSpecWith("mcp", "latest", nil)
-		newSpec := serviceSpecWith("mcp", "latest", nil)
+		old := serviceSpecWith("mcp", "1.0.0", nil)
+		newSpec := serviceSpecWith("mcp", "1.0.0", nil)
 
 		require.NoError(t, o.ReconcileServiceInstanceSpec(old, newSpec))
 		require.NotNil(t, newSpec.ServiceSpec.OrchestratorOpts)

--- a/server/internal/orchestrator/swarm/service_images_test.go
+++ b/server/internal/orchestrator/swarm/service_images_test.go
@@ -24,10 +24,10 @@ func TestGetServiceImage(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:        "valid mcp latest",
+			name:        "valid mcp 1.0.0",
 			serviceType: "mcp",
-			version:     "latest",
-			wantTag:     "ghcr.io/pgedge/postgres-mcp:latest",
+			version:     "1.0.0",
+			wantTag:     "ghcr.io/pgedge/postgres-mcp:1.0.0",
 			wantErr:     false,
 		},
 		{
@@ -47,7 +47,7 @@ func TestGetServiceImage(t *testing.T) {
 		{
 			name:        "unregistered version",
 			serviceType: "mcp",
-			version:     "1.0.0",
+			version:     "2.0.0",
 			wantTag:     "",
 			wantErr:     true,
 		},
@@ -98,8 +98,8 @@ func TestSupportedServiceVersions(t *testing.T) {
 		{
 			name:           "mcp service has versions",
 			serviceType:    "mcp",
-			wantLatest:     true,
-			minPinnedCount: 0,
+			wantLatest:     false,
+			minPinnedCount: 1,
 			wantErr:        false,
 		},
 		{
@@ -198,7 +198,7 @@ func TestGetServiceImage_ConstraintsPopulated(t *testing.T) {
 	sv := newTestServiceVersions(t, cfg)
 
 	t.Run("mcp has no constraints", func(t *testing.T) {
-		img, err := sv.GetServiceImage("mcp", "latest")
+		img, err := sv.GetServiceImage("mcp", "1.0.0")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/server/internal/orchestrator/swarm/validate_instance_specs_test.go
+++ b/server/internal/orchestrator/swarm/validate_instance_specs_test.go
@@ -144,6 +144,57 @@ func TestValidateInstanceSpecs_ImageValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("no result for digest-pinned image with matching versions", func(t *testing.T) {
+		changes := []*database.InstanceSpecChange{
+			{Current: &database.InstanceSpec{
+				NodeName:      "n1",
+				HostID:        "host-1",
+				PgEdgeVersion: knownVersion, // 17.9 / 5
+				OrchestratorOpts: &database.OrchestratorOpts{
+					Swarm: &database.SwarmOpts{Image: "ghcr.io/pgedge/pgedge-postgres:17.9-spock5.0.6-standard-2@sha256:abc123"},
+				},
+			}},
+		}
+		results, err := o.ValidateInstanceSpecs(ctx, changes)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("error for digest-pinned image with version mismatch", func(t *testing.T) {
+		changes := []*database.InstanceSpecChange{
+			{Current: &database.InstanceSpec{
+				NodeName:      "n1",
+				HostID:        "host-1",
+				PgEdgeVersion: knownVersion, // 17.9 / 5
+				OrchestratorOpts: &database.OrchestratorOpts{
+					Swarm: &database.SwarmOpts{Image: "ghcr.io/pgedge/pgedge-postgres:18.3-spock5.0.6-standard-2@sha256:abc123"},
+				},
+			}},
+		}
+		results, err := o.ValidateInstanceSpecs(ctx, changes)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.False(t, results[0].Valid)
+		assert.Contains(t, results[0].Errors[0], "18.3")
+	})
+
+	t.Run("no result for major-only mutable tag matching spec", func(t *testing.T) {
+		pgEdgeVersion := ds.MustParsePgEdgeVersion("17", "5")
+		changes := []*database.InstanceSpecChange{
+			{Current: &database.InstanceSpec{
+				NodeName:      "n1",
+				HostID:        "host-1",
+				PgEdgeVersion: pgEdgeVersion,
+				OrchestratorOpts: &database.OrchestratorOpts{
+					Swarm: &database.SwarmOpts{Image: "ghcr.io/pgedge/pgedge-postgres:17-spock5-standard"},
+				},
+			}},
+		}
+		results, err := o.ValidateInstanceSpecs(ctx, changes)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
 	t.Run("error when image tag spock version mismatches spec", func(t *testing.T) {
 		changes := []*database.InstanceSpecChange{
 			{Current: &database.InstanceSpec{

--- a/server/internal/orchestrator/swarm/validate_instance_specs_test.go
+++ b/server/internal/orchestrator/swarm/validate_instance_specs_test.go
@@ -50,11 +50,11 @@ func TestValidateInstanceSpecs_ImageValidation(t *testing.T) {
 		}
 		results, err := o.ValidateInstanceSpecs(ctx, changes)
 		require.NoError(t, err)
-		// Registry check skipped (no docker client). Image accepted as-is.
+		// Registry check skipped (no docker client). Version check passes.
 		assert.Empty(t, results)
 	})
 
-	t.Run("no result when Image differs from manifest (registry check skipped in unit tests)", func(t *testing.T) {
+	t.Run("no result when image tag format is unrecognizable (dev build)", func(t *testing.T) {
 		changes := []*database.InstanceSpecChange{
 			{Current: &database.InstanceSpec{
 				NodeName:      "n1",
@@ -67,11 +67,11 @@ func TestValidateInstanceSpecs_ImageValidation(t *testing.T) {
 		}
 		results, err := o.ValidateInstanceSpecs(ctx, changes)
 		require.NoError(t, err)
-		// Registry check skipped (no docker client). Any image override is accepted as-is.
+		// Unrecognizable tag format skips version validation and is accepted.
 		assert.Empty(t, results)
 	})
 
-	t.Run("no result when Image is set for an unknown version", func(t *testing.T) {
+	t.Run("no result when image tag format is unrecognizable for unknown spec version", func(t *testing.T) {
 		changes := []*database.InstanceSpecChange{
 			{Current: &database.InstanceSpec{
 				NodeName:      "n1",
@@ -85,5 +85,81 @@ func TestValidateInstanceSpecs_ImageValidation(t *testing.T) {
 		results, err := o.ValidateInstanceSpecs(ctx, changes)
 		require.NoError(t, err)
 		assert.Empty(t, results)
+	})
+
+	t.Run("no result for recognizable tag with matching versions (multi-digit patch)", func(t *testing.T) {
+		changes := []*database.InstanceSpecChange{
+			{Current: &database.InstanceSpec{
+				NodeName:      "n1",
+				HostID:        "host-1",
+				PgEdgeVersion: knownVersion, // 17.9 / 5
+				OrchestratorOpts: &database.OrchestratorOpts{
+					Swarm: &database.SwarmOpts{Image: "ghcr.io/pgedge/pgedge-postgres:17.9-spock5.0.10-standard-1"},
+				},
+			}},
+		}
+		results, err := o.ValidateInstanceSpecs(ctx, changes)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("error when image tag postgres version mismatches spec", func(t *testing.T) {
+		changes := []*database.InstanceSpecChange{
+			{Current: &database.InstanceSpec{
+				NodeName:      "n1",
+				HostID:        "host-1",
+				PgEdgeVersion: knownVersion, // 17.9 / 5
+				OrchestratorOpts: &database.OrchestratorOpts{
+					Swarm: &database.SwarmOpts{Image: "ghcr.io/pgedge/pgedge-postgres:18.3-spock5.0.6-standard-2"},
+				},
+			}},
+		}
+		results, err := o.ValidateInstanceSpecs(ctx, changes)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.False(t, results[0].Valid)
+		assert.Contains(t, results[0].Errors[0], "18.3")
+		assert.Contains(t, results[0].Errors[0], "17.9")
+	})
+
+	t.Run("accepted when upgrading spock patch within same major (e.g. 5.0.9 → 5.0.10)", func(t *testing.T) {
+		pgEdgeVersion := ds.MustParsePgEdgeVersion("17.10", "5")
+		for _, img := range []string{
+			"ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-2",
+			"ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.10-standard-2",
+		} {
+			changes := []*database.InstanceSpecChange{
+				{Current: &database.InstanceSpec{
+					NodeName:      "n1",
+					HostID:        "host-1",
+					PgEdgeVersion: pgEdgeVersion,
+					OrchestratorOpts: &database.OrchestratorOpts{
+						Swarm: &database.SwarmOpts{Image: img},
+					},
+				}},
+			}
+			results, err := o.ValidateInstanceSpecs(ctx, changes)
+			require.NoError(t, err)
+			assert.Emptyf(t, results, "image %s should be accepted", img)
+		}
+	})
+
+	t.Run("error when image tag spock version mismatches spec", func(t *testing.T) {
+		changes := []*database.InstanceSpecChange{
+			{Current: &database.InstanceSpec{
+				NodeName:      "n1",
+				HostID:        "host-1",
+				PgEdgeVersion: knownVersion, // 17.9 / 5
+				OrchestratorOpts: &database.OrchestratorOpts{
+					Swarm: &database.SwarmOpts{Image: "ghcr.io/pgedge/pgedge-postgres:17.9-spock4.0.0-standard-1"},
+				},
+			}},
+		}
+		results, err := o.ValidateInstanceSpecs(ctx, changes)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.False(t, results[0].Valid)
+		assert.Contains(t, results[0].Errors[0], "4.0.0")
+		assert.Contains(t, results[0].Errors[0], "5")
 	})
 }

--- a/server/internal/orchestrator/swarm/validate_instance_specs_test.go
+++ b/server/internal/orchestrator/swarm/validate_instance_specs_test.go
@@ -178,13 +178,15 @@ func TestValidateInstanceSpecs_ImageValidation(t *testing.T) {
 		assert.Contains(t, results[0].Errors[0], "18.3")
 	})
 
-	t.Run("no result for major-only mutable tag matching spec", func(t *testing.T) {
-		pgEdgeVersion := ds.MustParsePgEdgeVersion("17", "5")
+	t.Run("no result for major-only pg mutable tag (unrecognizable, skips version check)", func(t *testing.T) {
+		// The API requires postgres_version in major.minor format, so a tag like
+		// "17-spock5-standard" (major-only pg) is treated as unrecognizable and
+		// accepted without version validation — same as a dev build tag.
 		changes := []*database.InstanceSpecChange{
 			{Current: &database.InstanceSpec{
 				NodeName:      "n1",
 				HostID:        "host-1",
-				PgEdgeVersion: pgEdgeVersion,
+				PgEdgeVersion: knownVersion, // 17.9 / 5
 				OrchestratorOpts: &database.OrchestratorOpts{
 					Swarm: &database.SwarmOpts{Image: "ghcr.io/pgedge/pgedge-postgres:17-spock5-standard"},
 				},

--- a/server/internal/orchestrator/swarm/version-manifest.json
+++ b/server/internal/orchestrator/swarm/version-manifest.json
@@ -96,11 +96,6 @@
     ],
     "postgrest": [
       {
-        "version": "latest",
-        "image": "postgrest:latest",
-        "stability": "stable"
-      },
-      {
         "version": "14.5",
         "image": "postgrest:14.5",
         "stability": "stable",
@@ -109,16 +104,16 @@
     ],
     "mcp": [
       {
-        "version": "latest",
-        "image": "postgres-mcp:latest",
+        "version": "1.0.0",
+        "image": "postgres-mcp:1.0.0",
         "stability": "stable",
         "default": true
       }
     ],
     "rag": [
       {
-        "version": "latest",
-        "image": "rag-server:latest",
+        "version": "1.0.0",
+        "image": "rag-server:1.0.0",
         "stability": "stable",
         "default": true
       }


### PR DESCRIPTION

## Summary
This PR refines the custom image validation logic. Unrecognizable image tags (for example, development builds) are now accepted without version checks, while recognizable pgEdge-formatted image tags continue to be validated against the versions declared in the specification.

## Changes

- Allow unrecognized image tags (for example, `my-dev-build` or `latest`) without version validation. These tags are accepted as long as the image exists in the registry.
- Continue validating recognizable pgEdge image tags (`{pgver}-spock{spockver}-{variant}-{build}`) against the versions declared in the cluster specification.
- Return a clear validation error when the PostgreSQL or Spock version in a recognized pgEdge image tag does not match the declared specification.
- Support patch-level upgrades through prefix matching. For example, a cluster with `spock_version: "5"` accepts image tags such as `spock5.0.9` and `spock5.0.10` without requiring a spec update.


## Testing
Verification:
1. Create cluster
2. Created Database 
```
 cp1-req create-database < ../demo/Images/create_db_with_no_image.json | cp-follow-task

{
  "database": {
    "created_at": "2026-07-10T15:56:26Z",
    "id": "storefront-no-image",
    "spec": {
      "database_name": "storefront",
      "database_users": [
        {
          "attributes": [
            "SUPERUSER",
            "LOGIN"
          ],
          "db_owner": true,
          "username": "admin"
        }
      ],
      "nodes": [
        {
          "host_ids": [
            "host-1",
            "host-2",
            "host-3"
          ],
          "name": "n1"
        }
      ],
      "postgres_version": "18.4",
      "spock_version": "5"
    },
    "state": "creating",
    "updated_at": "2026-07-10T15:56:26Z"
  },
  "task": {
    "created_at": "2026-07-10T15:56:26Z",
    "database_id": "storefront-no-image",
    "entity_id": "storefront-no-image",
    "scope": "database",
    "status": "pending",
    "task_id": "019f4cbe-96fc-7555-bb6f-095b7b86054c",
    "type": "create"
  }
}
[2026-07-10T15:56:28Z] refreshing current state
[2026-07-10T15:56:28Z] finished refreshing current state (took 198.975708ms)
[2026-07-10T15:56:30Z] creating resource common.patroni_cluster::n1
[2026-07-10T15:56:30Z] finished creating resource common.patroni_cluster::n1 (took 22.75µs)
[2026-07-10T15:56:30Z] creating resource swarm.network::storefront-no-image-database
[2026-07-10T15:56:30Z] finished creating resource swarm.network::storefront-no-image-database (took 6.078792ms)
[2026-07-10T15:56:30Z] creating resource filesystem.dir::storefront-no-image-n1-689qacsi-instance
[2026-07-10T15:56:30Z] finished creating resource filesystem.dir::storefront-no-image-n1-689qacsi-instance (took 1.204791ms)
[2026-07-10T15:56:30Z] creating resource common.patroni_member::storefront-no-image-n1-689qacsi
[2026-07-10T15:56:30Z] finished creating resource common.patroni_member::storefront-no-image-n1-689qacsi (took 35.917µs)
[2026-07-10T15:56:31Z] creating resource filesystem.dir::storefront-no-image-n1-689qacsi-data
[2026-07-10T15:56:31Z] finished creating resource filesystem.dir::storefront-no-image-n1-689qacsi-data (took 916.333µs)
[2026-07-10T15:56:31Z] creating resource filesystem.dir::storefront-no-image-n1-689qacsi-configs
[2026-07-10T15:56:31Z] finished creating resource filesystem.dir::storefront-no-image-n1-689qacsi-configs (took 916.125µs)
[2026-07-10T15:56:31Z] creating resource filesystem.dir::storefront-no-image-n1-689qacsi-certificates
[2026-07-10T15:56:31Z] finished creating resource filesystem.dir::storefront-no-image-n1-689qacsi-certificates (took 447.333µs)
[2026-07-10T15:56:31Z] creating resource common.etcd_creds::storefront-no-image-n1-689qacsi
[2026-07-10T15:56:31Z] finished creating resource common.etcd_creds::storefront-no-image-n1-689qacsi (took 79.95725ms)
[2026-07-10T15:56:31Z] creating resource common.postgres_certs::storefront-no-image-n1-689qacsi
[2026-07-10T15:56:31Z] finished creating resource common.postgres_certs::storefront-no-image-n1-689qacsi (took 8.007791ms)
[2026-07-10T15:56:32Z] creating resource swarm.patroni_config::storefront-no-image-n1-689qacsi
[2026-07-10T15:56:32Z] finished creating resource swarm.patroni_config::storefront-no-image-n1-689qacsi (took 2.552416ms)
[2026-07-10T15:56:32Z] creating resource swarm.postgres_service_spec::storefront-no-image-n1-689qacsi
[2026-07-10T15:56:32Z] finished creating resource swarm.postgres_service_spec::storefront-no-image-n1-689qacsi (took 241.25µs)
[2026-07-10T15:56:32Z] creating resource swarm.check_will_restart::storefront-no-image-n1-689qacsi
[2026-07-10T15:56:32Z] finished creating resource swarm.check_will_restart::storefront-no-image-n1-689qacsi (took 4.643167ms)
[2026-07-10T15:56:33Z] creating resource swarm.switchover::storefront-no-image-n1-689qacsi
[2026-07-10T15:56:33Z] finished creating resource swarm.switchover::storefront-no-image-n1-689qacsi (took 25.375µs)
[2026-07-10T15:56:33Z] creating resource swarm.postgres_service::storefront-no-image-n1-689qacsi
[2026-07-10T15:56:53Z] finished creating resource swarm.postgres_service::storefront-no-image-n1-689qacsi (took 20.019009342s)
[2026-07-10T15:56:53Z] creating resource database.instance::storefront-no-image-n1-689qacsi
[2026-07-10T15:57:03Z] finished creating resource database.instance::storefront-no-image-n1-689qacsi (took 10.056880921s)
[2026-07-10T15:57:04Z] creating resource filesystem.dir::storefront-no-image-n1-ant97dj4-instance
[2026-07-10T15:57:04Z] finished creating resource filesystem.dir::storefront-no-image-n1-ant97dj4-instance (took 800.125µs)
[2026-07-10T15:57:04Z] creating resource filesystem.dir::storefront-no-image-n1-9ptayhma-instance
[2026-07-10T15:57:04Z] finished creating resource filesystem.dir::storefront-no-image-n1-9ptayhma-instance (took 873.916µs)
[2026-07-10T15:57:04Z] creating resource common.patroni_member::storefront-no-image-n1-9ptayhma
[2026-07-10T15:57:04Z] finished creating resource common.patroni_member::storefront-no-image-n1-9ptayhma (took 26.625µs)
[2026-07-10T15:57:04Z] creating resource common.patroni_member::storefront-no-image-n1-ant97dj4
[2026-07-10T15:57:04Z] finished creating resource common.patroni_member::storefront-no-image-n1-ant97dj4 (took 7.541µs)
[2026-07-10T15:57:04Z] creating resource filesystem.dir::storefront-no-image-n1-ant97dj4-data
[2026-07-10T15:57:04Z] finished creating resource filesystem.dir::storefront-no-image-n1-ant97dj4-data (took 603.958µs)
[2026-07-10T15:57:04Z] creating resource filesystem.dir::storefront-no-image-n1-ant97dj4-certificates
[2026-07-10T15:57:04Z] finished creating resource filesystem.dir::storefront-no-image-n1-ant97dj4-certificates (took 446.041µs)
[2026-07-10T15:57:04Z] creating resource filesystem.dir::storefront-no-image-n1-ant97dj4-configs
[2026-07-10T15:57:04Z] finished creating resource filesystem.dir::storefront-no-image-n1-ant97dj4-configs (took 493.125µs)
[2026-07-10T15:57:04Z] creating resource filesystem.dir::storefront-no-image-n1-9ptayhma-certificates
[2026-07-10T15:57:04Z] finished creating resource filesystem.dir::storefront-no-image-n1-9ptayhma-certificates (took 762.583µs)
[2026-07-10T15:57:04Z] creating resource filesystem.dir::storefront-no-image-n1-9ptayhma-configs
[2026-07-10T15:57:04Z] finished creating resource filesystem.dir::storefront-no-image-n1-9ptayhma-configs (took 347.625µs)
[2026-07-10T15:57:04Z] creating resource filesystem.dir::storefront-no-image-n1-9ptayhma-data
[2026-07-10T15:57:04Z] finished creating resource filesystem.dir::storefront-no-image-n1-9ptayhma-data (took 503.333µs)
[2026-07-10T15:57:05Z] creating resource common.postgres_certs::storefront-no-image-n1-ant97dj4
[2026-07-10T15:57:05Z] creating resource common.etcd_creds::storefront-no-image-n1-ant97dj4
[2026-07-10T15:57:05Z] finished creating resource common.postgres_certs::storefront-no-image-n1-ant97dj4 (took 24.313625ms)
[2026-07-10T15:57:05Z] creating resource common.postgres_certs::storefront-no-image-n1-9ptayhma
[2026-07-10T15:57:05Z] creating resource common.etcd_creds::storefront-no-image-n1-9ptayhma
[2026-07-10T15:57:05Z] finished creating resource common.postgres_certs::storefront-no-image-n1-9ptayhma (took 14.30425ms)
[2026-07-10T15:57:05Z] finished creating resource common.etcd_creds::storefront-no-image-n1-ant97dj4 (took 70.603708ms)
[2026-07-10T15:57:05Z] finished creating resource common.etcd_creds::storefront-no-image-n1-9ptayhma (took 70.762792ms)
[2026-07-10T15:57:05Z] creating resource swarm.patroni_config::storefront-no-image-n1-ant97dj4
[2026-07-10T15:57:05Z] finished creating resource swarm.patroni_config::storefront-no-image-n1-ant97dj4 (took 2.172375ms)
[2026-07-10T15:57:05Z] creating resource swarm.patroni_config::storefront-no-image-n1-9ptayhma
[2026-07-10T15:57:05Z] finished creating resource swarm.patroni_config::storefront-no-image-n1-9ptayhma (took 2.276042ms)
[2026-07-10T15:57:05Z] creating resource swarm.postgres_service_spec::storefront-no-image-n1-ant97dj4
[2026-07-10T15:57:05Z] finished creating resource swarm.postgres_service_spec::storefront-no-image-n1-ant97dj4 (took 117.375µs)
[2026-07-10T15:57:05Z] creating resource swarm.postgres_service_spec::storefront-no-image-n1-9ptayhma
[2026-07-10T15:57:05Z] finished creating resource swarm.postgres_service_spec::storefront-no-image-n1-9ptayhma (took 109.541µs)
[2026-07-10T15:57:06Z] creating resource swarm.check_will_restart::storefront-no-image-n1-ant97dj4
[2026-07-10T15:57:06Z] finished creating resource swarm.check_will_restart::storefront-no-image-n1-ant97dj4 (took 1.830208ms)
[2026-07-10T15:57:06Z] creating resource swarm.check_will_restart::storefront-no-image-n1-9ptayhma
[2026-07-10T15:57:06Z] finished creating resource swarm.check_will_restart::storefront-no-image-n1-9ptayhma (took 1.789083ms)
[2026-07-10T15:57:06Z] creating resource swarm.switchover::storefront-no-image-n1-ant97dj4
[2026-07-10T15:57:06Z] finished creating resource swarm.switchover::storefront-no-image-n1-ant97dj4 (took 12.417µs)
[2026-07-10T15:57:06Z] creating resource swarm.switchover::storefront-no-image-n1-9ptayhma
[2026-07-10T15:57:06Z] finished creating resource swarm.switchover::storefront-no-image-n1-9ptayhma (took 12.125µs)
[2026-07-10T15:57:06Z] creating resource swarm.postgres_service::storefront-no-image-n1-ant97dj4
[2026-07-10T15:57:06Z] creating resource swarm.postgres_service::storefront-no-image-n1-9ptayhma
[2026-07-10T15:57:26Z] finished creating resource swarm.postgres_service::storefront-no-image-n1-ant97dj4 (took 20.015112675s)
[2026-07-10T15:57:26Z] finished creating resource swarm.postgres_service::storefront-no-image-n1-9ptayhma (took 20.0090998s)
[2026-07-10T15:57:27Z] creating resource database.instance::storefront-no-image-n1-ant97dj4
[2026-07-10T15:57:27Z] creating resource database.instance::storefront-no-image-n1-9ptayhma
[2026-07-10T15:57:37Z] finished creating resource database.instance::storefront-no-image-n1-ant97dj4 (took 10.034570046s)
[2026-07-10T15:57:37Z] finished creating resource database.instance::storefront-no-image-n1-9ptayhma (took 10.018996088s)
[2026-07-10T15:57:37Z] creating resource database.node::n1
[2026-07-10T15:57:37Z] finished creating resource database.node::n1 (took 161.958µs)
[2026-07-10T15:57:37Z] creating resource monitor.instance::storefront-no-image-n1-ant97dj4
[2026-07-10T15:57:37Z] finished creating resource monitor.instance::storefront-no-image-n1-ant97dj4 (took 15.64025ms)
[2026-07-10T15:57:37Z] creating resource monitor.instance::storefront-no-image-n1-9ptayhma
[2026-07-10T15:57:37Z] creating resource monitor.instance::storefront-no-image-n1-689qacsi
[2026-07-10T15:57:37Z] finished creating resource monitor.instance::storefront-no-image-n1-689qacsi (took 11.953958ms)
[2026-07-10T15:57:37Z] finished creating resource monitor.instance::storefront-no-image-n1-9ptayhma (took 18.93625ms)
[2026-07-10T15:57:38Z] creating resource database.postgres_database::n1:storefront
[2026-07-10T15:57:38Z] finished creating resource database.postgres_database::n1:storefront (took 367.068667ms)

database entity storefront-no-image task 019f4cbe-96fc-7555-bb6f-095b7b86054c completed
```
4. Create DB with manifest image
```
cp1-req create-database < ../demo/Images/create_db_manifest_image.json | cp-follow-task
{
  "database": {
    "created_at": "2026-07-10T16:09:43Z",
    "id": "storefront-manifest-image",
    "spec": {
      "database_name": "storefront",
      "database_users": [
        {
          "attributes": [
            "SUPERUSER",
            "LOGIN"
          ],
          "db_owner": true,
          "username": "admin"
        }
      ],
      "nodes": [
        {
          "host_ids": [
            "host-1",
            "host-2",
            "host-3"
          ],
          "name": "n1"
        }
      ],
      "orchestrator_opts": {
        "swarm": {
          "image": "ghcr.io/pgedge/pgedge-postgres:17.9-spock5.0.6-standard-2"
        }
      },
      "postgres_version": "17.9",
      "spock_version": "5"
    },
    "state": "creating",
    "updated_at": "2026-07-10T16:09:43Z"
  },
  "task": {
    "created_at": "2026-07-10T16:09:43Z",
    "database_id": "storefront-manifest-image",
    "entity_id": "storefront-manifest-image",
    "scope": "database",
    "status": "pending",
    "task_id": "019f4cca-bf40-72de-b7dd-0a185f9cce86",
    "type": "create"
  }
}
[2026-07-10T16:09:44Z] refreshing current state
[2026-07-10T16:09:44Z] finished refreshing current state (took 211.905708ms)
[2026-07-10T16:09:47Z] creating resource common.patroni_cluster::n1
[2026-07-10T16:09:47Z] finished creating resource common.patroni_cluster::n1 (took 32.166µs)
[2026-07-10T16:09:47Z] creating resource swarm.network::storefront-manifest-image-database
[2026-07-10T16:09:47Z] finished creating resource swarm.network::storefront-manifest-image-database (took 8.11925ms)
[2026-07-10T16:09:47Z] creating resource filesystem.dir::storefront-manifest-image-n1-689qacsi-instance
[2026-07-10T16:09:47Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-689qacsi-instance (took 714.125µs)
[2026-07-10T16:09:47Z] creating resource common.patroni_member::storefront-manifest-image-n1-689qacsi
[2026-07-10T16:09:47Z] finished creating resource common.patroni_member::storefront-manifest-image-n1-689qacsi (took 18.208µs)
[2026-07-10T16:09:47Z] creating resource filesystem.dir::storefront-manifest-image-n1-689qacsi-data
[2026-07-10T16:09:47Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-689qacsi-data (took 1.363625ms)
[2026-07-10T16:09:47Z] creating resource filesystem.dir::storefront-manifest-image-n1-689qacsi-certificates
[2026-07-10T16:09:47Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-689qacsi-certificates (took 590µs)
[2026-07-10T16:09:47Z] creating resource filesystem.dir::storefront-manifest-image-n1-689qacsi-configs
[2026-07-10T16:09:47Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-689qacsi-configs (took 581.584µs)
[2026-07-10T16:09:47Z] creating resource common.postgres_certs::storefront-manifest-image-n1-689qacsi
[2026-07-10T16:09:47Z] creating resource common.etcd_creds::storefront-manifest-image-n1-689qacsi
[2026-07-10T16:09:47Z] finished creating resource common.postgres_certs::storefront-manifest-image-n1-689qacsi (took 14.818167ms)
[2026-07-10T16:09:47Z] finished creating resource common.etcd_creds::storefront-manifest-image-n1-689qacsi (took 77.156209ms)
[2026-07-10T16:09:48Z] creating resource swarm.patroni_config::storefront-manifest-image-n1-689qacsi
[2026-07-10T16:09:48Z] finished creating resource swarm.patroni_config::storefront-manifest-image-n1-689qacsi (took 2.778375ms)
[2026-07-10T16:09:48Z] creating resource swarm.postgres_service_spec::storefront-manifest-image-n1-689qacsi
[2026-07-10T16:09:48Z] finished creating resource swarm.postgres_service_spec::storefront-manifest-image-n1-689qacsi (took 246.459µs)
[2026-07-10T16:09:49Z] creating resource swarm.check_will_restart::storefront-manifest-image-n1-689qacsi
[2026-07-10T16:09:49Z] finished creating resource swarm.check_will_restart::storefront-manifest-image-n1-689qacsi (took 2.525417ms)
[2026-07-10T16:09:49Z] creating resource swarm.switchover::storefront-manifest-image-n1-689qacsi
[2026-07-10T16:09:49Z] finished creating resource swarm.switchover::storefront-manifest-image-n1-689qacsi (took 12.125µs)
[2026-07-10T16:09:49Z] creating resource swarm.postgres_service::storefront-manifest-image-n1-689qacsi
[2026-07-10T16:10:09Z] finished creating resource swarm.postgres_service::storefront-manifest-image-n1-689qacsi (took 20.014297176s)
[2026-07-10T16:10:09Z] creating resource database.instance::storefront-manifest-image-n1-689qacsi
[2026-07-10T16:10:19Z] finished creating resource database.instance::storefront-manifest-image-n1-689qacsi (took 10.057459879s)
[2026-07-10T16:10:20Z] creating resource filesystem.dir::storefront-manifest-image-n1-ant97dj4-instance
[2026-07-10T16:10:20Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-ant97dj4-instance (took 690.542µs)
[2026-07-10T16:10:20Z] creating resource filesystem.dir::storefront-manifest-image-n1-9ptayhma-instance
[2026-07-10T16:10:20Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-9ptayhma-instance (took 866.375µs)
[2026-07-10T16:10:20Z] creating resource common.patroni_member::storefront-manifest-image-n1-ant97dj4
[2026-07-10T16:10:20Z] finished creating resource common.patroni_member::storefront-manifest-image-n1-ant97dj4 (took 14.166µs)
[2026-07-10T16:10:20Z] creating resource common.patroni_member::storefront-manifest-image-n1-9ptayhma
[2026-07-10T16:10:20Z] finished creating resource common.patroni_member::storefront-manifest-image-n1-9ptayhma (took 7.458µs)
[2026-07-10T16:10:20Z] creating resource filesystem.dir::storefront-manifest-image-n1-ant97dj4-data
[2026-07-10T16:10:20Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-ant97dj4-data (took 886.792µs)
[2026-07-10T16:10:20Z] creating resource filesystem.dir::storefront-manifest-image-n1-ant97dj4-certificates
[2026-07-10T16:10:20Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-ant97dj4-certificates (took 616.125µs)
[2026-07-10T16:10:20Z] creating resource filesystem.dir::storefront-manifest-image-n1-ant97dj4-configs
[2026-07-10T16:10:20Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-ant97dj4-configs (took 422.75µs)
[2026-07-10T16:10:20Z] creating resource filesystem.dir::storefront-manifest-image-n1-9ptayhma-data
[2026-07-10T16:10:20Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-9ptayhma-data (took 672µs)
[2026-07-10T16:10:20Z] creating resource filesystem.dir::storefront-manifest-image-n1-9ptayhma-configs
[2026-07-10T16:10:20Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-9ptayhma-configs (took 556.5µs)
[2026-07-10T16:10:20Z] creating resource filesystem.dir::storefront-manifest-image-n1-9ptayhma-certificates
[2026-07-10T16:10:20Z] finished creating resource filesystem.dir::storefront-manifest-image-n1-9ptayhma-certificates (took 547.458µs)
[2026-07-10T16:10:21Z] creating resource common.etcd_creds::storefront-manifest-image-n1-ant97dj4
[2026-07-10T16:10:21Z] creating resource common.postgres_certs::storefront-manifest-image-n1-ant97dj4
[2026-07-10T16:10:21Z] finished creating resource common.postgres_certs::storefront-manifest-image-n1-ant97dj4 (took 9.075667ms)
[2026-07-10T16:10:21Z] creating resource common.postgres_certs::storefront-manifest-image-n1-9ptayhma
[2026-07-10T16:10:21Z] creating resource common.etcd_creds::storefront-manifest-image-n1-9ptayhma
[2026-07-10T16:10:21Z] finished creating resource common.etcd_creds::storefront-manifest-image-n1-ant97dj4 (took 73.997041ms)
[2026-07-10T16:10:21Z] finished creating resource common.etcd_creds::storefront-manifest-image-n1-9ptayhma (took 64.066459ms)
[2026-07-10T16:10:21Z] finished creating resource common.postgres_certs::storefront-manifest-image-n1-9ptayhma (took 194.316042ms)
[2026-07-10T16:10:21Z] creating resource swarm.patroni_config::storefront-manifest-image-n1-ant97dj4
[2026-07-10T16:10:21Z] finished creating resource swarm.patroni_config::storefront-manifest-image-n1-ant97dj4 (took 2.412792ms)
[2026-07-10T16:10:21Z] creating resource swarm.patroni_config::storefront-manifest-image-n1-9ptayhma
[2026-07-10T16:10:21Z] finished creating resource swarm.patroni_config::storefront-manifest-image-n1-9ptayhma (took 2.35875ms)
[2026-07-10T16:10:22Z] creating resource swarm.postgres_service_spec::storefront-manifest-image-n1-ant97dj4
[2026-07-10T16:10:22Z] finished creating resource swarm.postgres_service_spec::storefront-manifest-image-n1-ant97dj4 (took 161.416µs)
[2026-07-10T16:10:22Z] creating resource swarm.postgres_service_spec::storefront-manifest-image-n1-9ptayhma
[2026-07-10T16:10:22Z] finished creating resource swarm.postgres_service_spec::storefront-manifest-image-n1-9ptayhma (took 129.75µs)
[2026-07-10T16:10:22Z] creating resource swarm.check_will_restart::storefront-manifest-image-n1-ant97dj4
[2026-07-10T16:10:22Z] finished creating resource swarm.check_will_restart::storefront-manifest-image-n1-ant97dj4 (took 1.937334ms)
[2026-07-10T16:10:22Z] creating resource swarm.check_will_restart::storefront-manifest-image-n1-9ptayhma
[2026-07-10T16:10:22Z] finished creating resource swarm.check_will_restart::storefront-manifest-image-n1-9ptayhma (took 1.949875ms)
[2026-07-10T16:10:22Z] creating resource swarm.switchover::storefront-manifest-image-n1-ant97dj4
[2026-07-10T16:10:22Z] finished creating resource swarm.switchover::storefront-manifest-image-n1-ant97dj4 (took 14.292µs)
[2026-07-10T16:10:22Z] creating resource swarm.switchover::storefront-manifest-image-n1-9ptayhma
[2026-07-10T16:10:22Z] finished creating resource swarm.switchover::storefront-manifest-image-n1-9ptayhma (took 14.333µs)
[2026-07-10T16:10:23Z] creating resource swarm.postgres_service::storefront-manifest-image-n1-ant97dj4
[2026-07-10T16:10:23Z] creating resource swarm.postgres_service::storefront-manifest-image-n1-9ptayhma
[2026-07-10T16:10:43Z] finished creating resource swarm.postgres_service::storefront-manifest-image-n1-ant97dj4 (took 20.013457717s)
[2026-07-10T16:10:43Z] finished creating resource swarm.postgres_service::storefront-manifest-image-n1-9ptayhma (took 20.011691759s)
[2026-07-10T16:10:43Z] creating resource database.instance::storefront-manifest-image-n1-ant97dj4
[2026-07-10T16:10:43Z] creating resource database.instance::storefront-manifest-image-n1-9ptayhma
[2026-07-10T16:10:53Z] finished creating resource database.instance::storefront-manifest-image-n1-ant97dj4 (took 10.024973505s)
[2026-07-10T16:10:53Z] finished creating resource database.instance::storefront-manifest-image-n1-9ptayhma (took 10.021085422s)
[2026-07-10T16:10:53Z] creating resource database.node::n1
[2026-07-10T16:10:53Z] finished creating resource database.node::n1 (took 191.833µs)
[2026-07-10T16:10:53Z] creating resource monitor.instance::storefront-manifest-image-n1-ant97dj4
[2026-07-10T16:10:53Z] finished creating resource monitor.instance::storefront-manifest-image-n1-ant97dj4 (took 12.593041ms)
[2026-07-10T16:10:53Z] creating resource monitor.instance::storefront-manifest-image-n1-9ptayhma
[2026-07-10T16:10:53Z] creating resource monitor.instance::storefront-manifest-image-n1-689qacsi
[2026-07-10T16:10:53Z] finished creating resource monitor.instance::storefront-manifest-image-n1-689qacsi (took 11.698583ms)
[2026-07-10T16:10:53Z] finished creating resource monitor.instance::storefront-manifest-image-n1-9ptayhma (took 14.723583ms)
[2026-07-10T16:10:54Z] creating resource database.postgres_database::n1:storefront
[2026-07-10T16:10:54Z] finished creating resource database.postgres_database::n1:storefront (took 324.564541ms)

database entity storefront-manifest-image task 019f4cca-bf40-72de-b7dd-0a185f9cce86 completed
```
5. Create DB with wrong pg versions

```
cp1-req create-database < ../demo/Images/create_db_wrong_pg_version.json
HTTP/1.1 400 Bad Request
Content-Length: 363
Content-Type: application/json
Date: Fri, 10 Jul 2026 16:21:17 GMT
Goa-Error: invalid_input

{
  message: "validation error for node n1, host host-1: image tag postgres version 18.3 does not match spec version 17.9
    validation error for node n1, host host-2: image tag postgres version 18.3 does not match spec version 17.9
    validation error for node n1, host host-3: image tag postgres version 18.3 does not match spec version 17.9"
  name: "invalid_input"
}
```
6. Create DB with not available images
```
cp1-req create-database < ../demo/Images/create_db_lower_image.json

HTTP/1.1 400 Bad Request
Content-Length: 1136
Content-Type: application/json
Date: Fri, 10 Jul 2026 16:22:45 GMT
Goa-Error: invalid_input

{
  message: "validation error for node n1, host host-2: image \"ghcr.io/pgedge/pgedge-postgres:17.9-spock4.0.0-standard-1\" could not be verified: image \"ghcr.io/pgedge/pgedge-postgres:17.9-spock4.0.0-standard-1\" not found or inaccessible: Error response from daemon: manifest unknown
    validation error for node n2, host host-3: image \"ghcr.io/pgedge/pgedge-postgres:17.9-spock4.0.0-standard-1\" could not be verified: image \"ghcr.io/pgedge/pgedge-postgres:17.9-spock4.0.0-standard-1\" not found or inaccessible: Error response from daemon: manifest unknown
    validation error for node n2, host host-4: image \"ghcr.io/pgedge/pgedge-postgres:17.9-spock4.0.0-standard-1\" could not be verified: image \"ghcr.io/pgedge/pgedge-postgres:17.9-spock4.0.0-standard-1\" not found or inaccessible: Error response from daemon: manifest unknown
    validation error for node n1, host host-1: image \"ghcr.io/pgedge/pgedge-postgres:17.9-spock4.0.0-standard-1\" could not be verified: image \"ghcr.io/pgedge/pgedge-postgres:17.9-spock4.0.0-standard-1\" not found or inaccessible: Error response from daemon: manifest unknown"
  name: "invalid_input"
}
```

7. Create DB with custom image
```
cp1-req create-database < ../demo/Images/create_db_custom_image_success.json | cp-follow-task

{
  "database": {
    "created_at": "2026-07-10T16:29:58Z",
    "id": "storefront-custom-img",
    "spec": {
      "database_name": "storefront",
      "database_users": [
        {
          "attributes": [
            "SUPERUSER",
            "LOGIN"
          ],
          "db_owner": true,
          "username": "admin"
        }
      ],
      "nodes": [
        {
          "host_ids": [
            "host-1",
            "host-2",
            "host-3"
          ],
          "name": "n1"
        }
      ],
      "orchestrator_opts": {
        "swarm": {
          "image": "ghcr.io/pgedge/pgedge-postgres:17.9-spock5.0.6-standard-2"
        }
      },
      "postgres_version": "17.9",
      "spock_version": "5"
    },
    "state": "creating",
    "updated_at": "2026-07-10T16:29:58Z"
  },
  "task": {
    "created_at": "2026-07-10T16:29:58Z",
    "database_id": "storefront-custom-img",
    "entity_id": "storefront-custom-img",
    "scope": "database",
    "status": "pending",
    "task_id": "019f4cdd-4939-7d10-8acd-2fe735613612",
    "type": "create"
  }
}
[2026-07-10T16:29:59Z] refreshing current state
[2026-07-10T16:29:59Z] finished refreshing current state (took 207.813708ms)
[2026-07-10T16:30:01Z] creating resource common.patroni_cluster::n1
[2026-07-10T16:30:01Z] finished creating resource common.patroni_cluster::n1 (took 19.792µs)
[2026-07-10T16:30:01Z] creating resource swarm.network::storefront-custom-img-database
[2026-07-10T16:30:01Z] finished creating resource swarm.network::storefront-custom-img-database (took 6.199417ms)
[2026-07-10T16:30:01Z] creating resource filesystem.dir::storefront-custom-img-n1-689qacsi-instance
[2026-07-10T16:30:01Z] finished creating resource filesystem.dir::storefront-custom-img-n1-689qacsi-instance (took 756.917µs)
[2026-07-10T16:30:02Z] creating resource common.patroni_member::storefront-custom-img-n1-689qacsi
[2026-07-10T16:30:02Z] finished creating resource common.patroni_member::storefront-custom-img-n1-689qacsi (took 19.584µs)
[2026-07-10T16:30:02Z] creating resource filesystem.dir::storefront-custom-img-n1-689qacsi-certificates
[2026-07-10T16:30:02Z] finished creating resource filesystem.dir::storefront-custom-img-n1-689qacsi-certificates (took 1.049292ms)
[2026-07-10T16:30:02Z] creating resource filesystem.dir::storefront-custom-img-n1-689qacsi-data
[2026-07-10T16:30:02Z] finished creating resource filesystem.dir::storefront-custom-img-n1-689qacsi-data (took 858.375µs)
[2026-07-10T16:30:02Z] creating resource filesystem.dir::storefront-custom-img-n1-689qacsi-configs
[2026-07-10T16:30:02Z] finished creating resource filesystem.dir::storefront-custom-img-n1-689qacsi-configs (took 734.584µs)
[2026-07-10T16:30:02Z] creating resource common.postgres_certs::storefront-custom-img-n1-689qacsi
[2026-07-10T16:30:02Z] creating resource common.etcd_creds::storefront-custom-img-n1-689qacsi
[2026-07-10T16:30:02Z] finished creating resource common.etcd_creds::storefront-custom-img-n1-689qacsi (took 69.00175ms)
[2026-07-10T16:30:02Z] finished creating resource common.postgres_certs::storefront-custom-img-n1-689qacsi (took 95.252ms)
[2026-07-10T16:30:03Z] creating resource swarm.patroni_config::storefront-custom-img-n1-689qacsi
[2026-07-10T16:30:03Z] finished creating resource swarm.patroni_config::storefront-custom-img-n1-689qacsi (took 2.266875ms)
[2026-07-10T16:30:03Z] creating resource swarm.postgres_service_spec::storefront-custom-img-n1-689qacsi
[2026-07-10T16:30:03Z] finished creating resource swarm.postgres_service_spec::storefront-custom-img-n1-689qacsi (took 230.417µs)
[2026-07-10T16:30:03Z] creating resource swarm.check_will_restart::storefront-custom-img-n1-689qacsi
[2026-07-10T16:30:03Z] finished creating resource swarm.check_will_restart::storefront-custom-img-n1-689qacsi (took 2.402625ms)
[2026-07-10T16:30:04Z] creating resource swarm.switchover::storefront-custom-img-n1-689qacsi
[2026-07-10T16:30:04Z] finished creating resource swarm.switchover::storefront-custom-img-n1-689qacsi (took 15.209µs)
[2026-07-10T16:30:04Z] creating resource swarm.postgres_service::storefront-custom-img-n1-689qacsi
[2026-07-10T16:30:24Z] finished creating resource swarm.postgres_service::storefront-custom-img-n1-689qacsi (took 20.018430092s)
[2026-07-10T16:30:24Z] creating resource database.instance::storefront-custom-img-n1-689qacsi
[2026-07-10T16:30:34Z] finished creating resource database.instance::storefront-custom-img-n1-689qacsi (took 10.043639004s)
[2026-07-10T16:30:35Z] creating resource filesystem.dir::storefront-custom-img-n1-ant97dj4-instance
[2026-07-10T16:30:35Z] finished creating resource filesystem.dir::storefront-custom-img-n1-ant97dj4-instance (took 587.042µs)
[2026-07-10T16:30:35Z] creating resource filesystem.dir::storefront-custom-img-n1-9ptayhma-instance
[2026-07-10T16:30:35Z] finished creating resource filesystem.dir::storefront-custom-img-n1-9ptayhma-instance (took 753.875µs)
[2026-07-10T16:30:35Z] creating resource common.patroni_member::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:30:35Z] finished creating resource common.patroni_member::storefront-custom-img-n1-9ptayhma (took 11.75µs)
[2026-07-10T16:30:35Z] creating resource common.patroni_member::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:30:35Z] finished creating resource common.patroni_member::storefront-custom-img-n1-ant97dj4 (took 7.542µs)
[2026-07-10T16:30:35Z] creating resource filesystem.dir::storefront-custom-img-n1-ant97dj4-data
[2026-07-10T16:30:35Z] finished creating resource filesystem.dir::storefront-custom-img-n1-ant97dj4-data (took 475.167µs)
[2026-07-10T16:30:35Z] creating resource filesystem.dir::storefront-custom-img-n1-ant97dj4-configs
[2026-07-10T16:30:35Z] finished creating resource filesystem.dir::storefront-custom-img-n1-ant97dj4-configs (took 567.917µs)
[2026-07-10T16:30:35Z] creating resource filesystem.dir::storefront-custom-img-n1-ant97dj4-certificates
[2026-07-10T16:30:35Z] finished creating resource filesystem.dir::storefront-custom-img-n1-ant97dj4-certificates (took 464.417µs)
[2026-07-10T16:30:35Z] creating resource filesystem.dir::storefront-custom-img-n1-9ptayhma-configs
[2026-07-10T16:30:35Z] finished creating resource filesystem.dir::storefront-custom-img-n1-9ptayhma-configs (took 652.167µs)
[2026-07-10T16:30:35Z] creating resource filesystem.dir::storefront-custom-img-n1-9ptayhma-data
[2026-07-10T16:30:35Z] finished creating resource filesystem.dir::storefront-custom-img-n1-9ptayhma-data (took 695.792µs)
[2026-07-10T16:30:35Z] creating resource filesystem.dir::storefront-custom-img-n1-9ptayhma-certificates
[2026-07-10T16:30:35Z] finished creating resource filesystem.dir::storefront-custom-img-n1-9ptayhma-certificates (took 487.125µs)
[2026-07-10T16:30:36Z] creating resource common.etcd_creds::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:30:36Z] creating resource common.postgres_certs::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:30:36Z] creating resource common.etcd_creds::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:30:36Z] creating resource common.postgres_certs::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:30:36Z] finished creating resource common.etcd_creds::storefront-custom-img-n1-ant97dj4 (took 75.753125ms)
[2026-07-10T16:30:36Z] finished creating resource common.etcd_creds::storefront-custom-img-n1-9ptayhma (took 69.389083ms)
[2026-07-10T16:30:36Z] finished creating resource common.postgres_certs::storefront-custom-img-n1-ant97dj4 (took 9.386083ms)
[2026-07-10T16:30:36Z] finished creating resource common.postgres_certs::storefront-custom-img-n1-9ptayhma (took 13.571125ms)
[2026-07-10T16:30:36Z] creating resource swarm.patroni_config::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:30:36Z] finished creating resource swarm.patroni_config::storefront-custom-img-n1-ant97dj4 (took 2.630083ms)
[2026-07-10T16:30:36Z] creating resource swarm.patroni_config::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:30:36Z] finished creating resource swarm.patroni_config::storefront-custom-img-n1-9ptayhma (took 2.1965ms)
[2026-07-10T16:30:37Z] creating resource swarm.postgres_service_spec::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:30:37Z] finished creating resource swarm.postgres_service_spec::storefront-custom-img-n1-ant97dj4 (took 136.792µs)
[2026-07-10T16:30:37Z] creating resource swarm.postgres_service_spec::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:30:37Z] finished creating resource swarm.postgres_service_spec::storefront-custom-img-n1-9ptayhma (took 123.625µs)
[2026-07-10T16:30:37Z] creating resource swarm.check_will_restart::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:30:37Z] finished creating resource swarm.check_will_restart::storefront-custom-img-n1-ant97dj4 (took 2.287209ms)
[2026-07-10T16:30:37Z] creating resource swarm.check_will_restart::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:30:37Z] finished creating resource swarm.check_will_restart::storefront-custom-img-n1-9ptayhma (took 1.485834ms)
[2026-07-10T16:30:37Z] creating resource swarm.switchover::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:30:37Z] finished creating resource swarm.switchover::storefront-custom-img-n1-ant97dj4 (took 12.875µs)
[2026-07-10T16:30:37Z] creating resource swarm.switchover::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:30:37Z] finished creating resource swarm.switchover::storefront-custom-img-n1-9ptayhma (took 14.167µs)
[2026-07-10T16:30:37Z] creating resource swarm.postgres_service::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:30:38Z] creating resource swarm.postgres_service::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:30:58Z] finished creating resource swarm.postgres_service::storefront-custom-img-n1-ant97dj4 (took 20.011605676s)
[2026-07-10T16:30:58Z] finished creating resource swarm.postgres_service::storefront-custom-img-n1-9ptayhma (took 20.010301801s)
[2026-07-10T16:30:58Z] creating resource database.instance::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:30:58Z] creating resource database.instance::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:31:08Z] finished creating resource database.instance::storefront-custom-img-n1-ant97dj4 (took 10.027166004s)
[2026-07-10T16:31:08Z] finished creating resource database.instance::storefront-custom-img-n1-9ptayhma (took 10.020927005s)
[2026-07-10T16:31:08Z] creating resource database.node::n1
[2026-07-10T16:31:08Z] finished creating resource database.node::n1 (took 142.958µs)
[2026-07-10T16:31:08Z] creating resource monitor.instance::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:31:08Z] finished creating resource monitor.instance::storefront-custom-img-n1-ant97dj4 (took 21.35825ms)
[2026-07-10T16:31:08Z] creating resource monitor.instance::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:31:08Z] creating resource monitor.instance::storefront-custom-img-n1-689qacsi
[2026-07-10T16:31:08Z] finished creating resource monitor.instance::storefront-custom-img-n1-9ptayhma (took 18.935833ms)
[2026-07-10T16:31:08Z] finished creating resource monitor.instance::storefront-custom-img-n1-689qacsi (took 14.15725ms)
[2026-07-10T16:31:09Z] creating resource database.postgres_database::n1:storefront
[2026-07-10T16:31:09Z] finished creating resource database.postgres_database::n1:storefront (took 395.819708ms)

database entity storefront-custom-img task 019f4cdd-4939-7d10-8acd-2fe735613612 completed
```
8. Update the databse created using custom image
```
cp1-req update-database storefront-custom-img < ../demo/Images/update_db_spock_patch_upgrade.json | cp-follow-task
{
  "database": {
    "created_at": "2026-07-10T16:29:58Z",
    "id": "storefront-custom-img",
    "instances": [
      {
        "created_at": "2026-07-10T16:30:01Z",
        "host_id": "host-1",
        "id": "storefront-custom-img-n1-689qacsi",
        "node_name": "n1",
        "postgres": {
          "patroni_state": "running",
          "role": "primary",
          "version": "17.9"
        },
        "spock": {
          "read_only": "off",
          "version": "5.0.6"
        },
        "state": "available",
        "status_updated_at": "2026-07-10T16:40:53Z",
        "updated_at": "2026-07-10T16:30:34Z"
      },
      {
        "created_at": "2026-07-10T16:30:34Z",
        "host_id": "host-2",
        "id": "storefront-custom-img-n1-9ptayhma",
        "node_name": "n1",
        "postgres": {
          "patroni_state": "running",
          "role": "replica",
          "version": "17.9"
        },
        "state": "available",
        "status_updated_at": "2026-07-10T16:40:53Z",
        "updated_at": "2026-07-10T16:31:08Z"
      },
      {
        "created_at": "2026-07-10T16:30:34Z",
        "host_id": "host-3",
        "id": "storefront-custom-img-n1-ant97dj4",
        "node_name": "n1",
        "postgres": {
          "patroni_state": "running",
          "role": "replica",
          "version": "17.9"
        },
        "state": "available",
        "status_updated_at": "2026-07-10T16:40:53Z",
        "updated_at": "2026-07-10T16:31:08Z"
      }
    ],
    "spec": {
      "database_name": "storefront",
      "database_users": [
        {
          "attributes": [
            "SUPERUSER",
            "LOGIN"
          ],
          "db_owner": true,
          "username": "admin"
        }
      ],
      "nodes": [
        {
          "host_ids": [
            "host-1",
            "host-2",
            "host-3"
          ],
          "name": "n1"
        }
      ],
      "orchestrator_opts": {
        "swarm": {
          "image": "ghcr.io/pgedge/pgedge-postgres:17.10-spock5.0.9-standard-1"
        }
      },
      "postgres_version": "17.10",
      "spock_version": "5"
    },
    "state": "modifying",
    "updated_at": "2026-07-10T16:40:54Z"
  },
  "task": {
    "created_at": "2026-07-10T16:40:54Z",
    "database_id": "storefront-custom-img",
    "entity_id": "storefront-custom-img",
    "scope": "database",
    "status": "pending",
    "task_id": "019f4ce7-4bfe-7d26-a53a-c80752eb1185",
    "type": "update"
  }
}
[2026-07-10T16:40:56Z] refreshing current state
[2026-07-10T16:41:04Z] finished refreshing current state (took 8.197391463s)
[2026-07-10T16:41:06Z] updating resource swarm.postgres_service_spec::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:41:06Z] finished updating resource swarm.postgres_service_spec::storefront-custom-img-n1-9ptayhma (took 152.75µs)
[2026-07-10T16:41:07Z] updating resource swarm.check_will_restart::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:41:07Z] finished updating resource swarm.check_will_restart::storefront-custom-img-n1-9ptayhma (took 5.825458ms)
[2026-07-10T16:41:07Z] updating resource swarm.switchover::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:41:07Z] finished updating resource swarm.switchover::storefront-custom-img-n1-9ptayhma (took 1.690209ms)
[2026-07-10T16:41:07Z] updating resource swarm.postgres_service::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:41:32Z] finished updating resource swarm.postgres_service::storefront-custom-img-n1-9ptayhma (took 25.012387136s)
[2026-07-10T16:41:33Z] updating resource database.instance::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:41:43Z] finished updating resource database.instance::storefront-custom-img-n1-9ptayhma (took 10.013509796s)
[2026-07-10T16:41:43Z] updating resource database.node::n1
[2026-07-10T16:41:43Z] finished updating resource database.node::n1 (took 116.917µs)
[2026-07-10T16:41:43Z] updating resource monitor.instance::storefront-custom-img-n1-9ptayhma
[2026-07-10T16:41:43Z] finished updating resource monitor.instance::storefront-custom-img-n1-9ptayhma (took 15.783417ms)
[2026-07-10T16:41:43Z] updating resource database.postgres_database::n1:storefront
[2026-07-10T16:41:43Z] finished updating resource database.postgres_database::n1:storefront (took 26.409625ms)
[2026-07-10T16:41:44Z] updating resource swarm.postgres_service_spec::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:41:44Z] finished updating resource swarm.postgres_service_spec::storefront-custom-img-n1-ant97dj4 (took 145µs)
[2026-07-10T16:41:44Z] updating resource swarm.check_will_restart::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:41:44Z] finished updating resource swarm.check_will_restart::storefront-custom-img-n1-ant97dj4 (took 4.806541ms)
[2026-07-10T16:41:44Z] updating resource swarm.switchover::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:41:44Z] finished updating resource swarm.switchover::storefront-custom-img-n1-ant97dj4 (took 2.97575ms)
[2026-07-10T16:41:44Z] updating resource swarm.postgres_service::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:42:09Z] finished updating resource swarm.postgres_service::storefront-custom-img-n1-ant97dj4 (took 25.013117803s)
[2026-07-10T16:42:10Z] updating resource database.instance::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:42:20Z] finished updating resource database.instance::storefront-custom-img-n1-ant97dj4 (took 10.01397638s)
[2026-07-10T16:42:20Z] updating resource database.node::n1
[2026-07-10T16:42:20Z] finished updating resource database.node::n1 (took 104.292µs)
[2026-07-10T16:42:20Z] updating resource monitor.instance::storefront-custom-img-n1-ant97dj4
[2026-07-10T16:42:20Z] finished updating resource monitor.instance::storefront-custom-img-n1-ant97dj4 (took 13.288584ms)
[2026-07-10T16:42:20Z] updating resource database.postgres_database::n1:storefront
[2026-07-10T16:42:20Z] finished updating resource database.postgres_database::n1:storefront (took 25.866084ms)
[2026-07-10T16:42:21Z] updating resource swarm.postgres_service_spec::storefront-custom-img-n1-689qacsi
[2026-07-10T16:42:21Z] finished updating resource swarm.postgres_service_spec::storefront-custom-img-n1-689qacsi (took 155.125µs)
[2026-07-10T16:42:21Z] updating resource swarm.check_will_restart::storefront-custom-img-n1-689qacsi
[2026-07-10T16:42:21Z] finished updating resource swarm.check_will_restart::storefront-custom-img-n1-689qacsi (took 4.758208ms)
[2026-07-10T16:42:21Z] updating resource swarm.switchover::storefront-custom-img-n1-689qacsi
[2026-07-10T16:42:33Z] finished updating resource swarm.switchover::storefront-custom-img-n1-689qacsi (took 12.061781922s)
[2026-07-10T16:42:34Z] updating resource swarm.postgres_service::storefront-custom-img-n1-689qacsi
[2026-07-10T16:42:59Z] finished updating resource swarm.postgres_service::storefront-custom-img-n1-689qacsi (took 25.016098219s)
[2026-07-10T16:42:59Z] updating resource database.instance::storefront-custom-img-n1-689qacsi
[2026-07-10T16:43:09Z] finished updating resource database.instance::storefront-custom-img-n1-689qacsi (took 10.013919379s)
[2026-07-10T16:43:09Z] updating resource database.node::n1
[2026-07-10T16:43:09Z] finished updating resource database.node::n1 (took 120.875µs)
[2026-07-10T16:43:09Z] updating resource monitor.instance::storefront-custom-img-n1-689qacsi
[2026-07-10T16:43:09Z] finished updating resource monitor.instance::storefront-custom-img-n1-689qacsi (took 13.666208ms)
[2026-07-10T16:43:10Z] updating resource database.postgres_database::n1:storefront
[2026-07-10T16:43:10Z] finished updating resource database.postgres_database::n1:storefront (took 58.575875ms)
[2026-07-10T16:43:10Z] creating resource database.switchover::storefront-custom-img-n1-689qacsi
[2026-07-10T16:43:26Z] finished creating resource database.switchover::storefront-custom-img-n1-689qacsi (took 16.065814132s)

database entity storefront-custom-img task 019f4ce7-4bfe-7d26-a53a-c80752eb1185 completed
```

## Checklist

- [x] Tests added or updated


[PLAT-641](https://pgedge.atlassian.net/browse/PLAT-641)

[PLAT-641]: https://pgedge.atlassian.net/browse/PLAT-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ