### PR TITLE
fix: reject Spock major version change on update

### DIFF
--- a/docs/using/image-management.md
+++ b/docs/using/image-management.md
@@ -320,9 +320,8 @@ pinning a specific build. See
 
     This preview supports only creating a new database on Spock 6. It
     does not support upgrading an existing database from Spock 5.x to
-    Spock 6. The Control Plane does not validate or block a
-    `spock_version` change on an existing database's spec, but doing so
-    is unsupported and can break replication, since a Spock 6
+    Spock 6. The Control Plane rejects a spec update that changes the
+    Spock major version on an existing database, since a Spock 6
     subscription cannot sync from a Spock 5.x peer.
 
 !!! warning

--- a/server/internal/database/service.go
+++ b/server/internal/database/service.go
@@ -1098,7 +1098,7 @@ func majorVersionChanged(old, new *ds.PgEdgeVersion) error {
 	}
 	if oldSpockMajor != newSpockMajor {
 		return fmt.Errorf(
-			"spock major version changed from %d to %d: upgrading the spock major version on an existing database is not supported",
+			"spock major version changed from %d to %d: changing the spock major version on an existing database is not supported",
 			oldSpockMajor, newSpockMajor,
 		)
 	}

--- a/server/internal/database/service.go
+++ b/server/internal/database/service.go
@@ -1087,6 +1087,21 @@ func majorVersionChanged(old, new *ds.PgEdgeVersion) error {
 	if oldPgMajor != newPgMajor {
 		return fmt.Errorf("major version changed from %d to %d", oldPgMajor, newPgMajor)
 	}
+
+	oldSpockMajor, ok := old.SpockVersion.Major()
+	if !ok {
+		return errors.New("current spock version is missing its major component")
+	}
+	newSpockMajor, ok := new.SpockVersion.Major()
+	if !ok {
+		return errors.New("updated spock version is missing its major component")
+	}
+	if oldSpockMajor != newSpockMajor {
+		return fmt.Errorf(
+			"spock major version changed from %d to %d: upgrading the spock major version on an existing database is not supported",
+			oldSpockMajor, newSpockMajor,
+		)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Major-version guard now rejects Spock major version changes on an existing database. 

## Changes

- ValidateChangedSpec rejects Spock major version changes on an existing database
- image-management.md updated to reflect these change
