### PR TITLE
docs: document output_plugin_libraries gate

### DIFF
--- a/changes/unreleased/Fixed-20260812-123144.yaml
+++ b/changes/unreleased/Fixed-20260812-123144.yaml
@@ -1,3 +1,3 @@
 kind: Fixed
-body: Fixed replication slot creation failing on Postgres 16.15, 17.11, 18.5, and newer minor versions by automatically setting `output_plugin_libraries` to allow `spock_output`.
+body: Fixed replication slot creation failing on Postgres 16.15, 17.11, 18.6, and newer minor versions by automatically setting `output_plugin_libraries` to allow `spock_output`.
 time: 2026-08-12T12:31:44.954828+05:30

--- a/changes/unreleased/Fixed-20260812-123144.yaml
+++ b/changes/unreleased/Fixed-20260812-123144.yaml
@@ -1,3 +1,3 @@
 kind: Fixed
-body: Enable spock_output for Postgres 16.15+, 17.11+, and 18.5+ to restore replication slot creation.
+body: Fixed replication slot creation failing on Postgres 16.15, 17.11, 18.5, and newer minor versions by automatically setting `output_plugin_libraries` to allow `spock_output`.
 time: 2026-08-12T12:31:44.954828+05:30

--- a/docs/using/create-db.md
+++ b/docs/using/create-db.md
@@ -233,13 +233,13 @@ After creating the database, you can enable extensions in your database using `C
 
 ### output_plugin_libraries and Postgres Minor Versions
 
-Postgres 16.15, 17.11, 18.5, and later minor versions add a new `output_plugin_libraries` allow-list that restricts which logical decoding output plugins the server accepts. Its built-in default is `pgoutput, test_decoding`, which does not include `spock_output`. Without it on the list, Spock cannot create its replication slot and replication stops on the provider node.
+Postgres 16.15, 17.11, 18.6, and later minor versions add a new `output_plugin_libraries` allow-list that restricts which logical decoding output plugins the server accepts. Its built-in default is `pgoutput, test_decoding`, which does not include `spock_output`. Without it on the list, Spock cannot create its replication slot and replication stops on the provider node.
 
 The Control Plane automatically sets `output_plugin_libraries` to `pgoutput, test_decoding, spock_output` on any instance running one of these patched minor versions or newer, so Spock keeps working once an instance is upgraded to a patched version. No action is required to benefit from this.
 
 !!! warning
 
-    `output_plugin_libraries` is a core Postgres setting, not an extension GUC. A minor version older than 16.15 / 17.11 / 18.5 does not recognize it at all, and refuses to start with `unrecognized configuration parameter "output_plugin_libraries"` if it is set to any value, including an empty one. The Control Plane only sets this parameter for instances already running a patched minor version, so pinning an older `postgres_version` (see [Upgrading a Database](./upgrade-db.md#minor-version-upgrades)) requires no action on your part — just don't set `output_plugin_libraries` in `postgresql_conf` yourself unless every node in the database is already on a patched minor version.
+    `output_plugin_libraries` is a core Postgres setting, not an extension GUC. A minor version older than 16.15 / 17.11 / 18.6 does not recognize it at all, and refuses to start with `unrecognized configuration parameter "output_plugin_libraries"` if it is set to any value, including an empty one. The Control Plane only sets this parameter for instances already running a patched minor version, so pinning an older `postgres_version` (see [Upgrading a Database](./upgrade-db.md#minor-version-upgrades)) requires no action on your part — just don't set `output_plugin_libraries` in `postgresql_conf` yourself unless every node in the database is already on a patched minor version.
 
 If you need to allow additional output plugins beyond `spock_output`, set `postgresql_conf.output_plugin_libraries` explicitly with the full list you need; this overrides the Control Plane's default for that database or node.
 

--- a/docs/using/create-db.md
+++ b/docs/using/create-db.md
@@ -231,6 +231,18 @@ After creating the database, you can enable extensions in your database using `C
 
     Always include `spock` in `shared_preload_libraries`, as it is required for core functionality provided by the Control Plane. The Control Plane will call `CREATE EXTENSION` for spock when initializing each instance.
 
+### output_plugin_libraries and Postgres Minor Versions
+
+Postgres 16.15, 17.11, 18.5, and later minor versions add a new `output_plugin_libraries` allow-list that restricts which logical decoding output plugins the server accepts. Its built-in default is `pgoutput, test_decoding`, which does not include `spock_output`. Without it on the list, Spock cannot create its replication slot and replication stops on the provider node.
+
+The Control Plane automatically sets `output_plugin_libraries` to `pgoutput, test_decoding, spock_output` on any instance running one of these patched minor versions or newer, so Spock keeps working once an instance is upgraded to a patched version. No action is required to benefit from this.
+
+!!! warning
+
+    `output_plugin_libraries` is a core Postgres setting, not an extension GUC. A minor version older than 16.15 / 17.11 / 18.5 does not recognize it at all, and refuses to start with `unrecognized configuration parameter "output_plugin_libraries"` if it is set to any value, including an empty one. The Control Plane only sets this parameter for instances already running a patched minor version, so pinning an older `postgres_version` (see [Upgrading a Database](./upgrade-db.md#minor-version-upgrades)) requires no action on your part — just don't set `output_plugin_libraries` in `postgresql_conf` yourself unless every node in the database is already on a patched minor version.
+
+If you need to allow additional output plugins beyond `spock_output`, set `postgresql_conf.output_plugin_libraries` explicitly with the full list you need; this overrides the Control Plane's default for that database or node.
+
 ## User-Defined Scripts
 
 The `scripts` field allows you to run SQL statements at specific points during the database creation process. The scripts are executed by the `pgedge` superuser. This is useful for setting up roles, default privileges, schema objects, and other one-time initialization that must happen before the database is ready for use.

--- a/server/internal/postgres/gucs.go
+++ b/server/internal/postgres/gucs.go
@@ -13,7 +13,7 @@ import (
 var minOutputPluginLibrariesVersions = map[uint64]*ds.Version{
 	16: ds.MustParseVersion("16.15"),
 	17: ds.MustParseVersion("17.11"),
-	18: ds.MustParseVersion("18.5"),
+	18: ds.MustParseVersion("18.6"),
 }
 
 // needsOutputPluginLibraries reports whether the given Postgres version

--- a/server/internal/postgres/gucs_test.go
+++ b/server/internal/postgres/gucs_test.go
@@ -25,8 +25,8 @@ func TestDefaultGUCsOutputPluginLibraries(t *testing.T) {
 		{name: "pg16 above gate", version: ds.MustParsePgEdgeVersion("16.16", "4"), expectedPresent: true},
 		{name: "pg17 below gate", version: ds.MustParsePgEdgeVersion("17.10", "4"), expectedPresent: false},
 		{name: "pg17 at gate", version: ds.MustParsePgEdgeVersion("17.11", "4"), expectedPresent: true},
-		{name: "pg18 below gate", version: ds.MustParsePgEdgeVersion("18.4", "4"), expectedPresent: false},
-		{name: "pg18 at gate", version: ds.MustParsePgEdgeVersion("18.5", "4"), expectedPresent: true},
+		{name: "pg18 below gate", version: ds.MustParsePgEdgeVersion("18.5", "4"), expectedPresent: false},
+		{name: "pg18 at gate", version: ds.MustParsePgEdgeVersion("18.6", "4"), expectedPresent: true},
 		{name: "future major", version: ds.MustParsePgEdgeVersion("19.0", "4"), expectedPresent: true},
 		{name: "older major", version: ds.MustParsePgEdgeVersion("15.10", "4"), expectedPresent: false},
 	} {


### PR DESCRIPTION

## Summary
This PR documents the new `output_plugin_libraries` gating on Postgres 16.15/17.11/18.5+ for users


## Changes
- Added an "output_plugin_libraries and Postgres Minor Versions" subsection to `docs/using/create-db.md`, explaining why Postgres 16.15, 17.11, 18.5, and newer minors require `spock_output` on the `output_plugin_libraries` allow-list, that the Control Plane sets this automatically per instance, the failure mode on unpatched minors, and how to override via `postgresql_conf` if needed.


## Testing
NA

## Checklist

- [x] Documentation updated

[PLAT-721](https://pgedge.atlassian.net/browse/PLAT-721)

[PLAT-721]: https://pgedge.atlassian.net/browse/PLAT-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ