### PR TITLE
fix: restore '~' in pre-release deb filenames before apt push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -236,6 +236,14 @@ jobs:
                       ver="${ver##*:}"   # drop any epoch, matching reprepro's pool naming
                       canonical="deb-dl/${pkg}_${ver}_${arch}.deb"
                       if [ "$f" != "$canonical" ]; then
+                          # Refuse to clobber: if a distinct asset already
+                          # occupies the canonical name, two debs share the same
+                          # Package/Version/Architecture. Fail loudly rather than
+                          # silently discard one package's bytes.
+                          if [ -e "$canonical" ]; then
+                              echo "::error::canonical filename collision: '$(basename "$f")' and an existing asset both map to '$(basename "$canonical")'"
+                              exit 1
+                          fi
                           mv -- "$f" "$canonical"
                           echo "Restored canonical name: $(basename "$f") -> $(basename "$canonical")"
                       fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -216,6 +216,30 @@ jobs:
                   set -euo pipefail
                   mkdir -p deb-dl
                   gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern '*.deb' --dir deb-dl
+                  # GitHub Releases sanitizes '~' to '.' in asset filenames on
+                  # upload, so a pre-release deb built as '...~rc1-1...' comes
+                  # back from the release as '...\.rc1-1...'. reprepro pools
+                  # debs under the canonical '<Package>_<Version>_<Arch>.deb'
+                  # name, and Version keeps the '~', so the sanitized download
+                  # name no longer matches the pooled name. On a re-push the
+                  # apt-repo-builder then holds the pooled '~' copy AND the '.'
+                  # download as two different files for the same version, and
+                  # reprepro rejects the second. Rebuild the canonical filename
+                  # from each deb's own control metadata (the same fields
+                  # reprepro uses), so the download name matches the pool name
+                  # again. This reads metadata and renames only — package bytes
+                  # are never touched — and is a no-op for GA releases (no '~').
+                  for f in deb-dl/*.deb; do
+                      pkg="$(dpkg-deb -f "$f" Package)"
+                      ver="$(dpkg-deb -f "$f" Version)"
+                      arch="$(dpkg-deb -f "$f" Architecture)"
+                      ver="${ver##*:}"   # drop any epoch, matching reprepro's pool naming
+                      canonical="deb-dl/${pkg}_${ver}_${arch}.deb"
+                      if [ "$f" != "$canonical" ]; then
+                          mv -- "$f" "$canonical"
+                          echo "Restored canonical name: $(basename "$f") -> $(basename "$canonical")"
+                      fi
+                  done
                   ls -la deb-dl
             - name: Organize DEBs by codename + build targets/cells
               id: targets


### PR DESCRIPTION
GitHub Releases sanitizes `~` → `.` in asset filenames on upload, so a
  pre-release deb goreleaser builds as `...~rc1-1...` is served from the
  release as `...\.rc1-1...`. reprepro pools debs under their canonical
  `<Package>_<Version>_<Arch>.deb` name (which keeps the `~`), so the
  sanitized download name no longer matches the pooled name.

  On a re-push of an already-published pre-release, the apt-repo-builder
  moves the pooled `~` copy into its staging dir and copies the `.`
  download alongside it. Because the names differ, the copy doesn't
  replace the pooled copy, so reprepro receives two files for the same
  version with different bytes and fails:

  ERROR: '...~rc1-1.bookworm_amd64.deb' cannot be included ...
  Already existing files can only be included again, if they are the same

  ## Fix

  After `gh release download`, rebuild each deb's canonical filename from
  its own control metadata (`Package`/`Version`/`Architecture` — the same
  fields reprepro uses), restoring the `~`. This only reads metadata and
  renames; package bytes are untouched, and it's a no-op for GA releases
  (no `~`).

  ## Testing

  Verified end-to-end in a `debian:bookworm` container:
  - Sanitized `.rc1` download restored to canonical `~rc1` name
  - Package bytes unchanged (md5 identical before/after)
  - GA name already canonical → no rename
  - Full re-push simulation (pooled `~` copy + renamed download) collapses
    to one file → `reprepro includedeb` succeeds, no collision

  Note: only affects pre-releases (rc/beta/etc.); GA releases were never impacted. No repo cleanup needed — the fix makes the next push's names match the existing pooled ~ names.