### PR TITLE
fix: bundle README/LICENSE and set explicit file modes in rpm/deb packages and fix files permissions issue.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,6 +75,25 @@ nfpms:
         dst: /usr/share/pgedge-control-plane/pgedge-control-plane-sbom.json
       - src: ".sbom/sbom.{{ .Format }}.asc"
         dst: /usr/share/pgedge-control-plane/pgedge-control-plane-sbom.json.asc
+      # Docs and license, at the same paths for both formats. The 'doc' and
+      # 'license' types add the %doc/%license markers to the rpm spec, but nfpm
+      # drops content of those types from non-rpm packages, so the deb needs its
+      # own plain-file entries (scoped with `packager` so each format gets
+      # exactly one entry per path).
+      - src: README.md
+        dst: /usr/share/doc/pgedge-control-plane/README.md
+        type: doc
+        packager: rpm
+      - src: README.md
+        dst: /usr/share/doc/pgedge-control-plane/README.md
+        packager: deb
+      - src: LICENSE.md
+        dst: /usr/share/licenses/pgedge-control-plane/LICENSE.md
+        type: license
+        packager: rpm
+      - src: LICENSE.md
+        dst: /usr/share/licenses/pgedge-control-plane/LICENSE.md
+        packager: deb
     formats: [rpm]
     release: "1.el9"
   - <<: *nfpm_defaults

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,17 +64,30 @@ nfpms:
         scripts:
           postinstall: packaging/deb/postinstall.sh
           preremove: packaging/deb/preremove.sh
+    # Every entry sets file_info.mode explicitly. Without it nfpm packages the
+    # mode of the file as checked out on the builder, which is umask-dependent
+    # (CI runs with umask 002, so git creates 0664 and that mode shipped in the
+    # packages). config.json is 0640 because it may hold credentials; the unit
+    # runs as root, so root-only read access is sufficient.
     contents:
       - src: packaging/pgedge-control-plane.service
         dst: /usr/lib/systemd/system/pgedge-control-plane.service
         type: config
+        file_info:
+          mode: 0644
       - src: packaging/config.json
         dst: /etc/pgedge-control-plane/config.json
         type: config|noreplace
+        file_info:
+          mode: 0640
       - src: .sbom/sbom.json
         dst: /usr/share/pgedge-control-plane/pgedge-control-plane-sbom.json
+        file_info:
+          mode: 0644
       - src: ".sbom/sbom.{{ .Format }}.asc"
         dst: /usr/share/pgedge-control-plane/pgedge-control-plane-sbom.json.asc
+        file_info:
+          mode: 0644
       # Docs and license, at the same paths for both formats. The 'doc' and
       # 'license' types add the %doc/%license markers to the rpm spec, but nfpm
       # drops content of those types from non-rpm packages, so the deb needs its
@@ -84,16 +97,24 @@ nfpms:
         dst: /usr/share/doc/pgedge-control-plane/README.md
         type: doc
         packager: rpm
+        file_info:
+          mode: 0644
       - src: README.md
         dst: /usr/share/doc/pgedge-control-plane/README.md
         packager: deb
+        file_info:
+          mode: 0644
       - src: LICENSE.md
         dst: /usr/share/licenses/pgedge-control-plane/LICENSE.md
         type: license
         packager: rpm
+        file_info:
+          mode: 0644
       - src: LICENSE.md
         dst: /usr/share/licenses/pgedge-control-plane/LICENSE.md
         packager: deb
+        file_info:
+          mode: 0644
     formats: [rpm]
     release: "1.el9"
   - <<: *nfpm_defaults

--- a/changes/unreleased/Fixed-20260728-000000.yaml
+++ b/changes/unreleased/Fixed-20260728-000000.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: The RPM and DEB packages now bundle the project documentation and license, installing `README.md` to `/usr/share/doc/pgedge-control-plane/` and `LICENSE.md` to `/usr/share/licenses/pgedge-control-plane/`.
+time: 2026-07-28T00:00:00.000000+00:00

--- a/changes/unreleased/Fixed-20260729-000000.yaml
+++ b/changes/unreleased/Fixed-20260729-000000.yaml
@@ -1,3 +1,3 @@
 kind: Fixed
-body: RPM and DEB packages now install files with explicit, deterministic permissions rather than inheriting the build machine's umask, which produced world-writable-group `0664` files. `/usr/lib/systemd/system/pgedge-control-plane.service` is now `0644` and `/etc/pgedge-control-plane/config.json` is now `0640`.
+body: RPM and DEB packages now install files with explicit, deterministic permissions rather than inheriting the build machine's umask, which produced group-writable `0664` files. `/usr/lib/systemd/system/pgedge-control-plane.service` is now `0644` and `/etc/pgedge-control-plane/config.json` is now `0640`.
 time: 2026-07-29T00:00:00.000000+00:00

--- a/changes/unreleased/Fixed-20260729-000000.yaml
+++ b/changes/unreleased/Fixed-20260729-000000.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: RPM and DEB packages now install files with explicit, deterministic permissions rather than inheriting the build machine's umask, which produced world-writable-group `0664` files. `/usr/lib/systemd/system/pgedge-control-plane.service` is now `0644` and `/etc/pgedge-control-plane/config.json` is now `0640`.
+time: 2026-07-29T00:00:00.000000+00:00


### PR DESCRIPTION
## Problem

Two packaging defects found in the released rpm and deb packages.

### 1. `README.md` and `LICENSE.md` not bundled

The packages shipped only the binary, the systemd unit, the config file, and the SBOM:

| File | Expected path |
| --- | --- |
| `README.md` | `/usr/share/doc/pgedge-control-plane/README.md` |
| `LICENSE.md` | `/usr/share/licenses/pgedge-control-plane/LICENSE.md` |

Both are already in the release tarballs via `archives.files`, but the `nfpms` `contents:` list had no entries for them.

### 2. Files installed with `0664` instead of `0644` / `0640`

```
-rw-rw-r--. 1 root root 405 /usr/lib/systemd/system/pgedge-control-plane.service   # want 0644
-rw-rw-r--. 1 root root  79 /etc/pgedge-control-plane/config.json                  # want 0640
```

When no `file_info.mode` is given, nfpm packages the mode of the source file **as it exists on the builder**. CI checks out with `umask 002`, so git creates the files `0664` and that mode shipped in the packages. Group-writable for a systemd unit and a config file that may hold credentials.

## Fix

Both fixes are in the `contents:` list on the `&nfpm_defaults` anchor, so all nine per-distro package definitions (el9, el10, jammy, noble, bullseye, bookworm, trixie, resolute) inherit them.

**Docs and license.** Each file needs **two** entries. nfpm's `doc` and `license` content types are rpm-only — [`isRelevantForPackager`](https://github.com/goreleaser/nfpm/blob/main/files/files.go) filters entries of those types out of non-rpm packages — so a single typed entry would have fixed the rpm and silently left the deb unchanged. The entries are scoped with `packager:`: a typed one for rpm, so the spec carries the `%doc`/`%license` markers, and a plain one for deb. Both land at the same path.

**Modes.** `file_info.mode` is now set explicitly on every entry, so the packaged modes no longer depend on the builder's umask. `0640` for `config.json` (it may hold credentials, and the unit runs as root so root-only read access is sufficient), `0644` for everything else.

## Verification

Built snapshot releases locally with the pinned goreleaser (`v2.13.3`, per `common.mk`) and inspected the packages. For the mode fix the sources were first `chmod 664`'d to reproduce the CI umask.

**rpm** (`el9.x86_64`, inspected in a `rockylinux:9` container; `el10.aarch64` identical):

```
$ rpm -qlvp pgedge-control-plane-...el9.x86_64.rpm
-rw-r-----  1 root root      79 /etc/pgedge-control-plane/config.json
-rw-r--r--  1 root root     405 /usr/lib/systemd/system/pgedge-control-plane.service
-rwxr-xr-x  1 root root 6436061 /usr/sbin/pgedge-control-plane
-rw-r--r--  1 root root    5291 /usr/share/doc/pgedge-control-plane/README.md
-rw-r--r--  1 root root     958 /usr/share/licenses/pgedge-control-plane/LICENSE.md
-rw-r--r--  1 root root       2 /usr/share/pgedge-control-plane/pgedge-control-plane-sbom.json
-rw-r--r--  1 root root       5 /usr/share/pgedge-control-plane/pgedge-control-plane-sbom.json.asc

$ rpm -qdp ...   # %doc
/usr/share/doc/pgedge-control-plane/README.md

$ rpm -qLp ...   # %license
/usr/share/licenses/pgedge-control-plane/LICENSE.md
```

**deb** (`noble_amd64`):

```
$ ar x ...deb && tar tzvf data.tar.gz
-rw-r-----  0 root root      79 ./etc/pgedge-control-plane/config.json
-rw-r--r--  0 root root     405 ./usr/lib/systemd/system/pgedge-control-plane.service
-rwxr-xr-x  0 root root 6436061 ./usr/sbin/pgedge-control-plane
-rw-r--r--  0 root root    5291 ./usr/share/doc/pgedge-control-plane/README.md
-rw-r--r--  0 root root     958 ./usr/share/licenses/pgedge-control-plane/LICENSE.md
-rw-r--r--  0 root root       2 ./usr/share/pgedge-control-plane/pgedge-control-plane-sbom.json
-rw-r--r--  0 root root       5 ./usr/share/pgedge-control-plane/pgedge-control-plane-sbom.json.asc
```

README and LICENSE also appear in the deb's `md5sums`.

## Note

For Debian the conventional license path is `/usr/share/doc/pgedge-control-plane/copyright`, so lintian will still flag `no-copyright-file`. This PR uses `/usr/share/licenses/...` for both formats as specified; happy to add the Debian-native path alongside it if we want lintian clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)