### PR TITLE
feat: add spock 5.0.11 images to manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CI ?= false
 DEBUG ?= 0
 LOG_LEVEL ?= info
 DEV_IMAGE_REPO ?= ghcr.io/pgedge
+DEV_IMAGE_MANIFEST ?= local
 CONTROL_PLANE_IMAGE_REPO ?= host.docker.internal:5000/control-plane
 TEST_RERUN_FAILS ?= 0
 TEST_DISABLE_CACHE ?= 0
@@ -26,6 +27,20 @@ CLUSTER_TEST_DATA_DIR ?=
 DEV_LIMA_OS ?= rocky-9
 DEV_LIMA_USE_STAGING_PACKAGES ?= false
 
+ifeq ($(DEV_IMAGE_MANIFEST),local)
+	dev_manifest_vars=DEV_MANIFEST_PATH=/version-manifest.json \
+		DEV_MANIFEST_URL=""
+else ifeq ($(DEV_IMAGE_MANIFEST),staging)
+	dev_manifest_vars=DEV_MANIFEST_URL=https://downloads.pgedge.com/manifests/staging/control-plane/version-manifest.json \
+		DEV_MANIFEST_PATH=""
+else ifeq ($(DEV_IMAGE_MANIFEST),release)
+	dev_manifest_vars=DEV_MANIFEST_URL=https://downloads.pgedge.com/manifests/release/control-plane/version-manifest.json \
+		DEV_MANIFEST_PATH=""
+else
+$(error Invalid DEV_IMAGE_MANIFEST '$(DEV_IMAGE_MANIFEST)'. Valid options are 'local', 'staging', and 'release')
+endif
+
+
 ci_enabled=$(filter true,$(CI))
 docker_swarm_state=$(shell docker info --format '{{.Swarm.LocalNodeState}}')
 buildx_builder=$(if $(ci_enabled),"control-plane-ci","control-plane")
@@ -34,6 +49,7 @@ docker_compose_dev=WORKSPACE_DIR=$(shell pwd) \
 		DEBUG=$(DEBUG) \
 		LOG_LEVEL=$(LOG_LEVEL) \
 		DEV_IMAGE_REPO=$(DEV_IMAGE_REPO) \
+		$(dev_manifest_vars) \
 		docker compose -f ./docker/control-plane-dev/docker-compose.yaml
 docker_compose_ci=docker compose -f ./docker/control-plane-ci/docker-compose.yaml
 e2e_args=-tags=e2e_test -count=1 -timeout=45m \

--- a/docker/control-plane-dev/docker-compose.yaml
+++ b/docker/control-plane-dev/docker-compose.yaml
@@ -16,6 +16,8 @@ services:
       - PGEDGE_DATA_DIR=${WORKSPACE_DIR}/docker/control-plane-dev/data/host-1
       - PGEDGE_LOGGING__LEVEL=${LOG_LEVEL:-info}
       - PGEDGE_DOCKER_SWARM__IMAGE_REPOSITORY_HOST=${DEV_IMAGE_REPO:-ghcr.io/pgedge}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_PATH=${DEV_MANIFEST_PATH}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_URL=${DEV_MANIFEST_URL}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3000/v1/version"]
       interval: 2s
@@ -25,6 +27,7 @@ services:
       - ./config.json:/config.json
       - ./data:${WORKSPACE_DIR}/docker/control-plane-dev/data
       - /var/run/docker.sock:/var/run/docker.sock
+      - ../../server/internal/orchestrator/swarm/version-manifest.json:/version-manifest.json:ro
     network_mode: host
   host-2:
     extends:
@@ -38,6 +41,8 @@ services:
       - PGEDGE_ETCD_SERVER__CLIENT_PORT=2479
       - PGEDGE_LOGGING__LEVEL=${LOG_LEVEL:-info}
       - PGEDGE_DOCKER_SWARM__IMAGE_REPOSITORY_HOST=${DEV_IMAGE_REPO:-ghcr.io/pgedge}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_PATH=${DEV_MANIFEST_PATH}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_URL=${DEV_MANIFEST_URL}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3001/v1/version"]
       interval: 2s
@@ -55,6 +60,8 @@ services:
       - PGEDGE_ETCD_SERVER__CLIENT_PORT=2579
       - PGEDGE_LOGGING__LEVEL=${LOG_LEVEL:-info}
       - PGEDGE_DOCKER_SWARM__IMAGE_REPOSITORY_HOST=${DEV_IMAGE_REPO:-ghcr.io/pgedge}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_PATH=${DEV_MANIFEST_PATH}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_URL=${DEV_MANIFEST_URL}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3002/v1/version"]
       interval: 2s
@@ -71,6 +78,8 @@ services:
       - PGEDGE_ETCD_MODE=client
       - PGEDGE_LOGGING__LEVEL=${LOG_LEVEL:-info}
       - PGEDGE_DOCKER_SWARM__IMAGE_REPOSITORY_HOST=${DEV_IMAGE_REPO:-ghcr.io/pgedge}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_PATH=${DEV_MANIFEST_PATH}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_URL=${DEV_MANIFEST_URL}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3003/v1/version"]
       interval: 2s
@@ -87,6 +96,8 @@ services:
       - PGEDGE_ETCD_MODE=client
       - PGEDGE_LOGGING__LEVEL=${LOG_LEVEL:-info}
       - PGEDGE_DOCKER_SWARM__IMAGE_REPOSITORY_HOST=${DEV_IMAGE_REPO:-ghcr.io/pgedge}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_PATH=${DEV_MANIFEST_PATH}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_URL=${DEV_MANIFEST_URL}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3004/v1/version"]
       interval: 2s
@@ -103,6 +114,8 @@ services:
       - PGEDGE_ETCD_MODE=client
       - PGEDGE_LOGGING__LEVEL=${LOG_LEVEL:-info}
       - PGEDGE_DOCKER_SWARM__IMAGE_REPOSITORY_HOST=${DEV_IMAGE_REPO:-ghcr.io/pgedge}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_PATH=${DEV_MANIFEST_PATH}
+      - PGEDGE_DOCKER_SWARM__MANIFEST_URL=${DEV_MANIFEST_URL}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3005/v1/version"]
       interval: 2s

--- a/docs/development/running-locally.md
+++ b/docs/development/running-locally.md
@@ -196,6 +196,25 @@ This is an example remote debugging configuration for VSCode:
 
 After attaching the debugger, the server will start normally.
 
+#### Changing Manifests
+
+You can change the manifest source by specifying the `DEV_IMAGE_MANIFEST` environment
+variable when you run `make dev-watch`. This environment currently supports three different manifest sources:
+
+```sh
+# 'local' is the default option. This will use the local version manifest
+# server/internal/orchestrator/swarm/version-manifest.json
+make dev-watch DEV_IMAGE_MANIFEST=local
+
+# This will use the published staging manifest
+# https://downloads.pgedge.com/manifests/staging/control-plane/version-manifest.json
+make dev-watch DEV_IMAGE_MANIFEST=staging
+
+# This will use the published release manifest
+# https://downloads.pgedge.com/manifests/release/control-plane/version-manifest.json
+make dev-watch DEV_IMAGE_MANIFEST=release
+```
+
 ### API Documentation
 
 The `docker-compose.yaml` file for this configuration includes an API

--- a/server/internal/orchestrator/swarm/available_upgrades_test.go
+++ b/server/internal/orchestrator/swarm/available_upgrades_test.go
@@ -39,8 +39,8 @@ func TestVersions_AvailableUpgrades(t *testing.T) {
 	})
 
 	t.Run("returns nil when no newer entries exist (already at latest)", func(t *testing.T) {
-		// 18.4 is the newest in pg18 bucket — no upgrades available
-		current := ds.MustParsePgEdgeVersion("18.4", "5")
+		// 18.6 is the newest in pg18 bucket — no upgrades available
+		current := ds.MustParsePgEdgeVersion("18.6", "5")
 		upgrades := v.AvailableUpgrades(current)
 		assert.Nil(t, upgrades)
 	})

--- a/server/internal/orchestrator/swarm/version-manifest.json
+++ b/server/internal/orchestrator/swarm/version-manifest.json
@@ -33,6 +33,12 @@
         "stability": "stable"
       },
       {
+        "postgres_version": "16.15",
+        "spock_version": "5",
+        "image": "pgedge-postgres:16.15-spock5.0.11-standard-1",
+        "stability": "stable"
+      },
+      {
         "postgres_version": "17.6",
         "spock_version": "5",
         "image": "pgedge-postgres:17.6-spock5.0.4-standard-3",
@@ -63,6 +69,12 @@
         "stability": "stable"
       },
       {
+        "postgres_version": "17.11",
+        "spock_version": "5",
+        "image": "pgedge-postgres:17.11-spock5.0.11-standard-1",
+        "stability": "stable"
+      },
+      {
         "postgres_version": "18.0",
         "spock_version": "5",
         "image": "pgedge-postgres:18.0-spock5.0.4-standard-3",
@@ -90,6 +102,12 @@
         "postgres_version": "18.4",
         "spock_version": "5",
         "image": "pgedge-postgres:18.4-spock5.0.10-standard-1",
+        "stability": "stable"
+      },
+      {
+        "postgres_version": "18.6",
+        "spock_version": "5",
+        "image": "pgedge-postgres:18.6-spock5.0.11-standard-1",
         "stability": "stable",
         "default": true
       },


### PR DESCRIPTION
## Summary

Adds the Spock 5.0.11 images to the manifest and adds a `DEV_IMAGE_MANIFEST` option to `make dev-watch` to make it possible to test both local and remote manifests. With this change, Control Plane will support the following new version combinations:

- Postgres 16.15 + Spock 5.0.11
- Postgres 17.11 + Spock 5.0.11
- Postgres 18.6 + Spock 5.0.11 (now the default)

## Testing

I've updated both the committed manifest and the published staging manifest. To test these in the local dev environment, start the server with:

```sh
# To test with the local manifest
make dev-watch

# To test with the staging manifest
make dev-watch DEV_IMAGE_MANIFEST=staging
```

To test in a deployed environment, you can add this environment variable to each host in your `stack.yaml` file:

```sh
PGEDGE_DOCKER_SWARM__MANIFEST_URL=https://downloads.pgedge.com/manifests/staging/control-plane/version-manifest.json
```

Set the `postgres_version` option in the database spec to one of `16.15`, `17.11`, or `18.6` to try the new images. The `postgres_version` should default to `18.6` when unspecified.

## Notes for Reviewers

Once we've validated and merged this PR, I'll publish the manifest to our release location.