### PR TITLE
docs: systemd docs recommend enterprise repo download

### DIFF
--- a/docs/installation/systemd-installation.md
+++ b/docs/installation/systemd-installation.md
@@ -3,8 +3,10 @@
 This guide covers installing the pgEdge Control Plane on Linux hosts that use
 the RPM Package Manager (RPM) package format (e.g., Red Hat Enterprise Linux
 (RHEL), Rocky Linux, AlmaLinux) or the Debian (deb) package format (e.g.,
-Ubuntu, Debian) using the package files attached to each
-[GitHub release](https://github.com/pgedge/control-plane/releases).
+Ubuntu, Debian). We recommend installing from the pgEdge Enterprise package
+repositories; package files are also attached to each [GitHub
+release](https://github.com/pgedge/control-plane/releases) for hosts without
+repository access.
 
 Unlike the Docker Swarm installation method, the system package installation
 runs the Control Plane directly on the host. The Control Plane uses systemd to
@@ -115,9 +117,8 @@ sudo apt install -y pgedge-control-plane
 
 ### Installing from GitHub Releases
 
-If you don't have access to the pgEdge Enterprise package repositories (for
-example, on an air-gapped host), you can download and install packages
-directly from the [GitHub releases
+If you don't have access to the pgEdge Enterprise package repositories, you can
+download and install packages directly from the [GitHub releases
 page](https://github.com/pgedge/control-plane/releases).
 
 #### RPM Package

--- a/docs/installation/systemd-installation.md
+++ b/docs/installation/systemd-installation.md
@@ -83,9 +83,8 @@ sudo systemctl disable --now postgresql@${POSTGRES_MAJOR_VERSION}-main.service
 
 ## Installing the Control Plane
 
-The pgEdge Control Plane packages are published with each release on the
-[GitHub releases page](https://github.com/pgedge/control-plane/releases) for
-both `amd64` and `arm64` architectures.
+The pgEdge Control Plane packages are published for both `amd64` and `arm64`
+architectures.
 
 Every package will install the following files:
 
@@ -93,7 +92,35 @@ Every package will install the following files:
 - The systemd service unit is installed at `/usr/lib/systemd/system/pgedge-control-plane.service`.
 - The default configuration file is installed at `/etc/pgedge-control-plane/config.json`.
 
+We recommend installing the Control Plane from the pgEdge Enterprise package
+repositories you configured in the [Packages](#packages) section above. If you
+don't have access to those repositories, see [Installing from GitHub
+Releases](#installing-from-github-releases) below.
+
 ### RPM Package
+
+Use the following command to install the Control Plane on RHEL-like hosts:
+
+```sh
+sudo dnf install -y pgedge-control-plane
+```
+
+### Deb Package
+
+Use the following command to install the Control Plane on Debian-based hosts:
+
+```sh
+sudo apt install -y pgedge-control-plane
+```
+
+### Installing from GitHub Releases
+
+If you don't have access to the pgEdge Enterprise package repositories (for
+example, on an air-gapped host), you can download and install packages
+directly from the [GitHub releases
+page](https://github.com/pgedge/control-plane/releases).
+
+#### RPM Package
 
 Use the following commands to download and install the RPM:
 
@@ -111,7 +138,7 @@ curl -LO "https://github.com/pgedge/control-plane/releases/download/${VERSION}/p
 sudo rpm -i pgedge-control-plane_${VERSION#v}_linux_${ARCH}.rpm
 ```
 
-### Deb Package
+#### Deb Package
 
 Use the following commands to download and install the deb package:
 
@@ -274,30 +301,6 @@ instructions.
 > Unlike with the Swarm orchestrator, `patroni_port` is a required field in
 > systemd clusters. As with other port fields, you can specify `0` to assign a
 > random port.
-
-### Deb Package
-
-Use the following commands to download and install the deb package:
-
-```sh
-# (Optional) print the current version via the API
-curl http://localhost:3000/v1/version
-
-# Detect architecture
-ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-
-# Set the new version to install
-VERSION="v0.9.0"
-
-# Download the deb package
-curl -LO --output-dir /tmp "https://github.com/pgedge/control-plane/releases/download/${VERSION}/pgedge-control-plane_${VERSION#v}_linux_${ARCH}.deb"
-
-# Install the deb package
-sudo apt install /tmp/pgedge-control-plane_${VERSION#v}_linux_${ARCH}.deb
-
-# (Optional) print the updated version via the API
-curl http://localhost:3000/v1/version
-```
 
 ## Uninstalling the Control Plane
 

--- a/docs/installation/systemd-upgrading.md
+++ b/docs/installation/systemd-upgrading.md
@@ -6,7 +6,43 @@ automatically restart the Control Plane service after the update is complete.
 > The package upgrade will preserve any modifications to the configuration file
 > at `/etc/pgedge-control-plane/config.json`.
 
+We recommend updating the Control Plane using the pgEdge Enterprise package
+repositories you configured in the [Packages](systemd-installation.md#packages)
+section. If you installed the Control Plane manually, see [Updating from
+GitHub Releases](#updating-from-github-releases) below.
+
 ### RPM Package
+
+```sh
+# (Optional) print the current version via the API
+curl http://localhost:3000/v1/version
+
+# Upgrade the package
+sudo dnf upgrade -y pgedge-control-plane
+
+# (Optional) print the updated version via the API
+curl http://localhost:3000/v1/version
+```
+
+### Deb Package
+
+```sh
+# (Optional) print the current version via the API
+curl http://localhost:3000/v1/version
+
+# Upgrade the package
+sudo apt install --only-upgrade -y pgedge-control-plane
+
+# (Optional) print the updated version via the API
+curl http://localhost:3000/v1/version
+```
+
+### Updating from GitHub Releases
+
+If you installed the Control Plane manually from GitHub releases, download and
+install the updated package version.
+
+#### RPM Package
 
 Use the following commands to download and install the updated RPM:
 
@@ -30,8 +66,7 @@ sudo rpm -U pgedge-control-plane_${VERSION#v}_linux_${ARCH}.rpm
 curl http://localhost:3000/v1/version
 ```
 
-
-### Deb Package
+#### Deb Package
 
 Use the following commands to download and install the deb package:
 

--- a/docs/installation/systemd-upgrading.md
+++ b/docs/installation/systemd-upgrading.md
@@ -11,6 +11,8 @@ repositories you configured in the [Packages](systemd-installation.md#packages)
 section. If you installed the Control Plane manually, see [Updating from
 GitHub Releases](#updating-from-github-releases) below.
 
+## Updating the Control Plane
+
 ### RPM Package
 
 ```sh


### PR DESCRIPTION
## Summary

 Recommend installing and updating the Control Plane package on systemd hosts from the pgEdge Enterprise dnf/apt repositories,since the control-plane package will begin publishing there starting with the next release. The existing GitHub Releases curl-based method is kept as a fallback for air-gapped hosts or pinning an exact version.

## Changes

 - Installing the Control Plane doc now recommends dnf install/apt install pgedge-control-plane from the enterprise repo, keeps original logic as a fallback subsection.
  - docs/installation/systemd-upgrading.md: same treatment for upgrades, enterprise repo recommended but fallback kept