### PR TITLE
fix: resolve latest service version to manifest default

### DIFF
--- a/server/internal/orchestrator/swarm/manifest_loader.go
+++ b/server/internal/orchestrator/swarm/manifest_loader.go
@@ -415,10 +415,19 @@ func buildServiceVersions(cfg config.Config, mf *versionManifest) (*ServiceVersi
 		{"mcp", mf.Images.MCP},
 		{"rag", mf.Images.RAG},
 	} {
+		var defaultImage *ServiceImage
 		for _, e := range s.entries {
-			sv.addServiceImage(s.name, e.Version, &ServiceImage{
-				Tag: serviceImageTag(cfg, e.Image),
-			})
+			img := &ServiceImage{Tag: serviceImageTag(cfg, e.Image)}
+			sv.addServiceImage(s.name, e.Version, img)
+			if e.Default {
+				defaultImage = img
+			}
+		}
+		if defaultImage == nil && len(s.entries) > 0 {
+			defaultImage = &ServiceImage{Tag: serviceImageTag(cfg, s.entries[len(s.entries)-1].Image)}
+		}
+		if defaultImage != nil {
+			sv.addServiceImage(s.name, "latest", defaultImage)
 		}
 	}
 

--- a/server/internal/orchestrator/swarm/manifest_loader.go
+++ b/server/internal/orchestrator/swarm/manifest_loader.go
@@ -415,16 +415,17 @@ func buildServiceVersions(cfg config.Config, mf *versionManifest) (*ServiceVersi
 		{"mcp", mf.Images.MCP},
 		{"rag", mf.Images.RAG},
 	} {
-		var defaultImage *ServiceImage
+		var defaultImage, lastImage *ServiceImage
 		for _, e := range s.entries {
 			img := &ServiceImage{Tag: serviceImageTag(cfg, e.Image)}
 			sv.addServiceImage(s.name, e.Version, img)
 			if e.Default {
 				defaultImage = img
 			}
+			lastImage = img
 		}
-		if defaultImage == nil && len(s.entries) > 0 {
-			defaultImage = &ServiceImage{Tag: serviceImageTag(cfg, s.entries[len(s.entries)-1].Image)}
+		if defaultImage == nil {
+			defaultImage = lastImage
 		}
 		if defaultImage != nil {
 			sv.addServiceImage(s.name, "latest", defaultImage)


### PR DESCRIPTION
## Summary
This PR addresses an issue where service specifications using `"version": "latest"` failed at runtime because `"latest"` was not registered in the manifest-backed version map.
 

## Changes
- `manifest_loader.go`: `buildServiceVersions` now registers a `"latest"`
  alias for each service type (PostgREST, MCP, RAG) pointing to the
  `default: true` manifest entry, or the last entry if none is marked

## Testing

### Verification:
#### Services with version - 1.0.0
```
cp1-req create-database < ../demo/Images/create_db_with_rag.json | cp-follow-task
{
  "database": {
    "created_at": "2026-07-16T07:19:59Z",
    "id": "storefront-with-services",
    "spec": {
      "database_name": "storefront",
      "database_users": [
        {
          "attributes": [
            "SUPERUSER",
            "LOGIN"
          ],
          "db_owner": true,
          "username": "admin"
        },
        {
          "attributes": [
            "LOGIN"
          ],
          "db_owner": false,
          "username": "web_anon"
        }
      ],
      "nodes": [
        {
          "host_ids": [
            "host-1"
          ],
          "name": "n1"
        }
      ],
      "postgres_version": "17.9",
      "services": [
        {
          "config": {
            "defaults": {
              "token_budget": 2000,
              "top_n": 10
            },
            "pipelines": [
              {
                "description": "Main RAG pipeline",
                "embedding_llm": {
                  "model": "text-embedding-3-small",
                  "provider": "openai"
                },
                "name": "default",
                "rag_llm": {
                  "model": "claude-sonnet-4-5",
                  "provider": "anthropic"
                },
                "search": {
                  "hybrid_enabled": true,
                  "vector_weight": 0.7
                },
                "tables": [
                  {
                    "table": "documents_content_chunks",
                    "text_column": "content",
                    "vector_column": "embedding"
                  }
                ],
                "token_budget": 4000,
                "top_n": 15
              }
            ]
          },
          "connect_as": "admin",
          "host_ids": [
            "host-1"
          ],
          "port": 0,
          "service_id": "rag",
          "service_type": "rag",
          "version": "1.0.0"
        },
        {
          "config": {
            "allow_writes": false,
            "embedding_model": "text-embedding-3-small",
            "embedding_provider": "openai"
          },
          "connect_as": "admin",
          "host_ids": [
            "host-1"
          ],
          "port": 0,
          "service_id": "mcp",
          "service_type": "mcp",
          "version": "1.0.0"
        },
        {
          "config": {
            "db_anon_role": "web_anon",
            "db_schemas": "public"
          },
          "connect_as": "admin",
          "host_ids": [
            "host-1"
          ],
          "port": 0,
          "service_id": "postgrest",
          "service_type": "postgrest",
          "version": "14.5"
        }
      ],
      "spock_version": "5"
    },
    "state": "creating",
    "updated_at": "2026-07-16T07:19:59Z"
  },
  "task": {
    "created_at": "2026-07-16T07:19:59Z",
    "database_id": "storefront-with-services",
    "entity_id": "storefront-with-services",
    "scope": "database",
    "status": "pending",
    "task_id": "019f69cb-e935-719d-aeb6-f590fa1fef12",
    "type": "create"
  }
}
[2026-07-16T07:20:00Z] refreshing current state
[2026-07-16T07:20:00Z] finished refreshing current state (took 205.063626ms)
[2026-07-16T07:20:03Z] creating resource common.patroni_cluster::n1
[2026-07-16T07:20:03Z] finished creating resource common.patroni_cluster::n1 (took 28.5µs)
[2026-07-16T07:20:03Z] creating resource swarm.network::storefront-with-services-database
[2026-07-16T07:20:03Z] finished creating resource swarm.network::storefront-with-services-database (took 8.067209ms)
[2026-07-16T07:20:03Z] creating resource filesystem.dir::storefront-with-services-n1-689qacsi-instance
[2026-07-16T07:20:03Z] finished creating resource filesystem.dir::storefront-with-services-n1-689qacsi-instance (took 968.459µs)
[2026-07-16T07:20:03Z] creating resource common.patroni_member::storefront-with-services-n1-689qacsi
[2026-07-16T07:20:03Z] finished creating resource common.patroni_member::storefront-with-services-n1-689qacsi (took 30.125µs)
[2026-07-16T07:20:03Z] creating resource filesystem.dir::storefront-with-services-n1-689qacsi-certificates
[2026-07-16T07:20:03Z] finished creating resource filesystem.dir::storefront-with-services-n1-689qacsi-certificates (took 1.221583ms)
[2026-07-16T07:20:03Z] creating resource filesystem.dir::storefront-with-services-n1-689qacsi-data
[2026-07-16T07:20:03Z] finished creating resource filesystem.dir::storefront-with-services-n1-689qacsi-data (took 810.416µs)
[2026-07-16T07:20:03Z] creating resource filesystem.dir::storefront-with-services-n1-689qacsi-configs
[2026-07-16T07:20:03Z] finished creating resource filesystem.dir::storefront-with-services-n1-689qacsi-configs (took 602.583µs)
[2026-07-16T07:20:04Z] creating resource common.etcd_creds::storefront-with-services-n1-689qacsi
[2026-07-16T07:20:04Z] creating resource common.postgres_certs::storefront-with-services-n1-689qacsi
[2026-07-16T07:20:04Z] finished creating resource common.etcd_creds::storefront-with-services-n1-689qacsi (took 84.767542ms)
[2026-07-16T07:20:04Z] finished creating resource common.postgres_certs::storefront-with-services-n1-689qacsi (took 7.393791ms)
[2026-07-16T07:20:04Z] creating resource swarm.patroni_config::storefront-with-services-n1-689qacsi
[2026-07-16T07:20:04Z] finished creating resource swarm.patroni_config::storefront-with-services-n1-689qacsi (took 3.08225ms)
[2026-07-16T07:20:05Z] creating resource swarm.postgres_service_spec::storefront-with-services-n1-689qacsi
[2026-07-16T07:20:05Z] finished creating resource swarm.postgres_service_spec::storefront-with-services-n1-689qacsi (took 148.125µs)
[2026-07-16T07:20:05Z] creating resource swarm.check_will_restart::storefront-with-services-n1-689qacsi
[2026-07-16T07:20:05Z] finished creating resource swarm.check_will_restart::storefront-with-services-n1-689qacsi (took 2.649583ms)
[2026-07-16T07:20:05Z] creating resource swarm.switchover::storefront-with-services-n1-689qacsi
[2026-07-16T07:20:05Z] finished creating resource swarm.switchover::storefront-with-services-n1-689qacsi (took 26µs)
[2026-07-16T07:20:05Z] creating resource swarm.postgres_service::storefront-with-services-n1-689qacsi
[2026-07-16T07:20:16Z] finished creating resource swarm.postgres_service::storefront-with-services-n1-689qacsi (took 10.017318879s)
[2026-07-16T07:20:16Z] creating resource database.instance::storefront-with-services-n1-689qacsi
[2026-07-16T07:20:26Z] finished creating resource database.instance::storefront-with-services-n1-689qacsi (took 10.053828004s)
[2026-07-16T07:20:26Z] creating resource database.node::n1
[2026-07-16T07:20:26Z] finished creating resource database.node::n1 (took 284.458µs)
[2026-07-16T07:20:26Z] creating resource filesystem.dir::storefront-with-services-postgrest-host-1-data
[2026-07-16T07:20:26Z] finished creating resource filesystem.dir::storefront-with-services-postgrest-host-1-data (took 1.196083ms)
[2026-07-16T07:20:26Z] creating resource filesystem.dir::storefront-with-services-mcp-host-1-data
[2026-07-16T07:20:26Z] finished creating resource filesystem.dir::storefront-with-services-mcp-host-1-data (took 1.250792ms)
[2026-07-16T07:20:26Z] creating resource filesystem.dir::storefront-with-services-rag-host-1-data
[2026-07-16T07:20:26Z] finished creating resource filesystem.dir::storefront-with-services-rag-host-1-data (took 531.625µs)
[2026-07-16T07:20:27Z] creating resource swarm.postgrest_config::storefront-with-services-postgrest-host-1
[2026-07-16T07:20:27Z] finished creating resource swarm.postgrest_config::storefront-with-services-postgrest-host-1 (took 1.362542ms)
[2026-07-16T07:20:27Z] creating resource swarm.mcp_config::storefront-with-services-mcp-host-1
[2026-07-16T07:20:27Z] finished creating resource swarm.mcp_config::storefront-with-services-mcp-host-1 (took 2.90975ms)
[2026-07-16T07:20:27Z] creating resource swarm.rag_service_keys::storefront-with-services-rag-host-1
[2026-07-16T07:20:27Z] finished creating resource swarm.rag_service_keys::storefront-with-services-rag-host-1 (took 1.626209ms)
[2026-07-16T07:20:27Z] creating resource swarm.service_instance_spec::storefront-with-services-mcp-host-1
[2026-07-16T07:20:27Z] finished creating resource swarm.service_instance_spec::storefront-with-services-mcp-host-1 (took 149.75µs)
[2026-07-16T07:20:27Z] creating resource swarm.service_instance::storefront-with-services-mcp-host-1
[2026-07-16T07:20:38Z] finished creating resource swarm.service_instance::storefront-with-services-mcp-host-1 (took 10.028961005s)
[2026-07-16T07:20:38Z] creating resource monitor.service_instance::storefront-with-services-mcp-host-1
[2026-07-16T07:20:38Z] finished creating resource monitor.service_instance::storefront-with-services-mcp-host-1 (took 8.037375ms)
[2026-07-16T07:20:38Z] creating resource monitor.instance::storefront-with-services-n1-689qacsi
[2026-07-16T07:20:38Z] finished creating resource monitor.instance::storefront-with-services-n1-689qacsi (took 12.698917ms)
[2026-07-16T07:20:39Z] creating resource database.postgres_database::n1:storefront
[2026-07-16T07:20:39Z] finished creating resource database.postgres_database::n1:storefront (took 236.848083ms)
[2026-07-16T07:20:39Z] creating resource swarm.postgrest_authenticator::postgrest-auth-n1
[2026-07-16T07:20:39Z] creating resource swarm.rag_preflight::storefront-with-services-rag-host-1
[2026-07-16T07:20:39Z] finished creating resource swarm.postgrest_authenticator::postgrest-auth-n1 (took 13.597375ms)
[2026-07-16T07:20:39Z] creating resource swarm.postgrest_preflight::postgrest
[2026-07-16T07:20:39Z] finished creating resource swarm.rag_preflight::storefront-with-services-rag-host-1 (took 16.750958ms)
[2026-07-16T07:20:39Z] finished creating resource swarm.postgrest_preflight::postgrest (took 9.746833ms)
[2026-07-16T07:20:40Z] creating resource swarm.service_instance_spec::storefront-with-services-postgrest-host-1
[2026-07-16T07:20:40Z] finished creating resource swarm.service_instance_spec::storefront-with-services-postgrest-host-1 (took 98.375µs)
[2026-07-16T07:20:40Z] creating resource swarm.rag_config::storefront-with-services-rag-host-1
[2026-07-16T07:20:40Z] finished creating resource swarm.rag_config::storefront-with-services-rag-host-1 (took 1.014167ms)
[2026-07-16T07:20:40Z] creating resource swarm.service_instance::storefront-with-services-postgrest-host-1
[2026-07-16T07:20:40Z] creating resource swarm.service_instance_spec::storefront-with-services-rag-host-1
[2026-07-16T07:20:40Z] finished creating resource swarm.service_instance_spec::storefront-with-services-rag-host-1 (took 184.5µs)
[2026-07-16T07:20:50Z] finished creating resource swarm.service_instance::storefront-with-services-postgrest-host-1 (took 10.017025213s)
[2026-07-16T07:20:50Z] creating resource swarm.service_instance::storefront-with-services-rag-host-1
[2026-07-16T07:20:50Z] creating resource monitor.service_instance::storefront-with-services-postgrest-host-1
[2026-07-16T07:20:50Z] finished creating resource monitor.service_instance::storefront-with-services-postgrest-host-1 (took 8.054791ms)
[2026-07-16T07:21:00Z] finished creating resource swarm.service_instance::storefront-with-services-rag-host-1 (took 10.015463046s)
[2026-07-16T07:21:00Z] creating resource monitor.service_instance::storefront-with-services-rag-host-1
[2026-07-16T07:21:00Z] finished creating resource monitor.service_instance::storefront-with-services-rag-host-1 (took 9.822708ms)

database entity storefront-with-services task 019f69cb-e935-719d-aeb6-f590fa1fef12 completed
```
#### Services with latest version
```
➜  control-plane git:(PLAT-693-support-latest-as-a-resolvable-service-version-via-manifest-default-alias) cp1-req create-database < ../demo/Images/create_db_with_services_latest.json | cp-follow-task 
{
  "database": {
    "created_at": "2026-07-16T07:23:38Z",
    "id": "storefront-with-services-latest",
    "spec": {
      "database_name": "storefront",
      "database_users": [
        {
          "attributes": [
            "SUPERUSER",
            "LOGIN"
          ],
          "db_owner": true,
          "username": "admin"
        },
        {
          "attributes": [
            "LOGIN"
          ],
          "db_owner": false,
          "username": "web_anon"
        }
      ],
      "nodes": [
        {
          "host_ids": [
            "host-1"
          ],
          "name": "n1"
        }
      ],
      "postgres_version": "17.9",
      "services": [
        {
          "config": {
            "defaults": {
              "token_budget": 2000,
              "top_n": 10
            },
            "pipelines": [
              {
                "description": "Main RAG pipeline",
                "embedding_llm": {
                  "model": "text-embedding-3-small",
                  "provider": "openai"
                },
                "name": "default",
                "rag_llm": {
                  "model": "claude-sonnet-4-5",
                  "provider": "anthropic"
                },
                "search": {
                  "hybrid_enabled": true,
                  "vector_weight": 0.7
                },
                "tables": [
                  {
                    "table": "documents_content_chunks",
                    "text_column": "content",
                    "vector_column": "embedding"
                  }
                ],
                "token_budget": 4000,
                "top_n": 15
              }
            ]
          },
          "connect_as": "admin",
          "host_ids": [
            "host-1"
          ],
          "port": 0,
          "service_id": "rag",
          "service_type": "rag",
          "version": "latest"
        },
        {
          "config": {
            "allow_writes": false,
            "embedding_model": "text-embedding-3-small",
            "embedding_provider": "openai"
          },
          "connect_as": "admin",
          "host_ids": [
            "host-1"
          ],
          "port": 0,
          "service_id": "mcp",
          "service_type": "mcp",
          "version": "latest"
        },
        {
          "config": {
            "db_anon_role": "web_anon",
            "db_schemas": "public"
          },
          "connect_as": "admin",
          "host_ids": [
            "host-1"
          ],
          "port": 0,
          "service_id": "postgrest",
          "service_type": "postgrest",
          "version": "latest"
        }
      ],
      "spock_version": "5"
    },
    "state": "creating",
    "updated_at": "2026-07-16T07:23:38Z"
  },
  "task": {
    "created_at": "2026-07-16T07:23:38Z",
    "database_id": "storefront-with-services-latest",
    "entity_id": "storefront-with-services-latest",
    "scope": "database",
    "status": "pending",
    "task_id": "019f69cf-42c8-7b96-a883-272df5d0a3a3",
    "type": "create"
  }
}
[2026-07-16T07:23:39Z] refreshing current state
[2026-07-16T07:23:40Z] finished refreshing current state (took 199.761791ms)
[2026-07-16T07:23:42Z] creating resource common.patroni_cluster::n1
[2026-07-16T07:23:42Z] finished creating resource common.patroni_cluster::n1 (took 6.875µs)
[2026-07-16T07:23:42Z] creating resource swarm.network::storefront-with-services-latest-database
[2026-07-16T07:23:42Z] finished creating resource swarm.network::storefront-with-services-latest-database (took 4.315416ms)
[2026-07-16T07:23:42Z] creating resource filesystem.dir::storefront-with-services-latest-n1-689qacsi-instance
[2026-07-16T07:23:42Z] finished creating resource filesystem.dir::storefront-with-services-latest-n1-689qacsi-instance (took 456.041µs)
[2026-07-16T07:23:43Z] creating resource common.patroni_member::storefront-with-services-latest-n1-689qacsi
[2026-07-16T07:23:43Z] finished creating resource common.patroni_member::storefront-with-services-latest-n1-689qacsi (took 11.417µs)
[2026-07-16T07:23:43Z] creating resource filesystem.dir::storefront-with-services-latest-n1-689qacsi-configs
[2026-07-16T07:23:43Z] finished creating resource filesystem.dir::storefront-with-services-latest-n1-689qacsi-configs (took 1.153167ms)
[2026-07-16T07:23:43Z] creating resource filesystem.dir::storefront-with-services-latest-n1-689qacsi-certificates
[2026-07-16T07:23:43Z] finished creating resource filesystem.dir::storefront-with-services-latest-n1-689qacsi-certificates (took 1.0115ms)
[2026-07-16T07:23:43Z] creating resource filesystem.dir::storefront-with-services-latest-n1-689qacsi-data
[2026-07-16T07:23:43Z] finished creating resource filesystem.dir::storefront-with-services-latest-n1-689qacsi-data (took 762.333µs)
[2026-07-16T07:23:43Z] creating resource common.postgres_certs::storefront-with-services-latest-n1-689qacsi
[2026-07-16T07:23:43Z] creating resource common.etcd_creds::storefront-with-services-latest-n1-689qacsi
[2026-07-16T07:23:43Z] finished creating resource common.postgres_certs::storefront-with-services-latest-n1-689qacsi (took 16.971959ms)
[2026-07-16T07:23:43Z] finished creating resource common.etcd_creds::storefront-with-services-latest-n1-689qacsi (took 77.963834ms)
[2026-07-16T07:23:44Z] creating resource swarm.patroni_config::storefront-with-services-latest-n1-689qacsi
[2026-07-16T07:23:44Z] finished creating resource swarm.patroni_config::storefront-with-services-latest-n1-689qacsi (took 2.944334ms)
[2026-07-16T07:23:44Z] creating resource swarm.postgres_service_spec::storefront-with-services-latest-n1-689qacsi
[2026-07-16T07:23:44Z] finished creating resource swarm.postgres_service_spec::storefront-with-services-latest-n1-689qacsi (took 148.125µs)
[2026-07-16T07:23:44Z] creating resource swarm.check_will_restart::storefront-with-services-latest-n1-689qacsi
[2026-07-16T07:23:44Z] finished creating resource swarm.check_will_restart::storefront-with-services-latest-n1-689qacsi (took 1.723875ms)
[2026-07-16T07:23:45Z] creating resource swarm.switchover::storefront-with-services-latest-n1-689qacsi
[2026-07-16T07:23:45Z] finished creating resource swarm.switchover::storefront-with-services-latest-n1-689qacsi (took 26.917µs)
[2026-07-16T07:23:45Z] creating resource swarm.postgres_service::storefront-with-services-latest-n1-689qacsi
[2026-07-16T07:23:55Z] finished creating resource swarm.postgres_service::storefront-with-services-latest-n1-689qacsi (took 10.015875713s)
[2026-07-16T07:23:55Z] creating resource database.instance::storefront-with-services-latest-n1-689qacsi
[2026-07-16T07:24:05Z] finished creating resource database.instance::storefront-with-services-latest-n1-689qacsi (took 10.048588796s)
[2026-07-16T07:24:05Z] creating resource database.node::n1
[2026-07-16T07:24:05Z] finished creating resource database.node::n1 (took 79.958µs)
[2026-07-16T07:24:06Z] creating resource filesystem.dir::storefront-with-services-latest-rag-host-1-data
[2026-07-16T07:24:06Z] finished creating resource filesystem.dir::storefront-with-services-latest-rag-host-1-data (took 833.25µs)
[2026-07-16T07:24:06Z] creating resource filesystem.dir::storefront-with-services-latest-mcp-host-1-data
[2026-07-16T07:24:06Z] finished creating resource filesystem.dir::storefront-with-services-latest-mcp-host-1-data (took 558.625µs)
[2026-07-16T07:24:06Z] creating resource filesystem.dir::storefront-with-services-latest-postgrest-host-1-data
[2026-07-16T07:24:06Z] finished creating resource filesystem.dir::storefront-with-services-latest-postgrest-host-1-data (took 634.084µs)
[2026-07-16T07:24:06Z] creating resource swarm.rag_service_keys::storefront-with-services-latest-rag-host-1
[2026-07-16T07:24:06Z] finished creating resource swarm.rag_service_keys::storefront-with-services-latest-rag-host-1 (took 2.371875ms)
[2026-07-16T07:24:06Z] creating resource swarm.mcp_config::storefront-with-services-latest-mcp-host-1
[2026-07-16T07:24:06Z] finished creating resource swarm.mcp_config::storefront-with-services-latest-mcp-host-1 (took 2.339709ms)
[2026-07-16T07:24:06Z] creating resource swarm.postgrest_config::storefront-with-services-latest-postgrest-host-1
[2026-07-16T07:24:06Z] finished creating resource swarm.postgrest_config::storefront-with-services-latest-postgrest-host-1 (took 638.625µs)
[2026-07-16T07:24:07Z] creating resource swarm.service_instance_spec::storefront-with-services-latest-mcp-host-1
[2026-07-16T07:24:07Z] finished creating resource swarm.service_instance_spec::storefront-with-services-latest-mcp-host-1 (took 112.125µs)
[2026-07-16T07:24:07Z] creating resource swarm.service_instance::storefront-with-services-latest-mcp-host-1
[2026-07-16T07:24:17Z] finished creating resource swarm.service_instance::storefront-with-services-latest-mcp-host-1 (took 10.030255796s)
[2026-07-16T07:24:17Z] creating resource monitor.service_instance::storefront-with-services-latest-mcp-host-1
[2026-07-16T07:24:17Z] finished creating resource monitor.service_instance::storefront-with-services-latest-mcp-host-1 (took 7.000709ms)
[2026-07-16T07:24:18Z] creating resource monitor.instance::storefront-with-services-latest-n1-689qacsi
[2026-07-16T07:24:18Z] finished creating resource monitor.instance::storefront-with-services-latest-n1-689qacsi (took 16.729209ms)
[2026-07-16T07:24:18Z] creating resource database.postgres_database::n1:storefront
[2026-07-16T07:24:18Z] finished creating resource database.postgres_database::n1:storefront (took 277.651083ms)
[2026-07-16T07:24:19Z] creating resource swarm.postgrest_preflight::postgrest
[2026-07-16T07:24:19Z] creating resource swarm.rag_preflight::storefront-with-services-latest-rag-host-1
[2026-07-16T07:24:19Z] creating resource swarm.postgrest_authenticator::postgrest-auth-n1
[2026-07-16T07:24:19Z] finished creating resource swarm.postgrest_preflight::postgrest (took 14.220292ms)
[2026-07-16T07:24:19Z] finished creating resource swarm.rag_preflight::storefront-with-services-latest-rag-host-1 (took 8.639958ms)
[2026-07-16T07:24:19Z] finished creating resource swarm.postgrest_authenticator::postgrest-auth-n1 (took 7.167666ms)
[2026-07-16T07:24:19Z] creating resource swarm.rag_config::storefront-with-services-latest-rag-host-1
[2026-07-16T07:24:19Z] finished creating resource swarm.rag_config::storefront-with-services-latest-rag-host-1 (took 1.011667ms)
[2026-07-16T07:24:19Z] creating resource swarm.service_instance_spec::storefront-with-services-latest-postgrest-host-1
[2026-07-16T07:24:19Z] finished creating resource swarm.service_instance_spec::storefront-with-services-latest-postgrest-host-1 (took 83.125µs)
[2026-07-16T07:24:19Z] creating resource swarm.service_instance::storefront-with-services-latest-postgrest-host-1
[2026-07-16T07:24:19Z] creating resource swarm.service_instance_spec::storefront-with-services-latest-rag-host-1
[2026-07-16T07:24:19Z] finished creating resource swarm.service_instance_spec::storefront-with-services-latest-rag-host-1 (took 172.875µs)
[2026-07-16T07:24:29Z] finished creating resource swarm.service_instance::storefront-with-services-latest-postgrest-host-1 (took 10.016181129s)
[2026-07-16T07:24:30Z] creating resource swarm.service_instance::storefront-with-services-latest-rag-host-1
[2026-07-16T07:24:30Z] creating resource monitor.service_instance::storefront-with-services-latest-postgrest-host-1
[2026-07-16T07:24:30Z] finished creating resource monitor.service_instance::storefront-with-services-latest-postgrest-host-1 (took 7.348958ms)
[2026-07-16T07:24:40Z] finished creating resource swarm.service_instance::storefront-with-services-latest-rag-host-1 (took 10.024143255s)
[2026-07-16T07:24:40Z] creating resource monitor.service_instance::storefront-with-services-latest-rag-host-1
[2026-07-16T07:24:40Z] finished creating resource monitor.service_instance::storefront-with-services-latest-rag-host-1 (took 7.736125ms)

database entity storefront-with-services-latest task 019f69cf-42c8-7b96-a883-272df5d0a3a3 completed
```

## Checklist

- [x] Tests added or updated (unit and/or e2e, as needed)


[PLAT-693](https://pgedge.atlassian.net/browse/PLAT-693)

[PLAT-693]: https://pgedge.atlassian.net/browse/PLAT-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ