### PR TITLE
chore: added missing changelog entries

### DIFF
--- a/changes/unreleased/Added-20260625-000000.yaml
+++ b/changes/unreleased/Added-20260625-000000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: The Control Plane now rejects database specs that remove `spock` from `postgresql_conf.shared_preload_libraries`, preventing accidental disabling of the replication extension.
+time: 2026-06-25T00:00:00.000000+00:00

--- a/changes/unreleased/Added-20260701-000000.yaml
+++ b/changes/unreleased/Added-20260701-000000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added image upgrade support. Use `GET /v1/databases/{id}?include=available_upgrades` to list newer stable images within the same Postgres major and Spock major version bucket, and `POST /v1/databases/{id}/upgrade` to apply an upgrade without changing the Postgres major version.
+time: 2026-07-01T00:00:00.000000+00:00

--- a/changes/unreleased/Added-20260701-000001.yaml
+++ b/changes/unreleased/Added-20260701-000001.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added support for custom container image pinning per database or node via `orchestrator_opts.swarm.image`. pgEdge-formatted image tags are validated against the spec's declared versions; unrecognized tags are accepted without version checks. The Control Plane also persists the resolved image at creation time, preventing silent image changes during Control Plane upgrades.
+time: 2026-07-01T00:00:01.000000+00:00

--- a/changes/unreleased/Added-20260707-000000.yaml
+++ b/changes/unreleased/Added-20260707-000000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Version resolution is now fully manifest-driven. Supported versions update with manifest refreshes without requiring a Control Plane upgrade.
+time: 2026-07-07T00:00:00.000000+00:00

--- a/changes/unreleased/Added-20260707-000001.yaml
+++ b/changes/unreleased/Added-20260707-000001.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: The Control Plane now falls back to the first available IPv6 address when no IPv4 address is found during IP autodetection.
+time: 2026-07-07T00:00:01.000000+00:00

--- a/changes/unreleased/Added-20260713-000000.yaml
+++ b/changes/unreleased/Added-20260713-000000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Cancelling a task now propagates to any in-progress activities, interrupting long-running operations rather than waiting for them to complete.
+time: 2026-07-13T00:00:00.000000+00:00

--- a/changes/unreleased/Added-20260723-000000.yaml
+++ b/changes/unreleased/Added-20260723-000000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: RPM and DEB packages are now published to the pgEdge dnf and apt repositories on every release, enabling installation via `dnf` and `apt-get` in addition to the existing Docker and binary distribution methods.
+time: 2026-07-23T00:00:00.00000+00:00

--- a/changes/unreleased/Fixed-20260706-000000.yaml
+++ b/changes/unreleased/Fixed-20260706-000000.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed an issue where resources pending recreation were not correctly planned for creation in the right reconciliation phase, causing reconciliation errors.
+time: 2026-07-06T00:00:00.000000+00:00

--- a/changes/unreleased/Fixed-20260708-000000.yaml
+++ b/changes/unreleased/Fixed-20260708-000000.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed Patroni rejecting connections from IPv4 addresses presented as IPv4-mapped IPv6 addresses (e.g. `::ffff:192.168.1.1`) on dual-stack hosts.
+time: 2026-07-08T00:00:00.000000+00:00

--- a/changes/unreleased/Fixed-20260715-000001.yaml
+++ b/changes/unreleased/Fixed-20260715-000001.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed rolling updates failing on multi-node databases with replica instances due to replication slot timing during instance initialization.
+time: 2026-07-15T00:00:01.000000+00:00

--- a/changes/unreleased/Fixed-20260716-000000.yaml
+++ b/changes/unreleased/Fixed-20260716-000000.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed an issue where services configured with `"version": "latest"` failed at runtime because `"latest"` was not registered in the version map.
+time: 2026-07-16T00:00:00.000000+00:00

--- a/changes/unreleased/Fixed-20260716-000000.yaml
+++ b/changes/unreleased/Fixed-20260716-000000.yaml
@@ -1,3 +1,3 @@
 kind: Fixed
-body: Fixed an issue where services configured with `"version": "latest"` failed at runtime because `"latest"` was not registered in the version map.
+body: 'Fixed an issue where services configured with `"version": "latest"` failed at runtime because `"latest"` was not registered in the version map.'
 time: 2026-07-16T00:00:00.000000+00:00

--- a/changes/unreleased/Security-20260721-000000.yaml
+++ b/changes/unreleased/Security-20260721-000000.yaml
@@ -1,0 +1,3 @@
+kind: Security
+body: Fixed a SQL injection vulnerability in role attribute handling during database creation and updates.
+time: 2026-07-21T00:00:00.000000+00:00


### PR DESCRIPTION
Fixup missing changelog entries for the next release:

✗ changie batch minor --dry-run

## v0.10.0 - 2026-07-23

### Added

- The Control Plane now rejects database specs that remove `spock` from
  `postgresql_conf.shared_preload_libraries`, preventing accidental
  disabling of the replication extension.
- Added image upgrade support. Use
  `GET /v1/databases/{id}?include=available_upgrades` to list newer
  stable images within the same Postgres major and Spock major version
  bucket, and `POST /v1/databases/{id}/upgrade` to apply an upgrade
  without changing the Postgres major version.
- Added support for custom container image pinning per database or node
  via `orchestrator_opts.swarm.image`. pgEdge-formatted image tags are
  validated against the spec's declared versions; unrecognized tags are
  accepted without version checks. The Control Plane also persists the
  resolved image at creation time, preventing silent image changes
  during Control Plane upgrades.
- Version resolution is now fully manifest-driven. Supported versions
  update with manifest refreshes without requiring a Control Plane
  upgrade.
- The Control Plane now falls back to the first available IPv6 address
  when no IPv4 address is found during IP autodetection.
- Cancelling a task now propagates to any in-progress activities,
  interrupting long-running operations rather than waiting for them to
  complete.
- RPM and DEB packages are now published to the pgEdge dnf and apt
  repositories on every release, enabling installation via `dnf` and
  `apt-get` in addition to the existing Docker and binary distribution
  methods.

### Changed

- **Breaking:** Changed the default `password_encryption` from `md5` to
  `scram-sha-256`. If you're using the default password encryption,
  every role in a database's `database_users` will be automatically
  updated to `scram-sha-256` the next time you update that database.
  Roles created outside of `database_users` will need their passwords
  updated manually. To keep using `md5`, set
  `postgresql_conf.password_encryption` to `md5` in your database spec.

### Fixed

- Fixed an issue where resources pending recreation were not correctly
  planned for creation in the right reconciliation phase, causing
  reconciliation errors.
- Fixed Patroni rejecting connections from IPv4 addresses presented as
  IPv4-mapped IPv6 addresses (e.g. `::ffff:192.168.1.1`) on dual-stack
  hosts.
- Fixed rolling updates failing on multi-node databases with replica
  instances due to replication slot timing during instance
  initialization.
- Fixed an issue where services configured with `"version": "latest"`
  failed at runtime because `"latest"` was not registered in the
  version map.

### Security

- Updated vulnerable dependencies (pgx v5.10.0, OpenTelemetry v1.44.0,
  golang.org/x/crypto v0.54.0, golang.org/x/net v0.57.0) and bumped
  the Go toolchain to 1.26.5 to remediate Trivy-flagged CVEs.
- Fixed a SQL injection vulnerability in role attribute handling during
  database creation and updates.


[PLAT-696](https://pgedge.atlassian.net/browse/PLAT-696)

[PLAT-696]: https://pgedge.atlassian.net/browse/PLAT-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ