### PR TITLE
ci: re-enable tag_release workflow

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -1,10 +1,11 @@
 name: tag_release
 
-# Temporarily disabled: v0.10.0 was tagged manually, so this must not
-# fire again when the release/v0.10.0 PR is merged. Revert this in a
-# follow-up PR against main once that PR is merged.
 on:
-  workflow_dispatch: {}
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
 
 jobs:
   tag_release:


### PR DESCRIPTION

## Summary
Re-enables the `tag_release` workflow's automatic trigger on `main`, restoring the normal tag-on-merge behavior after it was temporarily disabled for the v0.10.0 release.


## Changes
- Revert `tag_release.yaml` to trigger on `pull_request` (`closed`, base `main`) 

## Testing

NA

[PLAT-710](https://pgedge.atlassian.net/browse/PLAT-710)

[PLAT-710]: https://pgedge.atlassian.net/browse/PLAT-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ