### PR TITLE
feat: add support for Spock 5.0.10

### DIFF
--- a/changes/unreleased/Added-20260724-000000.yaml
+++ b/changes/unreleased/Added-20260724-000000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added support for Spock 5.0.10 on Postgres 16.14, 17.10, and 18.4.
+time: 2026-07-24T00:00:00.000000+00:00

--- a/server/internal/orchestrator/swarm/version-manifest.json
+++ b/server/internal/orchestrator/swarm/version-manifest.json
@@ -29,7 +29,7 @@
       {
         "postgres_version": "16.14",
         "spock_version": "5",
-        "image": "pgedge-postgres:16.14-spock5.0.9-standard-1",
+        "image": "pgedge-postgres:16.14-spock5.0.10-standard-1",
         "stability": "stable"
       },
       {
@@ -59,7 +59,7 @@
       {
         "postgres_version": "17.10",
         "spock_version": "5",
-        "image": "pgedge-postgres:17.10-spock5.0.9-standard-1",
+        "image": "pgedge-postgres:17.10-spock5.0.10-standard-1",
         "stability": "stable"
       },
       {
@@ -89,7 +89,7 @@
       {
         "postgres_version": "18.4",
         "spock_version": "5",
-        "image": "pgedge-postgres:18.4-spock5.0.9-standard-1",
+        "image": "pgedge-postgres:18.4-spock5.0.10-standard-1",
         "stability": "stable",
         "default": true
       }


### PR DESCRIPTION

## Summary
This PR adds Spock 5.0.10 support to the Control Plane. 

## Changes

- Update image tags for PG 16.14, 17.10, and 18.4 from spock5.0.9-standard-1 to spock5.0.10-standard-1 in version-manifest.json and the dev manifest cache

## Testing

- No test changes required — the version system is fully manifest-driven and the image tag parser already handles two-digit patch versions.

[PLAT-697](https://pgedge.atlassian.net/browse/PLAT-697)

[PLAT-697]: https://pgedge.atlassian.net/browse/PLAT-697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ