### PR TITLE
docs: document Spock 6 preview support

### DIFF
--- a/changes/unreleased/Added-20260827-140429.yaml
+++ b/changes/unreleased/Added-20260827-140429.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added foundational support for Spock 6, available as a dev-stability preview image via the version manifest. Databases running Spock 6 on Postgres 17 or later automatically use Postgres's native replication slot failover.
+time: 2026-08-27T14:04:29.000000+00:00

--- a/changes/unreleased/Added-20260827-140429.yaml
+++ b/changes/unreleased/Added-20260827-140429.yaml
@@ -1,3 +1,3 @@
 kind: Added
-body: Added foundational support for Spock 6, available as a dev-stability preview image via the version manifest. Databases running Spock 6 on Postgres 17 or later automatically use Postgres's native replication slot failover.
+body: Added foundational support for Spock 6 on Docker Swarm, available as a preview image via the version manifest. Databases running Spock 6 or later on Postgres 17 or later automatically use Postgres's native replication slot failover.
 time: 2026-08-27T14:04:29.000000+00:00

--- a/changes/unreleased/Fixed-20260821-141322.yaml
+++ b/changes/unreleased/Fixed-20260821-141322.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: Fixed peer subscriptions remaining permanently disabled when adding a node to a database that already had three or more nodes.
-time: 2026-08-21T14:13:22.000000+00:00

--- a/changes/unreleased/Fixed-20260821-141322.yaml
+++ b/changes/unreleased/Fixed-20260821-141322.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed peer subscriptions remaining permanently disabled when adding a node to a database that already had three or more nodes.
+time: 2026-08-21T14:13:22.000000+00:00

--- a/docs/prerequisites/concepts.md
+++ b/docs/prerequisites/concepts.md
@@ -37,13 +37,14 @@ Each node is composed of one or more Postgres instances, where one instance is a
 
 When a node which has multiple instances is created, the primary instance for the node will be placed on the first host specified for the node in the database spec. After a database is created, the primary instance may change due to a failover or switchover operation. 
 
-For a node running Spock 6 on Postgres 17 or later, the Control Plane
-automatically configures Postgres's native replication slot failover
-(`sync_replication_slots` and `synchronized_standby_slots`) for that
-node. This keeps the node's Spock replication slots synchronized to its
-read replicas, so a failover or switchover can promote a replica without
-Spock needing to re-create replication slots on the new primary. No
-configuration is required to use this behavior.
+For a node running Spock 6 or later on Postgres 17 or later, the Control
+Plane automatically enables Postgres's native replication slot failover
+(`sync_replication_slots`) for that node. When the node also has read
+replicas, the Control Plane additionally configures
+`synchronized_standby_slots` to keep the node's Spock replication slots
+synchronized to those replicas, so a failover or switchover can promote
+a replica without Spock needing to re-create replication slots on the
+new primary. No configuration is required to use this behavior.
 
 ## Orchestrators
 

--- a/docs/prerequisites/concepts.md
+++ b/docs/prerequisites/concepts.md
@@ -37,6 +37,14 @@ Each node is composed of one or more Postgres instances, where one instance is a
 
 When a node which has multiple instances is created, the primary instance for the node will be placed on the first host specified for the node in the database spec. After a database is created, the primary instance may change due to a failover or switchover operation. 
 
+For a node running Spock 6 on Postgres 17 or later, the Control Plane
+automatically configures Postgres's native replication slot failover
+(`sync_replication_slots` and `synchronized_standby_slots`) for that
+node. This keeps the node's Spock replication slots synchronized to its
+read replicas, so a failover or switchover can promote a replica without
+Spock needing to re-create replication slots on the new primary. No
+configuration is required to use this behavior.
+
 ## Orchestrators
 
 The Control Plane is architected to support multiple orchestrators, giving you flexibility in how database instances are deployed and managed.

--- a/docs/using/image-management.md
+++ b/docs/using/image-management.md
@@ -266,8 +266,8 @@ value in `orchestrator_opts.swarm.image` when creating the database:
 
 ### Spock 6 Preview Images
 
-Spock 6 is available today as a preview manifest entry (`"stability":
-"dev"` in the version manifest), currently paired with Postgres 18.6.
+Spock 6 is available as a preview manifest entry (`"stability": "dev"`
+in the version manifest), currently paired with Postgres 18.6.
 Preview entries are excluded from image upgrades (see below) and are
 never chosen for a database that omits `postgres_version` and
 `spock_version`, but you can still request one directly by setting

--- a/docs/using/image-management.md
+++ b/docs/using/image-management.md
@@ -267,15 +267,17 @@ value in `orchestrator_opts.swarm.image` when creating the database:
 ### Spock 6 Preview Images
 
 Spock 6 is available as a preview manifest entry (`"stability": "dev"`
-in the version manifest), currently paired with Postgres 18.6.
+in the version manifest), currently paired with Postgres 18.6. Spock 6
+itself supports Postgres 15 through 19; the version manifest currently
+offers only this one Postgres 18.6 pairing as a preview. This preview
+is available for Docker Swarm deployments only; the systemd
+orchestrator does not currently support Spock 6 packages.
+
 Preview entries are excluded from image upgrades (see below) and are
 never chosen for a database that omits `postgres_version` and
-`spock_version`, but you can still request one directly by setting
-those fields to a matching manifest entry, or by pinning the image
-explicitly with `orchestrator_opts.swarm.image`.
-
-The following request creates a database pinned to the Spock 6 preview
-image:
+`spock_version`. To create a new database on the Spock 6 preview
+image, set `postgres_version` and `spock_version` to match the
+manifest entry:
 
 === "curl"
 
@@ -295,11 +297,6 @@ image:
                 ],
                 "postgres_version": "18.6",
                 "spock_version": "6",
-                "orchestrator_opts": {
-                    "swarm": {
-                        "image": "ghcr.io/pgedge/pgedge-postgres:18-spock6-standard"
-                    }
-                },
                 "nodes": [
                     { "name": "n1", "host_ids": ["host-1"] },
                     { "name": "n2", "host_ids": ["host-2"] }
@@ -308,11 +305,25 @@ image:
         }'
     ```
 
+Overriding `orchestrator_opts.swarm.image` is only necessary if you need
+an image other than the manifest default for that version pair, such as
+pinning a specific build. See
+[Using a Custom Image](#using-a-custom-image).
+
 !!! note
 
     The Spock 6 preview image tracks the latest Spock 6 build against
     Postgres 18, so its resolved Postgres minor version can advance ahead
     of the manifest entry's declared `postgres_version`.
+
+!!! warning
+
+    This preview supports only creating a new database on Spock 6. It
+    does not support upgrading an existing database from Spock 5.x to
+    Spock 6. The Control Plane does not validate or block a
+    `spock_version` change on an existing database's spec, but doing so
+    is unsupported and can break replication, since a Spock 6
+    subscription cannot sync from a Spock 5.x peer.
 
 !!! warning
 

--- a/docs/using/image-management.md
+++ b/docs/using/image-management.md
@@ -264,6 +264,63 @@ value in `orchestrator_opts.swarm.image` when creating the database:
     Digest pinning guarantees that you run a specific immutable image even
     if the tag is later reassigned to a different image in the registry.
 
+### Spock 6 Preview Images
+
+Spock 6 is available today as a preview manifest entry (`"stability":
+"dev"` in the version manifest), currently paired with Postgres 18.6.
+Preview entries are excluded from image upgrades (see below) and are
+never chosen for a database that omits `postgres_version` and
+`spock_version`, but you can still request one directly by setting
+those fields to a matching manifest entry, or by pinning the image
+explicitly with `orchestrator_opts.swarm.image`.
+
+The following request creates a database pinned to the Spock 6 preview
+image:
+
+=== "curl"
+
+    ```sh
+    curl -X POST http://host-3:3000/v1/databases \
+        -H 'Content-Type:application/json' \
+        --data '{
+            "id": "example",
+            "spec": {
+                "database_name": "example",
+                "database_users": [
+                    {
+                        "username": "admin",
+                        "db_owner": true,
+                        "attributes": ["SUPERUSER", "LOGIN"]
+                    }
+                ],
+                "postgres_version": "18.6",
+                "spock_version": "6",
+                "orchestrator_opts": {
+                    "swarm": {
+                        "image": "ghcr.io/pgedge/pgedge-postgres:18-spock6-standard"
+                    }
+                },
+                "nodes": [
+                    { "name": "n1", "host_ids": ["host-1"] },
+                    { "name": "n2", "host_ids": ["host-2"] }
+                ]
+            }
+        }'
+    ```
+
+!!! note
+
+    The Spock 6 preview image tracks the latest Spock 6 build against
+    Postgres 18, so its resolved Postgres minor version can advance ahead
+    of the manifest entry's declared `postgres_version`.
+
+!!! warning
+
+    Preview images are for evaluation, not production use. The Control
+    Plane rejects preview images as targets for the
+    [image upgrade](./upgrade-db.md#image-upgrades) action, and they are
+    excluded from `available_upgrades`.
+
 ## Image Validation
 
 When `orchestrator_opts.swarm.image` is set, the Control Plane validates the


### PR DESCRIPTION

## Summary
This PR documents the preview support for Spock 6, native replication slot failover behavior, and the corresponding changelog entries.

## Changes
- Add a "Spock 6 Preview Images" section to `docs/using/image-management.md`
  explaining how to use the Spock 6 preview manifest entry (`"stability":
  "dev"`), either by setting `postgres_version`/`spock_version` directly
  or by pinning `orchestrator_opts.swarm.image`, and its exclusion from
  the image-upgrade action and `available_upgrades`.
- Add a note to `docs/prerequisites/concepts.md`'s Instances section
  describing automatic native replication slot failover
  (`sync_replication_slots`/`synchronized_standby_slots`) for databases
  running Spock 6 on Postgres 17+.
- Add a changelog entry for Spock 6 foundational support.

## Testing
- Docs-only change; no code paths touched.

Verification:
```
curl -X POST http://localhost:3000/v1/databases \
        -H 'Content-Type:application/json' \
        --data '{
            "id": "example",
            "spec": {
                "database_name": "example",
                "database_users": [
                    {
                        "username": "admin",
                        "db_owner": true,
                        "attributes": ["SUPERUSER", "LOGIN"]
                    }
                ],
                "postgres_version": "18.6",
                "spock_version": "6",
                "orchestrator_opts": {
                    "swarm": {
                        "image": "ghcr.io/pgedge/pgedge-postgres:18-spock6-standard"
                    }
                },
                "nodes": [
                    { "name": "n1", "host_ids": ["host-1"] },
                    { "name": "n2", "host_ids": ["host-2"] }
                ]
            }
        }'

```
```
cp1-req list-databases
HTTP/1.1 200 OK
Content-Length: 943
Content-Type: application/json
Date: Wed, 02 Sep 2026 05:36:29 GMT

{
  databases: [
    {
      created_at: "2026-09-02T05:35:14Z"
      id: "example"
      instances: [
        {
          created_at: "2026-09-02T05:35:17Z"
          host_id: "host-1"
          id: "example-n1-689qacsi"
          node_name: "n1"
          postgres: {
            patroni_state: "running"
            role: "primary"
            version: "18.6"
          }
          spock: {
            read_only: "off"
            subscriptions: [
              {
                name: "sub_n2_n1"
                provider_node: "n2"
                status: "replicating"
              }
            ]
            version: "6.0.0"
          }
          state: "available"
          status_updated_at: "2026-09-02T05:36:26Z"
          updated_at: "2026-09-02T05:35:50Z"
        }
        {
          created_at: "2026-09-02T05:35:17Z"
          host_id: "host-2"
          id: "example-n2-9ptayhma"
          node_name: "n2"
          postgres: {
            patroni_state: "running"
            role: "primary"
            version: "18.6"
          }
          spock: {
            read_only: "off"
            subscriptions: [
              {
                name: "sub_n1_n2"
                provider_node: "n1"
                status: "replicating"
              }
            ]
            version: "6.0.0"
          }
          state: "available"
          status_updated_at: "2026-09-02T05:36:26Z"
          updated_at: "2026-09-02T05:35:50Z"
        }
      ]
      state: "available"
      updated_at: "2026-09-02T05:35:14Z"
    }
  ]
}
```
## Checklist

- [x] Documentation updated (if needed)


[PLAT-734](https://pgedge.atlassian.net/browse/PLAT-734)

[PLAT-734]: https://pgedge.atlassian.net/browse/PLAT-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ