### PR TITLE
feat: adopt MCP v1.1.0 and RAG v2.0.0

### DIFF
--- a/docs/development/supported-services.md
+++ b/docs/development/supported-services.md
@@ -852,7 +852,7 @@ Use these examples to verify your integration or to hand-test with `curl`.
       {
         "service_id": "mcp-server",
         "service_type": "mcp",
-        "version": "latest",
+        "version": "1.1.0",
         "host_ids": ["host-1"],
         "port": 8080,
         "config": {
@@ -895,7 +895,7 @@ Other common validation errors:
 | Unsupported `service_type` | `services[0].service_type: unsupported service type 'foo' (only 'mcp' is currently supported)` |
 | Bad `version` format | `services[0].version: version must be in semver format (e.g., '1.0.0') or 'latest'` |
 | Missing provider API key | `services[0].config: missing required field 'anthropic_api_key' for anthropic provider` |
-| Unsupported `llm_provider` | `services[0].config[llm_provider]: unsupported llm_provider 'foo' (must be one of: anthropic, openai, ollama)` |
+| Unsupported `llm_provider` | `services[0].config[llm_provider]: unsupported llm_provider 'foo' (must be one of: anthropic, openai, gemini, ollama)` |
 
 ### Reading a Database with Service Instances
 
@@ -913,7 +913,7 @@ Other common validation errors:
       {
         "service_id": "mcp-server",
         "service_type": "mcp",
-        "version": "latest",
+        "version": "1.1.0",
         "host_ids": ["host-1"],
         "port": 8080,
         "config": {
@@ -932,7 +932,7 @@ Other common validation errors:
       "state": "running",
       "status": {
         "container_id": "a1b2c3d4e5f6",
-        "image_version": "latest",
+        "image_version": "postgres-mcp:1.1.0",
         "addresses": [
             "10.0.1.5",
             "mcp-server-host-1.internal"
@@ -981,7 +981,7 @@ accordingly.
       {
         "service_id": "mcp-server",
         "service_type": "mcp",
-        "version": "latest",
+        "version": "1.1.0",
         "host_ids": ["host-1"],
         "config": {
           "llm_provider": "anthropic",

--- a/docs/services/mcp.md
+++ b/docs/services/mcp.md
@@ -10,6 +10,13 @@ searches. For more information, see the
 [pgEdge Postgres MCP](https://github.com/pgEdge/pgedge-postgres-mcp)
 project.
 
+!!! note
+
+    MCP version `1.1.0` is now the default: a service spec that omits
+    `version`, or sets it to `"latest"`, resolves to `1.1.0`. The
+    examples on this page pin `"version": "1.1.0"` explicitly so they
+    do not silently pick up a future default version.
+
 See [Managing Services](managing.md) for instructions on adding,
 updating, and removing services. The sections below cover MCP-specific
 configuration.
@@ -31,10 +38,11 @@ configuration fields:
 | Field                  | Type    | Default | Description |
 |------------------------|---------|---------|-------------|
 | `llm_enabled`          | boolean | `false` | Set to `true` to enable the LLM proxy. When `false`, the fields below must not be provided. |
-| `llm_provider`         | string  | —       | The LLM provider to use. One of: `anthropic`, `openai`, `ollama`. Required when `llm_enabled` is `true`. |
-| `llm_model`            | string  | —       | The model name for the selected provider (e.g., `claude-sonnet-4-5`, `gpt-4o`, `llama3.2`). Required when `llm_enabled` is `true`. |
+| `llm_provider`         | string  | —       | The LLM provider to use. One of: `anthropic`, `openai`, `gemini`, `ollama`. Required when `llm_enabled` is `true`. |
+| `llm_model`            | string  | —       | The model name for the selected provider (e.g., `claude-sonnet-4-5`, `gpt-4o`, `gemini-2.5-flash`, `llama3.2`). Required when `llm_enabled` is `true`. |
 | `anthropic_api_key`    | string  | —       | Your Anthropic API key. Required when `llm_provider` is `anthropic`. |
 | `openai_api_key`       | string  | —       | Your OpenAI API key. Required when `llm_provider` is `openai`. |
+| `gemini_api_key`       | string  | —       | Your Gemini API key. Required when `llm_provider` is `gemini`. |
 | `ollama_url`           | string  | —       | The base URL of your Ollama server (e.g., `http://ollama-host:11434`). Required when `llm_provider` is `ollama`. |
 
 ### Security
@@ -48,6 +56,8 @@ security configuration fields:
 | `allow_writes`   | boolean | `false` | When `true`, the `query_database` tool can execute write statements and the service connects to the primary node. When `false`, write statements are rejected by the MCP server and the service prefers a standby node. |
 | `init_token`     | string  | —       | A bootstrap token for initial access to the MCP server. See [Bootstrapping](#bootstrapping). |
 | `init_users`     | array   | —       | Initial user accounts to create on the MCP server. See [Bootstrapping](#bootstrapping). |
+| `audit_trace_enabled` | boolean | `false` | When `true`, the MCP server writes a per-request audit trace to `audit-trace.log` inside its existing data bind-mount; no additional mount is required. |
+| `audit_trace_metadata_only` | boolean | `true` | Only valid when `audit_trace_enabled` is `true`. When `true` (the default once tracing is enabled), the trace records request metadata only; query text and result rows are not written. Set to `false` for full detail, matching the upstream server's own default. |
 
 ### Tools
 
@@ -75,9 +85,9 @@ following table describes the embedding configuration fields:
 
 | Field                  | Type   | Description |
 |------------------------|--------|-------------|
-| `embedding_provider`   | string | The embedding provider. One of: `voyage`, `openai`, `ollama`. |
-| `embedding_model`      | string | The embedding model name (e.g., `voyage-3`, `text-embedding-3-small`, `nomic-embed-text`). Required when `embedding_provider` is set. |
-| `embedding_api_key`    | string | API key for the embedding provider. Required for `voyage` and `openai` providers. |
+| `embedding_provider`   | string | The embedding provider. One of: `voyage`, `openai`, `gemini`, `ollama`. |
+| `embedding_model`      | string | The embedding model name (e.g., `voyage-3`, `text-embedding-3-small`, `gemini-embedding-001`, `nomic-embed-text`). Required when `embedding_provider` is set. |
+| `embedding_api_key`    | string | API key for the embedding provider. Required for `voyage`, `openai`, and `gemini` providers. |
 
 ### Knowledgebase
 
@@ -87,8 +97,9 @@ host; the Control Plane bind-mounts it into the container read-only.
 Knowledgebase support is opt-in. When `kb_enabled` is `false` (the
 default), no KB file is required — and any other `kb_*` fields present
 in the config are **rejected** by the validator, not silently ignored.
-Only `voyage` and `openai` are supported as embedding providers for the
-knowledgebase; Ollama support is planned for a future release.
+Only `voyage`, `openai`, and `gemini` are supported as embedding
+providers for the knowledgebase; Ollama support is planned for a
+future release.
 
 !!! warning
 
@@ -113,9 +124,9 @@ The following table describes the knowledgebase configuration fields:
 | Field                     | Type    | Description |
 |---------------------------|---------|-------------|
 | `kb_enabled`              | boolean | Set to `true` to enable knowledgebase search. When `false` (the default), any other `kb_*` fields in the config are **rejected** — they must be removed before the config is accepted. |
-| `kb_embedding_provider`   | string  | Embedding provider for the KB. One of: `voyage`, `openai`. Required when `kb_enabled` is `true`. |
-| `kb_embedding_model`      | string  | Embedding model for the KB (e.g., `voyage-3-lite`, `text-embedding-3-small`). Required when `kb_enabled` is `true`. |
-| `kb_embedding_api_key`    | string  | API key for the KB embedding provider. Required for `voyage` and `openai`. Scrubbed from API responses. |
+| `kb_embedding_provider`   | string  | Embedding provider for the KB. One of: `voyage`, `openai`, `gemini`. Required when `kb_enabled` is `true`. |
+| `kb_embedding_model`      | string  | Embedding model for the KB (e.g., `voyage-3-lite`, `text-embedding-3-small`, `gemini-embedding-001`). Required when `kb_enabled` is `true`. |
+| `kb_embedding_api_key`    | string  | API key for the KB embedding provider. Required for `voyage`, `openai`, and `gemini`. Scrubbed from API responses. |
 | `kb_database_host_path`   | string  | Full path to the KB SQLite file on the host. Defaults to `{data_dir}/kb/nla-kb.db`. Must be an absolute path. |
 
 ### LLM Tuning
@@ -208,7 +219,7 @@ you connect via an MCP client that supplies its own LLM:
                     {
                         "service_id": "mcp-server",
                         "service_type": "mcp",
-                        "version": "latest",
+                        "version": "1.1.0",
                         "host_ids": ["host-1"],
                         "port": 8080,
                         "connect_as": "mcp_user",
@@ -253,7 +264,7 @@ Anthropic as the provider:
                     {
                         "service_id": "mcp-server",
                         "service_type": "mcp",
-                        "version": "latest",
+                        "version": "1.1.0",
                         "host_ids": ["host-1"],
                         "port": 8080,
                         "connect_as": "mcp_user",
@@ -302,7 +313,7 @@ OpenAI and configures embedding support:
                     {
                         "service_id": "mcp-server",
                         "service_type": "mcp",
-                        "version": "latest",
+                        "version": "1.1.0",
                         "host_ids": ["host-1"],
                         "port": 8080,
                         "connect_as": "mcp_user",
@@ -354,7 +365,7 @@ to use a self-hosted Ollama server for both the LLM and embeddings:
                     {
                         "service_id": "mcp-server",
                         "service_type": "mcp",
-                        "version": "latest",
+                        "version": "1.1.0",
                         "host_ids": ["host-1"],
                         "port": 8080,
                         "connect_as": "mcp_user",
@@ -408,7 +419,7 @@ sudo cp /path/to/your/nla-kb.db /var/lib/pgedge-control-plane/kb/nla-kb.db
                     {
                         "service_id": "mcp-server",
                         "service_type": "mcp",
-                        "version": "latest",
+                        "version": "1.1.0",
                         "host_ids": ["host-1"],
                         "port": 8080,
                         "connect_as": "mcp_user",

--- a/docs/services/rag.md
+++ b/docs/services/rag.md
@@ -19,9 +19,30 @@ queries to the service, which performs hybrid vector and keyword search
 against document tables and returns LLM-synthesized answers with source
 citations.
 
+RAG version `2.0.0` is now the default: a service spec that omits
+`version`, or sets it to `"latest"`, resolves to `2.0.0`. The examples
+on this page pin `"version": "2.0.0"` explicitly so they do not
+silently pick up a future default version.
+
+Upstream RAG 2.0.0 adds an opt-in caller-identity mode, where retrieval
+can run as the calling user instead of a single fixed database role.
+That mode is out of scope for the Control Plane: the single `connect_as`
+role model described above is unchanged.
+
 See [Managing Services](managing.md) for instructions on adding,
 updating, and removing services. The sections below cover RAG-specific
 configuration.
+
+!!! note "Upgrading from RAG 1.0.0"
+
+    RAG 2.0.0 fixes a hybrid-search bug present in 1.0.0: when a
+    pipeline's table had no `id_column` configured, the vector search
+    arm of hybrid search was silently dropped, and results came from
+    BM25 keyword search alone. In 2.0.0 both arms are correctly fused
+    via Reciprocal Rank Fusion regardless of whether `id_column` is
+    set. Existing pipelines without `id_column` will generally see
+    better, more semantically relevant results after upgrading; no
+    configuration change is required.
 
 ## Database Prerequisites
 
@@ -95,7 +116,7 @@ The following table describes the pipeline configuration fields:
 
 | Field | Type | Description |
 |---|---|---|
-| `pipelines[].name` | string | Required. Pipeline identifier used in query URLs. Lowercase alphanumeric, hyphens, and underscores. Must not start with a hyphen. |
+| `pipelines[].name` | string | Required. Pipeline identifier used in query URLs. Lowercase alphanumeric, hyphens, and underscores, up to 63 characters. Must not start with a hyphen. |
 | `pipelines[].description` | string | Optional. Human-readable pipeline description. |
 | `pipelines[].tables[]` | array | Required. Array of table specifications. See [Table Configuration](#table-configuration). |
 | `pipelines[].embedding_llm` | object | Required. Embedding provider config. See [Embedding Configuration](#embedding-configuration). |
@@ -104,21 +125,25 @@ The following table describes the pipeline configuration fields:
 | `pipelines[].top_n` | integer | Optional. Number of documents to retrieve per query. |
 | `pipelines[].system_prompt` | string | Optional. Custom system prompt prepended to every LLM request for this pipeline. |
 | `pipelines[].search` | object | Optional. Search behavior settings. See [Search Configuration](#search-configuration). |
+| `pipelines[].allow_include_sources` | boolean | Optional. Defaults to `false`. When `true`, clients querying this pipeline may set `include_sources: true` to receive the raw content of retrieved documents. Exposing a corpus this way is an explicit per-pipeline decision. |
+| `pipelines[].rerank` | object | Optional. Reranking stage that reorders search results by relevance before context building. See [Reranking Configuration](#reranking-configuration). |
 
 ### Embedding Configuration
 
 The `embedding_llm` object configures the embedding provider used to
 vectorize each incoming query. The embedding vector is then used for
 similarity search against stored document vectors. All required fields
-must be set; `api_key` is not required for `ollama`.
+must be set; `api_key` is not required for `ollama`. Anthropic is not
+a valid `embedding_llm` provider - Anthropic does not offer an
+embeddings API.
 
 The following table describes the embedding configuration fields:
 
 | Field | Type | Description |
 |---|---|---|
-| `provider` | string | Required. The embedding provider. One of: `openai`, `voyage`, `ollama`. |
-| `model` | string | Required. The embedding model name (e.g., `text-embedding-3-small`, `voyage-3`, `nomic-embed-text`). |
-| `api_key` | string | API key for the provider. Required for `openai` and `voyage`. Not used for `ollama`. |
+| `provider` | string | Required. The embedding provider. One of: `openai`, `voyage`, `gemini`, `ollama`. |
+| `model` | string | Required. The embedding model name (e.g., `text-embedding-3-small`, `voyage-3`, `gemini-embedding-001`, `nomic-embed-text`). |
+| `api_key` | string | API key for the provider. Required for `openai`, `voyage`, and `gemini`. Not used for `ollama`. |
 | `base_url` | string | Optional. Custom base URL for the provider API. Required for `ollama` - set this to the network-accessible address of your Ollama server (e.g., `http://192.168.1.10:11434`). |
 
 ### LLM Configuration
@@ -131,9 +156,9 @@ The following table describes the LLM configuration fields:
 
 | Field | Type | Description |
 |---|---|---|
-| `provider` | string | Required. The LLM provider. One of: `anthropic`, `openai`, `ollama`. |
-| `model` | string | Required. The model name (e.g., `claude-sonnet-4-5`, `gpt-4o`, `llama3.2`). |
-| `api_key` | string | API key for the provider. Required for `anthropic` and `openai`. Not used for `ollama`. |
+| `provider` | string | Required. The LLM provider. One of: `anthropic`, `openai`, `gemini`, `ollama`. |
+| `model` | string | Required. The model name (e.g., `claude-sonnet-4-5`, `gpt-4o`, `gemini-2.5-flash`, `llama3.2`). |
+| `api_key` | string | API key for the provider. Required for `anthropic`, `openai`, and `gemini`. Not used for `ollama`. |
 | `base_url` | string | Optional. Custom base URL for API gateway routing. Required for `ollama` - set this to the network-accessible address of your Ollama server (e.g., `http://192.168.1.10:11434`). |
 
 !!! note
@@ -165,6 +190,25 @@ configuration fields:
 |---|---|---|---|
 | `hybrid_enabled` | boolean | `true` | Enable hybrid search combining vector similarity and BM25 keyword matching. Set to `false` for vector-only search. |
 | `vector_weight` | float | `0.5` | Weight for vector search versus BM25 (0.0-1.0). Higher values prioritize semantic relevance. |
+
+### Reranking Configuration
+
+The optional `rerank` object adds a reranking stage that reorders
+search results by relevance immediately before context is built for
+the LLM. Voyage AI is currently the only supported reranking provider.
+When `embedding_llm` already uses `voyage` and supplies an `api_key`,
+`rerank.api_key` can be omitted - the pgEdge RAG Server reuses the
+`embedding_llm` key for the shared provider. If both fields do supply
+a key, the values must be identical.
+
+The following table describes the reranking configuration fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `rerank.provider` | string | Required. The reranking provider. Currently only `voyage` is supported. |
+| `rerank.model` | string | Required. The rerank model name (e.g., `rerank-2`). |
+| `rerank.api_key` | string | Optional. API key for the reranking provider. Required unless `embedding_llm` already uses `voyage` and supplies an `api_key`. |
+| `rerank.top_k` | integer | Optional. Number of top results to keep after reranking. `0` reorders all results without dropping any, matching upstream behavior. Must not be negative. |
 
 ### Defaults Configuration
 
@@ -279,7 +323,7 @@ that uses OpenAI for embeddings and Anthropic Claude to generate answers:
                     {
                         "service_id": "rag",
                         "service_type": "rag",
-                        "version": "latest",
+                        "version": "2.0.0",
                         "host_ids": ["host-1"],
                         "port": 9200,
                         "connect_as": "admin",
@@ -344,7 +388,7 @@ In the following example, OpenAI handles both embeddings and answer generation:
                     {
                         "service_id": "rag",
                         "service_type": "rag",
-                        "version": "latest",
+                        "version": "2.0.0",
                         "host_ids": ["host-1"],
                         "port": 9200,
                         "connect_as": "admin",
@@ -408,7 +452,7 @@ matching):
                     {
                         "service_id": "rag",
                         "service_type": "rag",
-                        "version": "latest",
+                        "version": "2.0.0",
                         "host_ids": ["host-1"],
                         "port": 9200,
                         "connect_as": "admin",
@@ -445,6 +489,80 @@ matching):
         }'
     ```
 
+### Reranking with Source Inclusion
+
+In the following example, Voyage AI provides both embeddings and
+reranking, sharing a single `api_key`. The pipeline also sets
+`allow_include_sources: true` so clients can request the raw content
+of retrieved documents:
+
+=== "curl"
+
+    ```sh
+    curl -X POST http://host-1:3000/v1/databases \
+        -H 'Content-Type: application/json' \
+        --data '{
+            "id": "knowledge-base",
+            "spec": {
+                "database_name": "knowledge_base",
+                "database_users": [
+                    {
+                        "username": "admin",
+                        "password": "admin_password",
+                        "db_owner": true,
+                        "attributes": ["SUPERUSER", "LOGIN"]
+                    }
+                ],
+                "nodes": [
+                    { "name": "n1", "host_ids": ["host-1"] }
+                ],
+                "services": [
+                    {
+                        "service_id": "rag",
+                        "service_type": "rag",
+                        "version": "2.0.0",
+                        "host_ids": ["host-1"],
+                        "port": 9200,
+                        "connect_as": "admin",
+                        "config": {
+                            "pipelines": [
+                                {
+                                    "name": "default",
+                                    "tables": [
+                                        {
+                                            "table": "documents_content_chunks",
+                                            "text_column": "content",
+                                            "vector_column": "embedding"
+                                        }
+                                    ],
+                                    "embedding_llm": {
+                                        "provider": "voyage",
+                                        "model": "voyage-3",
+                                        "api_key": "pa-..."
+                                    },
+                                    "rag_llm": {
+                                        "provider": "anthropic",
+                                        "model": "claude-sonnet-4-5",
+                                        "api_key": "sk-ant-..."
+                                    },
+                                    "rerank": {
+                                        "provider": "voyage",
+                                        "model": "rerank-2",
+                                        "top_k": 5
+                                    },
+                                    "allow_include_sources": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }'
+    ```
+
+    Since `rerank.provider` is `voyage` and `embedding_llm` already
+    supplies a Voyage `api_key`, `rerank.api_key` can be omitted here.
+
 ### Ollama (Self-Hosted)
 
 In the following example, the RAG service uses a self-hosted Ollama
@@ -475,7 +593,7 @@ required; the Ollama server URL is provided via `base_url`:
                     {
                         "service_id": "rag",
                         "service_type": "rag",
-                        "version": "latest",
+                        "version": "2.0.0",
                         "host_ids": ["host-1"],
                         "port": 9200,
                         "connect_as": "admin",
@@ -538,7 +656,7 @@ In the following example, two pipelines share default values for
                     {
                         "service_id": "rag",
                         "service_type": "rag",
-                        "version": "latest",
+                        "version": "2.0.0",
                         "host_ids": ["host-1"],
                         "port": 9200,
                         "connect_as": "admin",
@@ -650,7 +768,7 @@ URL stays stable across container restarts.
                     {
                         "service_id": "rag",
                         "service_type": "rag",
-                        "version": "latest",
+                        "version": "2.0.0",
                         "host_ids": ["host-1"],
                         "port": 9200,
                         "connect_as": "app_read_only",
@@ -739,6 +857,14 @@ In the response, look for the following items:
 The `host_port` value is the port to use when querying the RAG
 service. If you used a fixed `port: 9200` in the service spec, the
 host port will always be `9200`.
+
+!!! note
+    The RAG container's health check calls its `/v1/health` endpoint,
+    which pings every configured pipeline's embedding and LLM
+    providers - a check that can take up to roughly 10 seconds in the
+    worst case. To accommodate this, the Control Plane checks health
+    every 30 seconds with a 20 second timeout, so `last_health_at` can
+    lag actual container readiness by up to that interval.
 
 !!! tip
     Use a fixed `port` value (e.g. `9200`) in the service spec rather
@@ -878,7 +1004,7 @@ array:
                     {
                         "service_id": "rag",
                         "service_type": "rag",
-                        "version": "latest",
+                        "version": "2.0.0",
                         "host_ids": ["host-1"],
                         "port": 9200,
                         "connect_as": "app_read_only",

--- a/e2e/rag_service_test.go
+++ b/e2e/rag_service_test.go
@@ -727,3 +727,219 @@ func getEnvOrSkip(t testing.TB, key string) string {
 	}
 	return v
 }
+
+// TestProvisionRAGServicePinnedVersion200 provisions a RAG service pinned
+// explicitly to "2.0.0" (the current default, but pinning explicitly still
+// exercises manifest resolution end to end) and exercises the v2.0.0 config
+// fields: allow_include_sources and an optional voyage rerank stage.
+// Placeholder API keys are used so this runs without incurring LLM costs.
+func TestProvisionRAGServicePinnedVersion200(t *testing.T) {
+	t.Parallel()
+
+	fixture.SkipIfServicesUnsupported(t)
+
+	hosts := fixture.HostIDs()
+	require.GreaterOrEqual(t, len(hosts), 1, "requires at least 1 host")
+	host1 := hosts[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	t.Log("Creating database with RAG service pinned to 2.0.0")
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: &controlplane.DatabaseSpec{
+			DatabaseName: "test_rag_pinned_2_0_0",
+			DatabaseUsers: []*controlplane.DatabaseUserSpec{
+				{
+					Username:   "admin",
+					Password:   pointerTo("testpassword"),
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+				{
+					Username:   "rag_user",
+					Password:   pointerTo("ragpassword"),
+					Attributes: []string{"LOGIN"},
+				},
+			},
+			Port:        pointerTo(0),
+			PatroniPort: pointerTo(0),
+			Nodes: []*controlplane.DatabaseNodeSpec{
+				{
+					Name:    "n1",
+					HostIds: []controlplane.Identifier{controlplane.Identifier(host1)},
+				},
+			},
+			Services: []*controlplane.ServiceSpec{
+				{
+					ServiceID:   "rag",
+					ServiceType: "rag",
+					Version:     "2.0.0",
+					HostIds:     []controlplane.Identifier{controlplane.Identifier(host1)},
+					Port:        pointerTo(0),
+					ConnectAs:   "rag_user",
+					Config: map[string]any{
+						"pipelines": []any{
+							map[string]any{
+								"name": "default",
+								"tables": []any{
+									map[string]any{
+										"table":         "docs",
+										"text_column":   "content",
+										"vector_column": "embedding",
+									},
+								},
+								"embedding_llm": map[string]any{
+									"provider": "openai",
+									"model":    "text-embedding-3-small",
+									"api_key":  "sk-test-embed-key",
+								},
+								"rag_llm": map[string]any{
+									"provider": "anthropic",
+									"model":    "claude-haiku-4-5-20251001",
+									"api_key":  "sk-ant-test-key",
+								},
+								"allow_include_sources": true,
+								"rerank": map[string]any{
+									"provider": "voyage",
+									"model":    "rerank-2",
+									"api_key":  "pa-test-voyage-rerank-key",
+									"top_k":    5,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.NotNil(t, db.ServiceInstances, "ServiceInstances should not be nil")
+	require.Len(t, db.ServiceInstances, 1, "Expected 1 RAG service instance")
+
+	si := db.ServiceInstances[0]
+	assert.Equal(t, "rag", si.ServiceID)
+
+	t.Log("Waiting for RAG service to be running")
+	si = waitForServiceRunning(ctx, t, db, si.ServiceInstanceID, 8*time.Minute)
+	if si.Status != nil && si.Status.ImageVersion != nil {
+		assert.Contains(t, *si.Status.ImageVersion, "2.0.0", "running container should use the pinned 2.0.0 image")
+	}
+}
+
+// TestUpdateRAGServiceVersion is the PLAT-715 regression test for RAG: it
+// fetches a database via GetDatabase (which strips embedding_llm/rag_llm
+// api_key values from the returned pipelines config), mutates only the
+// service's Version in that fetched spec, and feeds it straight back into
+// UpdateDatabase without resupplying the stripped secrets. Before the
+// PLAT-715 fix this always 400s, because RAG config validation unconditionally
+// required api_key back for non-ollama providers.
+func TestUpdateRAGServiceVersion(t *testing.T) {
+	t.Parallel()
+
+	fixture.SkipIfServicesUnsupported(t)
+
+	hosts := fixture.HostIDs()
+	require.GreaterOrEqual(t, len(hosts), 1, "requires at least 1 host")
+	host1 := hosts[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	t.Log("Creating database with RAG service pinned to 1.0.0")
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: &controlplane.DatabaseSpec{
+			DatabaseName: "test_rag_version_update",
+			DatabaseUsers: []*controlplane.DatabaseUserSpec{
+				{
+					Username:   "admin",
+					Password:   pointerTo("testpassword"),
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+				{
+					Username:   "rag_user",
+					Password:   pointerTo("ragpassword"),
+					Attributes: []string{"LOGIN"},
+				},
+			},
+			Port:        pointerTo(0),
+			PatroniPort: pointerTo(0),
+			Nodes: []*controlplane.DatabaseNodeSpec{
+				{
+					Name:    "n1",
+					HostIds: []controlplane.Identifier{controlplane.Identifier(host1)},
+				},
+			},
+			Services: []*controlplane.ServiceSpec{
+				{
+					ServiceID:   "rag",
+					ServiceType: "rag",
+					Version:     "1.0.0",
+					HostIds:     []controlplane.Identifier{controlplane.Identifier(host1)},
+					Port:        pointerTo(0),
+					ConnectAs:   "rag_user",
+					Config: map[string]any{
+						"pipelines": []any{
+							map[string]any{
+								"name": "default",
+								"tables": []any{
+									map[string]any{
+										"table":         "docs",
+										"text_column":   "content",
+										"vector_column": "embedding",
+									},
+								},
+								"embedding_llm": map[string]any{
+									"provider": "openai",
+									"model":    "text-embedding-3-small",
+									"api_key":  "sk-test-embed-key-version-update",
+								},
+								"rag_llm": map[string]any{
+									"provider": "anthropic",
+									"model":    "claude-haiku-4-5-20251001",
+									"api_key":  "sk-ant-test-key-version-update",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, db.ServiceInstances, 1, "Expected 1 RAG service instance")
+	waitForServiceRunning(ctx, t, db, db.ServiceInstances[0].ServiceInstanceID, 8*time.Minute)
+
+	t.Log("Fetching the database (this strips embedding_llm/rag_llm api_key from the returned config)")
+	require.NoError(t, db.Refresh(ctx), "failed to refresh database")
+
+	var ragSvc *controlplane.ServiceSpec
+	for _, svc := range db.Spec.Services {
+		if svc.ServiceID == "rag" {
+			ragSvc = svc
+		}
+	}
+	require.NotNil(t, ragSvc, "rag service should be present in the fetched spec")
+	pipelines, ok := ragSvc.Config["pipelines"].([]any)
+	require.True(t, ok && len(pipelines) == 1, "fetched config should have 1 pipeline")
+	pipeline := pipelines[0].(map[string]any)
+	_, hasEmbedKey := pipeline["embedding_llm"].(map[string]any)["api_key"]
+	_, hasRAGKey := pipeline["rag_llm"].(map[string]any)["api_key"]
+	require.False(t, hasEmbedKey, "embedding_llm.api_key should have been stripped from the GET response")
+	require.False(t, hasRAGKey, "rag_llm.api_key should have been stripped from the GET response")
+
+	t.Log("Bumping only the service version in the fetched spec, then feeding it back into UpdateDatabase")
+	ragSvc.Version = "2.0.0"
+
+	err := db.Update(ctx, UpdateOptions{Spec: db.Spec})
+	require.NoError(t, err, "UpdateDatabase should succeed even though the fetched spec never had api_key values to resupply")
+
+	require.Len(t, db.ServiceInstances, 1, "Should still have 1 service instance")
+	si := waitForServiceRunning(ctx, t, db, db.ServiceInstances[0].ServiceInstanceID, 8*time.Minute)
+	if si.Status != nil && si.Status.ImageVersion != nil {
+		assert.Contains(t, *si.Status.ImageVersion, "2.0.0", "service should be running the new pinned version after update")
+	}
+}

--- a/e2e/rag_service_test.go
+++ b/e2e/rag_service_test.go
@@ -256,6 +256,7 @@ func waitForServiceRunning(
 	t.Helper()
 
 	deadline := time.Now().Add(maxWait)
+	var lastRunning *controlplane.ServiceInstance
 	for time.Now().Before(deadline) {
 		require.NoError(t, db.Refresh(ctx), "failed to refresh database")
 		for _, si := range db.ServiceInstances {
@@ -263,7 +264,17 @@ func waitForServiceRunning(
 				continue
 			}
 			if si.State == "running" {
-				return si
+				// State is flipped to "running" deterministically by the
+				// deploying resource as soon as the container starts, before
+				// ServiceInstanceMonitor's async health-check loop (which
+				// runs on its own ~10s cycle) has populated Status. Keep
+				// polling until Status/ImageVersion actually shows up so
+				// callers can rely on it being present rather than silently
+				// skipping checks that depend on it.
+				if si.Status != nil && si.Status.ImageVersion != nil {
+					return si
+				}
+				lastRunning = si
 			}
 			if si.State == "failed" {
 				var errMsg string
@@ -276,6 +287,9 @@ func waitForServiceRunning(
 		time.Sleep(5 * time.Second)
 	}
 
+	if lastRunning != nil {
+		t.Fatalf("service instance %s reached running state but status/image version was never populated within %s", serviceInstanceID, maxWait)
+	}
 	t.Fatalf("service instance %s did not reach running state within %s", serviceInstanceID, maxWait)
 	return nil
 }
@@ -823,9 +837,9 @@ func TestProvisionRAGServicePinnedVersion200(t *testing.T) {
 
 	t.Log("Waiting for RAG service to be running")
 	si = waitForServiceRunning(ctx, t, db, si.ServiceInstanceID, 8*time.Minute)
-	if si.Status != nil && si.Status.ImageVersion != nil {
-		assert.Contains(t, *si.Status.ImageVersion, "2.0.0", "running container should use the pinned 2.0.0 image")
-	}
+	require.NotNil(t, si.Status, "service instance status should be populated once running")
+	require.NotNil(t, si.Status.ImageVersion, "service instance image version should be populated once running")
+	assert.Contains(t, *si.Status.ImageVersion, "2.0.0", "running container should use the pinned 2.0.0 image")
 }
 
 // TestUpdateRAGServiceVersion is the PLAT-715 regression test for RAG: it
@@ -939,7 +953,7 @@ func TestUpdateRAGServiceVersion(t *testing.T) {
 
 	require.Len(t, db.ServiceInstances, 1, "Should still have 1 service instance")
 	si := waitForServiceRunning(ctx, t, db, db.ServiceInstances[0].ServiceInstanceID, 8*time.Minute)
-	if si.Status != nil && si.Status.ImageVersion != nil {
-		assert.Contains(t, *si.Status.ImageVersion, "2.0.0", "service should be running the new pinned version after update")
-	}
+	require.NotNil(t, si.Status, "service instance status should be populated once running")
+	require.NotNil(t, si.Status.ImageVersion, "service instance image version should be populated once running")
+	assert.Contains(t, *si.Status.ImageVersion, "2.0.0", "service should be running the new pinned version after update")
 }

--- a/e2e/service_provisioning_test.go
+++ b/e2e/service_provisioning_test.go
@@ -996,3 +996,148 @@ func TestUpdateMCPServiceConfig(t *testing.T) {
 	t.Logf("Service instance %s updated in-place after config change", serviceInstanceID)
 	t.Log("MCP service config update test completed successfully")
 }
+
+// TestProvisionMCPServicePinnedVersion110 provisions an MCP service pinned
+// explicitly to "1.1.0" (rather than "latest") and verifies it reaches running
+// state, confirming the version resolves through GetServiceImage end to end.
+func TestProvisionMCPServicePinnedVersion110(t *testing.T) {
+	t.Parallel()
+
+	fixture.SkipIfServicesUnsupported(t)
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	t.Log("Creating database with MCP service pinned to 1.1.0")
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: &controlplane.DatabaseSpec{
+			DatabaseName: "test_mcp_pinned_1_1_0",
+			DatabaseUsers: []*controlplane.DatabaseUserSpec{
+				{
+					Username:   "admin",
+					Password:   pointerTo("testpassword"),
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+			},
+			Port:        pointerTo(0),
+			PatroniPort: pointerTo(0),
+			Nodes: []*controlplane.DatabaseNodeSpec{
+				{
+					Name:    "n1",
+					HostIds: []controlplane.Identifier{controlplane.Identifier(host1)},
+				},
+			},
+			Services: []*controlplane.ServiceSpec{
+				{
+					ServiceID:   "mcp-server",
+					ServiceType: "mcp",
+					ConnectAs:   "admin",
+					Version:     "1.1.0",
+					HostIds:     []controlplane.Identifier{controlplane.Identifier(host1)},
+					Config: map[string]any{
+						"llm_enabled":       true,
+						"llm_provider":      "anthropic",
+						"llm_model":         "claude-sonnet-4-5",
+						"anthropic_api_key": "sk-ant-test-key-pinned-110",
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, db.ServiceInstances, 1, "Expected 1 service instance")
+
+	si := waitForServiceRunning(ctx, t, db, db.ServiceInstances[0].ServiceInstanceID, 5*time.Minute)
+	if si.Status != nil && si.Status.ImageVersion != nil {
+		assert.Contains(t, *si.Status.ImageVersion, "1.1.0", "running container should use the pinned 1.1.0 image")
+	}
+}
+
+// TestUpdateMCPServiceVersion is the PLAT-715 regression test: it fetches a
+// database via GetDatabase (which strips secret config fields such as
+// anthropic_api_key), mutates only the service's Version in that fetched spec,
+// and feeds it straight back into UpdateDatabase without resupplying the
+// stripped secret. Before the PLAT-715 fix this always 400s, because config
+// validation unconditionally required the secret back. It also verifies the
+// service actually moves to the new pinned version.
+func TestUpdateMCPServiceVersion(t *testing.T) {
+	t.Parallel()
+
+	fixture.SkipIfServicesUnsupported(t)
+
+	host1 := fixture.HostIDs()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	t.Log("Creating database with MCP service pinned to 1.0.0")
+
+	db := fixture.NewDatabaseFixture(ctx, t, &controlplane.CreateDatabaseRequest{
+		Spec: &controlplane.DatabaseSpec{
+			DatabaseName: "test_mcp_version_update",
+			DatabaseUsers: []*controlplane.DatabaseUserSpec{
+				{
+					Username:   "admin",
+					Password:   pointerTo("testpassword"),
+					DbOwner:    pointerTo(true),
+					Attributes: []string{"LOGIN", "SUPERUSER"},
+				},
+			},
+			Port:        pointerTo(0),
+			PatroniPort: pointerTo(0),
+			Nodes: []*controlplane.DatabaseNodeSpec{
+				{
+					Name:    "n1",
+					HostIds: []controlplane.Identifier{controlplane.Identifier(host1)},
+				},
+			},
+			Services: []*controlplane.ServiceSpec{
+				{
+					ServiceID:   "mcp-server",
+					ServiceType: "mcp",
+					ConnectAs:   "admin",
+					Version:     "1.0.0",
+					HostIds:     []controlplane.Identifier{controlplane.Identifier(host1)},
+					Config: map[string]any{
+						"llm_enabled":       true,
+						"llm_provider":      "anthropic",
+						"llm_model":         "claude-sonnet-4-5",
+						"anthropic_api_key": "sk-ant-test-key-version-update",
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, db.ServiceInstances, 1, "Expected 1 service instance")
+	waitForServiceRunning(ctx, t, db, db.ServiceInstances[0].ServiceInstanceID, 5*time.Minute)
+
+	t.Log("Fetching the database (this strips anthropic_api_key from the returned config)")
+	require.NoError(t, db.Refresh(ctx), "failed to refresh database")
+
+	var mcpSvc *controlplane.ServiceSpec
+	for _, svc := range db.Spec.Services {
+		if svc.ServiceID == "mcp-server" {
+			mcpSvc = svc
+		}
+	}
+	require.NotNil(t, mcpSvc, "mcp-server service should be present in the fetched spec")
+	_, hasKey := mcpSvc.Config["anthropic_api_key"]
+	require.False(t, hasKey, "anthropic_api_key should have been stripped from the GET response")
+
+	t.Log("Bumping only the service version in the fetched spec, then feeding it back into UpdateDatabase")
+	mcpSvc.Version = "1.1.0"
+
+	err := db.Update(ctx, UpdateOptions{Spec: db.Spec})
+	require.NoError(t, err, "UpdateDatabase should succeed even though the fetched spec never had anthropic_api_key to resupply")
+
+	require.Len(t, db.ServiceInstances, 1, "Should still have 1 service instance")
+	si := waitForServiceRunning(ctx, t, db, db.ServiceInstances[0].ServiceInstanceID, 5*time.Minute)
+	if si.Status != nil && si.Status.ImageVersion != nil {
+		assert.Contains(t, *si.Status.ImageVersion, "1.1.0", "service should be running the new pinned version after update")
+	}
+}

--- a/e2e/service_provisioning_test.go
+++ b/e2e/service_provisioning_test.go
@@ -1052,9 +1052,9 @@ func TestProvisionMCPServicePinnedVersion110(t *testing.T) {
 	require.Len(t, db.ServiceInstances, 1, "Expected 1 service instance")
 
 	si := waitForServiceRunning(ctx, t, db, db.ServiceInstances[0].ServiceInstanceID, 5*time.Minute)
-	if si.Status != nil && si.Status.ImageVersion != nil {
-		assert.Contains(t, *si.Status.ImageVersion, "1.1.0", "running container should use the pinned 1.1.0 image")
-	}
+	require.NotNil(t, si.Status, "service instance status should be populated once running")
+	require.NotNil(t, si.Status.ImageVersion, "service instance image version should be populated once running")
+	assert.Contains(t, *si.Status.ImageVersion, "1.1.0", "running container should use the pinned 1.1.0 image")
 }
 
 // TestUpdateMCPServiceVersion is the PLAT-715 regression test: it fetches a
@@ -1137,7 +1137,7 @@ func TestUpdateMCPServiceVersion(t *testing.T) {
 
 	require.Len(t, db.ServiceInstances, 1, "Should still have 1 service instance")
 	si := waitForServiceRunning(ctx, t, db, db.ServiceInstances[0].ServiceInstanceID, 5*time.Minute)
-	if si.Status != nil && si.Status.ImageVersion != nil {
-		assert.Contains(t, *si.Status.ImageVersion, "1.1.0", "service should be running the new pinned version after update")
-	}
+	require.NotNil(t, si.Status, "service instance status should be populated once running")
+	require.NotNil(t, si.Status.ImageVersion, "service instance image version should be populated once running")
+	assert.Contains(t, *si.Status.ImageVersion, "1.1.0", "service should be running the new pinned version after update")
 }

--- a/server/internal/api/apiv1/validate_test.go
+++ b/server/internal/api/apiv1/validate_test.go
@@ -1202,7 +1202,7 @@ func TestValidateDatabaseSpec(t *testing.T) {
 			},
 			expected: []string{
 				"services[0].config: llm_model is required",
-				"services[0].config: llm_provider must be one of: anthropic, openai, ollama",
+				"services[0].config: llm_provider must be one of: anthropic, openai, gemini, ollama",
 			},
 		},
 		{
@@ -1815,7 +1815,7 @@ func TestValidateServiceSpec(t *testing.T) {
 				},
 			},
 			expected: []string{
-				"config: llm_provider must be one of: anthropic, openai, ollama",
+				"config: llm_provider must be one of: anthropic, openai, gemini, ollama",
 			},
 		},
 		{

--- a/server/internal/database/mcp_service_config.go
+++ b/server/internal/database/mcp_service_config.go
@@ -26,6 +26,7 @@ type MCPServiceConfig struct {
 	LLMModel        string  `json:"llm_model"`
 	AnthropicAPIKey *string `json:"anthropic_api_key,omitempty"`
 	OpenAIAPIKey    *string `json:"openai_api_key,omitempty"`
+	GeminiAPIKey    *string `json:"gemini_api_key,omitempty"`
 	OllamaURL       *string `json:"ollama_url,omitempty"`
 
 	// Optional - security
@@ -60,6 +61,13 @@ type MCPServiceConfig struct {
 	KBEmbeddingModel    *string `json:"kb_embedding_model,omitempty"`
 	KBEmbeddingAPIKey   *string `json:"kb_embedding_api_key,omitempty"`
 	KBDatabaseHostPath  *string `json:"kb_database_host_path,omitempty"`
+
+	// Optional - audit trace logging. When enabled, the server writes a
+	// per-request audit trail to a file inside its existing data mount.
+	// AuditTraceMetadataOnly defaults to true (query text and result rows
+	// are not written) unless explicitly set to false.
+	AuditTraceEnabled      *bool `json:"audit_trace_enabled,omitempty"`
+	AuditTraceMetadataOnly *bool `json:"audit_trace_metadata_only,omitempty"`
 }
 
 // mcpKnownKeys is the set of all valid config keys for MCP service configuration.
@@ -69,6 +77,7 @@ var mcpKnownKeys = map[string]bool{
 	"llm_model":                    true,
 	"anthropic_api_key":            true,
 	"openai_api_key":               true,
+	"gemini_api_key":               true,
 	"ollama_url":                   true,
 	"allow_writes":                 true,
 	"init_token":                   true,
@@ -91,11 +100,13 @@ var mcpKnownKeys = map[string]bool{
 	"kb_embedding_model":           true,
 	"kb_embedding_api_key":         true,
 	"kb_database_host_path":        true,
+	"audit_trace_enabled":          true,
+	"audit_trace_metadata_only":    true,
 }
 
-var validLLMProviders = []string{"anthropic", "openai", "ollama"}
-var validEmbeddingProviders = []string{"voyage", "openai", "ollama"}
-var validKBEmbeddingProviders = []string{"voyage", "openai"}
+var validLLMProviders = []string{"anthropic", "openai", "gemini", "ollama"}
+var validEmbeddingProviders = []string{"voyage", "openai", "gemini", "ollama"}
+var validKBEmbeddingProviders = []string{"voyage", "openai", "gemini"}
 
 // ParseMCPServiceConfig parses and validates a config map into a typed
 // MCPServiceConfig. If isUpdate is true, bootstrap-only fields (init_token,
@@ -141,7 +152,7 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 	// rejected when llm_enabled is false.
 	var llmProvider string
 	var llmModel string
-	var anthropicKey, openaiKey, ollamaURL *string
+	var anthropicKey, openaiKey, geminiKey, ollamaURL *string
 	var llmTemperature *float64
 	var llmMaxTokens *int
 
@@ -174,6 +185,12 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 				if key != "" {
 					openaiKey = &key
 				}
+			case "gemini":
+				key, keyErrs := requireStringForProvider(config, "gemini_api_key", "gemini", isUpdate)
+				errs = append(errs, keyErrs...)
+				if key != "" {
+					geminiKey = &key
+				}
 			case "ollama":
 				// ollama_url is not a secret (GET never strips it), so it's
 				// always required here regardless of isUpdate.
@@ -205,7 +222,7 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 		}
 	} else {
 		// LLM is disabled — reject LLM-specific fields if present
-		llmOnlyFields := []string{"llm_provider", "llm_model", "anthropic_api_key", "openai_api_key", "llm_temperature", "llm_max_tokens"}
+		llmOnlyFields := []string{"llm_provider", "llm_model", "anthropic_api_key", "openai_api_key", "gemini_api_key", "llm_temperature", "llm_max_tokens"}
 		for _, key := range llmOnlyFields {
 			if _, ok := config[key]; ok {
 				errs = append(errs, fmt.Errorf("%s must not be set unless llm_enabled is true", key))
@@ -285,12 +302,12 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 		} else {
 			// ollama is not yet supported as a KB embedding provider
 			if strings.ToLower(*kbEmbeddingProvider) == "ollama" {
-				errs = append(errs, fmt.Errorf("kb_embedding_provider %q is not yet supported; use %q or %q", "ollama", "voyage", "openai"))
+				errs = append(errs, fmt.Errorf("kb_embedding_provider %q is not yet supported; use %q, %q, or %q", "ollama", "voyage", "openai", "gemini"))
 			} else if !slices.Contains(validKBEmbeddingProviders, *kbEmbeddingProvider) {
 				errs = append(errs, fmt.Errorf("kb_embedding_provider must be one of: %s", strings.Join(validKBEmbeddingProviders, ", ")))
 			} else {
-				// voyage and openai require an API key, except on an update,
-				// where an omitted key is expected to already have been
+				// voyage, openai, and gemini require an API key, except on an
+				// update, where an omitted key is expected to already have been
 				// restored from the stored spec before validation runs.
 				if !isUpdate && kbEmbeddingAPIKey == nil {
 					errs = append(errs, fmt.Errorf("kb_embedding_api_key is required when kb_embedding_provider is %q", *kbEmbeddingProvider))
@@ -346,7 +363,7 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 			// Provider-specific credential requirements. api_key is not
 			// required on an update — see requireStringForProvider.
 			switch *embeddingProvider {
-			case "voyage", "openai":
+			case "voyage", "openai", "gemini":
 				if !isUpdate && embeddingAPIKey == nil {
 					errs = append(errs, fmt.Errorf("embedding_api_key is required when embedding_provider is %q", *embeddingProvider))
 				}
@@ -356,6 +373,17 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 				}
 			}
 		}
+	}
+
+	// Audit trace fields
+	auditTraceEnabled, ateErrs := optionalBool(config, "audit_trace_enabled")
+	errs = append(errs, ateErrs...)
+
+	auditTraceMetadataOnly, atmoErrs := optionalBool(config, "audit_trace_metadata_only")
+	errs = append(errs, atmoErrs...)
+
+	if (auditTraceEnabled == nil || !*auditTraceEnabled) && auditTraceMetadataOnly != nil {
+		errs = append(errs, fmt.Errorf("audit_trace_metadata_only must not be set unless audit_trace_enabled is true"))
 	}
 
 	if len(errs) > 0 {
@@ -368,6 +396,7 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 		LLMModel:                   llmModel,
 		AnthropicAPIKey:            anthropicKey,
 		OpenAIAPIKey:               openaiKey,
+		GeminiAPIKey:               geminiKey,
 		OllamaURL:                  ollamaURL,
 		AllowWrites:                allowWrites,
 		InitToken:                  initToken,
@@ -390,6 +419,8 @@ func ParseMCPServiceConfig(config map[string]any, isUpdate bool) (*MCPServiceCon
 		KBEmbeddingModel:           kbEmbeddingModel,
 		KBEmbeddingAPIKey:          kbEmbeddingAPIKey,
 		KBDatabaseHostPath:         kbDatabaseHostPath,
+		AuditTraceEnabled:          auditTraceEnabled,
+		AuditTraceMetadataOnly:     auditTraceMetadataOnly,
 	}, nil
 }
 

--- a/server/internal/database/mcp_service_config_test.go
+++ b/server/internal/database/mcp_service_config_test.go
@@ -51,6 +51,16 @@ func noLLMBase() map[string]any {
 	return map[string]any{}
 }
 
+// geminiBase returns a minimal valid config for the gemini provider with LLM enabled.
+func geminiBase() map[string]any {
+	return map[string]any{
+		"llm_enabled":    true,
+		"llm_provider":   "gemini",
+		"llm_model":      "gemini-2.5-flash",
+		"gemini_api_key": "gm-key",
+	}
+}
+
 // joinedErr joins a []error into a single error for assertion convenience.
 func joinedErr(errs []error) error {
 	return errors.Join(errs...)
@@ -89,6 +99,25 @@ func TestParseMCPServiceConfig(t *testing.T) {
 			assert.Equal(t, "http://localhost:11434", *cfg.OllamaURL)
 			assert.Nil(t, cfg.AnthropicAPIKey)
 			assert.Nil(t, cfg.OpenAIAPIKey)
+		})
+
+		t.Run("minimal gemini config", func(t *testing.T) {
+			cfg, errs := database.ParseMCPServiceConfig(geminiBase(), false)
+			require.Empty(t, errs)
+			assert.Equal(t, "gemini", cfg.LLMProvider)
+			assert.Equal(t, "gemini-2.5-flash", cfg.LLMModel)
+			require.NotNil(t, cfg.GeminiAPIKey)
+			assert.Equal(t, "gm-key", *cfg.GeminiAPIKey)
+			assert.Nil(t, cfg.AnthropicAPIKey)
+			assert.Nil(t, cfg.OpenAIAPIKey)
+		})
+
+		t.Run("gemini llm_provider missing api_key", func(t *testing.T) {
+			config := geminiBase()
+			delete(config, "gemini_api_key")
+			_, errs := database.ParseMCPServiceConfig(config, false)
+			require.NotEmpty(t, errs)
+			assert.Contains(t, joinedErr(errs).Error(), "gemini_api_key is required")
 		})
 
 		t.Run("minimal no-LLM config", func(t *testing.T) {
@@ -582,6 +611,26 @@ func TestParseMCPServiceConfig(t *testing.T) {
 			_, errs := database.ParseMCPServiceConfig(config, false)
 			require.NotEmpty(t, errs)
 			assert.Contains(t, joinedErr(errs).Error(), `embedding_api_key is required when embedding_provider is "openai"`)
+		})
+
+		t.Run("gemini embedding with embedding_api_key", func(t *testing.T) {
+			config := anthropicBase()
+			config["embedding_provider"] = "gemini"
+			config["embedding_model"] = "gemini-embedding-001"
+			config["embedding_api_key"] = "gm-key"
+			cfg, errs := database.ParseMCPServiceConfig(config, false)
+			require.Empty(t, errs)
+			require.NotNil(t, cfg.EmbeddingProvider)
+			assert.Equal(t, "gemini", *cfg.EmbeddingProvider)
+		})
+
+		t.Run("gemini embedding without embedding_api_key", func(t *testing.T) {
+			config := anthropicBase()
+			config["embedding_provider"] = "gemini"
+			config["embedding_model"] = "gemini-embedding-001"
+			_, errs := database.ParseMCPServiceConfig(config, false)
+			require.NotEmpty(t, errs)
+			assert.Contains(t, joinedErr(errs).Error(), `embedding_api_key is required when embedding_provider is "gemini"`)
 		})
 
 		t.Run("unknown embedding_provider", func(t *testing.T) {
@@ -1138,6 +1187,30 @@ func TestParseMCPServiceConfig(t *testing.T) {
 				require.NotEmpty(t, errs)
 				assert.Contains(t, joinedErr(errs).Error(), `kb_embedding_api_key is required when kb_embedding_provider is "openai"`)
 			})
+
+			t.Run("gemini with kb_embedding_api_key", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "gemini",
+					"kb_embedding_model":    "gemini-embedding-001",
+					"kb_embedding_api_key":  "gm-key",
+				}
+				cfg, errs := database.ParseMCPServiceConfig(config, false)
+				require.Empty(t, errs)
+				require.NotNil(t, cfg.KBEmbeddingProvider)
+				assert.Equal(t, "gemini", *cfg.KBEmbeddingProvider)
+			})
+
+			t.Run("gemini without kb_embedding_api_key", func(t *testing.T) {
+				config := map[string]any{
+					"kb_enabled":            true,
+					"kb_embedding_provider": "gemini",
+					"kb_embedding_model":    "gemini-embedding-001",
+				}
+				_, errs := database.ParseMCPServiceConfig(config, false)
+				require.NotEmpty(t, errs)
+				assert.Contains(t, joinedErr(errs).Error(), `kb_embedding_api_key is required when kb_embedding_provider is "gemini"`)
+			})
 		})
 
 		t.Run("provider restrictions", func(t *testing.T) {
@@ -1429,6 +1502,45 @@ func TestParseMCPServiceConfig(t *testing.T) {
 			_, errs := database.ParseMCPServiceConfig(config, false)
 			require.NotEmpty(t, errs)
 			assert.Contains(t, joinedErr(errs).Error(), "llm_max_tokens must be an integer")
+		})
+	})
+
+	t.Run("audit trace", func(t *testing.T) {
+		t.Run("enabled with explicit metadata_only", func(t *testing.T) {
+			config := noLLMBase()
+			config["audit_trace_enabled"] = true
+			config["audit_trace_metadata_only"] = false
+			cfg, errs := database.ParseMCPServiceConfig(config, false)
+			require.Empty(t, errs)
+			require.NotNil(t, cfg.AuditTraceEnabled)
+			assert.True(t, *cfg.AuditTraceEnabled)
+			require.NotNil(t, cfg.AuditTraceMetadataOnly)
+			assert.False(t, *cfg.AuditTraceMetadataOnly)
+		})
+
+		t.Run("enabled without metadata_only", func(t *testing.T) {
+			config := noLLMBase()
+			config["audit_trace_enabled"] = true
+			cfg, errs := database.ParseMCPServiceConfig(config, false)
+			require.Empty(t, errs)
+			require.NotNil(t, cfg.AuditTraceEnabled)
+			assert.True(t, *cfg.AuditTraceEnabled)
+			assert.Nil(t, cfg.AuditTraceMetadataOnly)
+		})
+
+		t.Run("metadata_only without enabled is rejected", func(t *testing.T) {
+			config := noLLMBase()
+			config["audit_trace_metadata_only"] = true
+			_, errs := database.ParseMCPServiceConfig(config, false)
+			require.NotEmpty(t, errs)
+			assert.Contains(t, joinedErr(errs).Error(), "audit_trace_metadata_only must not be set unless audit_trace_enabled is true")
+		})
+
+		t.Run("not set", func(t *testing.T) {
+			cfg, errs := database.ParseMCPServiceConfig(noLLMBase(), false)
+			require.Empty(t, errs)
+			assert.Nil(t, cfg.AuditTraceEnabled)
+			assert.Nil(t, cfg.AuditTraceMetadataOnly)
 		})
 	})
 }

--- a/server/internal/database/rag_service_config.go
+++ b/server/internal/database/rag_service_config.go
@@ -21,6 +21,12 @@ const ragPipelineNamePatternText = `^[a-z0-9_][a-z0-9_-]*$`
 // misinterpreted as CLI flags if ever passed to a command.
 var ragPipelineNamePattern = regexp.MustCompile(ragPipelineNamePatternText)
 
+// ragPipelineNameMaxLen mirrors the RAG server's own maximum pipeline name
+// length (checked at its startup). Enforcing it here too means an
+// over-length name is rejected at config-submission time instead of
+// crash-looping the container after deployment.
+const ragPipelineNameMaxLen = 63
+
 // RAGPipelineLLMConfig represents LLM configuration for an embedding or RAG step.
 type RAGPipelineLLMConfig struct {
 	Provider string  `json:"provider"`
@@ -43,6 +49,19 @@ type RAGPipelineSearch struct {
 	VectorWeight  *float64 `json:"vector_weight,omitempty"`
 }
 
+// RAGRerankConfig represents an optional reranking stage that reorders search
+// results by relevance immediately before context building. The reranked
+// provider (Voyage) draws its API key from the same slot as embedding_llm
+// when it also uses Voyage; APIKey is only required here when rerank uses a
+// provider the pipeline's embedding_llm/rag_llm doesn't already authenticate
+// with.
+type RAGRerankConfig struct {
+	Provider string  `json:"provider"`
+	Model    string  `json:"model"`
+	APIKey   *string `json:"api_key,omitempty"`
+	TopK     *int    `json:"top_k,omitempty"`
+}
+
 // RAGPipeline represents a single RAG pipeline configuration.
 type RAGPipeline struct {
 	Name         string               `json:"name"`
@@ -54,6 +73,12 @@ type RAGPipeline struct {
 	TopN         *int                 `json:"top_n,omitempty"`
 	SystemPrompt *string              `json:"system_prompt,omitempty"`
 	Search       *RAGPipelineSearch   `json:"search,omitempty"`
+	Rerank       *RAGRerankConfig     `json:"rerank,omitempty"`
+	// AllowIncludeSources permits clients querying this pipeline to request
+	// the raw content of retrieved documents via include_sources. Defaults
+	// to false: exposing a corpus is an explicit per-pipeline decision, not
+	// something inherited from defaults.
+	AllowIncludeSources *bool `json:"allow_include_sources,omitempty"`
 }
 
 // RAGDefaults represents default values applied to all pipelines.
@@ -69,8 +94,11 @@ type RAGServiceConfig struct {
 	Defaults  *RAGDefaults  `json:"defaults,omitempty"`
 }
 
-var ragEmbeddingProviders = []string{"anthropic", "openai", "voyage", "ollama"}
-var ragLLMProviders = []string{"anthropic", "openai", "ollama"}
+// Anthropic has no embeddings API, so it is intentionally absent here even
+// though it's a valid rag_llm provider.
+var ragEmbeddingProviders = []string{"openai", "voyage", "gemini", "ollama"}
+var ragLLMProviders = []string{"anthropic", "openai", "gemini", "ollama"}
+var ragRerankProviders = []string{"voyage"}
 
 var ragKnownTopLevelKeys = map[string]bool{
 	"pipelines": true,
@@ -145,9 +173,11 @@ func validateRAGPipeline(p RAGPipeline, i int, seenNames map[string]bool, isUpda
 	var errs []error
 	prefix := fmt.Sprintf("pipelines[%d]", i)
 
-	// name (required, allowlist, unique)
+	// name (required, allowlist, max length, unique)
 	if p.Name == "" {
 		errs = append(errs, fmt.Errorf("%s.name is required", prefix))
+	} else if len(p.Name) > ragPipelineNameMaxLen {
+		errs = append(errs, fmt.Errorf("%s.name %q exceeds maximum length of %d characters", prefix, p.Name, ragPipelineNameMaxLen))
 	} else if !ragPipelineNamePattern.MatchString(p.Name) {
 		errs = append(errs, fmt.Errorf("%s.name %q is invalid: must match %s", prefix, p.Name, ragPipelineNamePatternText))
 	} else if seenNames[p.Name] {
@@ -188,6 +218,57 @@ func validateRAGPipeline(p RAGPipeline, i int, seenNames map[string]bool, isUpda
 		}
 	}
 
+	// rerank (optional)
+	if p.Rerank != nil {
+		errs = append(errs, validateRAGRerankConfig(*p.Rerank, p.EmbeddingLLM, prefix+".rerank", isUpdate)...)
+	}
+
+	return errs
+}
+
+// validateRAGRerankConfig validates an optional reranking stage. embeddingLLM
+// is the pipeline's embedding_llm config: since the reranker's only supported
+// provider (Voyage) shares a single API key slot per pipeline with an
+// embedding_llm that also uses Voyage, rerank.api_key is only required when
+// embedding_llm isn't already supplying that key — or, on an update, is
+// expected to have already been restored from the stored spec (see
+// Spec.DefaultOptionalFieldsFrom), same as the LLM provider fields above.
+func validateRAGRerankConfig(r RAGRerankConfig, embeddingLLM RAGPipelineLLMConfig, prefix string, isUpdate bool) []error {
+	var errs []error
+
+	// provider (required, currently only voyage is supported)
+	if r.Provider == "" {
+		return []error{fmt.Errorf("%s.provider is required", prefix)}
+	}
+	if !slices.Contains(ragRerankProviders, r.Provider) {
+		return []error{fmt.Errorf("%s.provider must be one of: %s", prefix, strings.Join(ragRerankProviders, ", "))}
+	}
+
+	// model (required)
+	if r.Model == "" {
+		errs = append(errs, fmt.Errorf("%s.model is required", prefix))
+	}
+
+	// api_key: required unless embedding_llm already uses this provider and
+	// supplies a key, or this is an update (see doc comment above).
+	embeddingHasKey := embeddingLLM.Provider == r.Provider && embeddingLLM.APIKey != nil && *embeddingLLM.APIKey != ""
+	if !isUpdate && !embeddingHasKey && (r.APIKey == nil || *r.APIKey == "") {
+		errs = append(errs, fmt.Errorf("%s.api_key is required when provider is %q and embedding_llm doesn't already supply one", prefix, r.Provider))
+	}
+
+	// If both roles supply a key for the shared provider, they must agree —
+	// the RAG server has a single key slot per provider and cannot reconcile
+	// two different values.
+	if embeddingLLM.Provider == r.Provider && embeddingLLM.APIKey != nil && *embeddingLLM.APIKey != "" &&
+		r.APIKey != nil && *r.APIKey != "" && *embeddingLLM.APIKey != *r.APIKey {
+		errs = append(errs, fmt.Errorf("%s.api_key does not match embedding_llm.api_key: both use provider %q and must share the same key", prefix, r.Provider))
+	}
+
+	// top_k (optional, >= 0 — 0 means "reorder all, drop none", matching upstream)
+	if r.TopK != nil && *r.TopK < 0 {
+		errs = append(errs, fmt.Errorf("%s.top_k must not be negative", prefix))
+	}
+
 	return errs
 }
 
@@ -226,7 +307,7 @@ func validateRAGLLMConfig(llm RAGPipelineLLMConfig, prefix string, validProvider
 	// an update, where an omitted key is expected to already have been
 	// restored from the stored spec before validation runs.
 	switch llm.Provider {
-	case "anthropic", "openai", "voyage":
+	case "anthropic", "openai", "voyage", "gemini":
 		if !isUpdate && (llm.APIKey == nil || *llm.APIKey == "") {
 			errs = append(errs, fmt.Errorf("%s.api_key is required when provider is %q", prefix, llm.Provider))
 		}

--- a/server/internal/database/rag_service_config_test.go
+++ b/server/internal/database/rag_service_config_test.go
@@ -1,6 +1,7 @@
 package database_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pgEdge/control-plane/server/internal/database"
@@ -371,6 +372,176 @@ func TestParseRAGServiceConfig_OllamaRAGLLM(t *testing.T) {
 	require.NotNil(t, cfg)
 	assert.Equal(t, "ollama", cfg.Pipelines[0].RAGLLM.Provider)
 	assert.Nil(t, cfg.Pipelines[0].RAGLLM.APIKey)
+}
+
+func TestParseRAGServiceConfig_AllowIncludeSources(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["allow_include_sources"] = true
+	cfg, errs := database.ParseRAGServiceConfig(config, false)
+	require.Empty(t, errs)
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.Pipelines[0].AllowIncludeSources)
+	assert.True(t, *cfg.Pipelines[0].AllowIncludeSources)
+}
+
+func TestParseRAGServiceConfig_PipelineNameTooLong(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["name"] = strings.Repeat("a", 64)
+	_, errs := database.ParseRAGServiceConfig(config, false)
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Error(), "exceeds maximum length")
+}
+
+func TestParseRAGServiceConfig_PipelineNameMaxLengthIsValid(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["name"] = strings.Repeat("a", 63)
+	_, errs := database.ParseRAGServiceConfig(config, false)
+	require.Empty(t, errs)
+}
+
+func TestParseRAGServiceConfig_AnthropicRejectedForEmbedding(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["embedding_llm"] = map[string]any{
+		"provider": "anthropic",
+		"model":    "claude-sonnet-4-5",
+		"api_key":  "sk-ant-key",
+	}
+	_, errs := database.ParseRAGServiceConfig(config, false)
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Error(), "embedding_llm.provider")
+}
+
+func TestParseRAGServiceConfig_GeminiEmbeddingAndRAGLLM(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["embedding_llm"] = map[string]any{
+		"provider": "gemini",
+		"model":    "gemini-embedding-001",
+		"api_key":  "gm-key",
+	}
+	config["pipelines"].([]any)[0].(map[string]any)["rag_llm"] = map[string]any{
+		"provider": "gemini",
+		"model":    "gemini-2.5-flash",
+		"api_key":  "gm-key",
+	}
+	cfg, errs := database.ParseRAGServiceConfig(config, false)
+	require.Empty(t, errs)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "gemini", cfg.Pipelines[0].EmbeddingLLM.Provider)
+	assert.Equal(t, "gemini", cfg.Pipelines[0].RAGLLM.Provider)
+}
+
+func TestParseRAGServiceConfig_Rerank_Valid(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["rerank"] = map[string]any{
+		"provider": "voyage",
+		"model":    "rerank-2",
+		"api_key":  "voy-rerank-key",
+		"top_k":    float64(5),
+	}
+	cfg, errs := database.ParseRAGServiceConfig(config, false)
+	require.Empty(t, errs)
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.Pipelines[0].Rerank)
+	assert.Equal(t, "voyage", cfg.Pipelines[0].Rerank.Provider)
+	assert.Equal(t, 5, *cfg.Pipelines[0].Rerank.TopK)
+}
+
+func TestParseRAGServiceConfig_Rerank_ReusesEmbeddingVoyageKey(t *testing.T) {
+	config := minimalRAGConfig()
+	pipeline := config["pipelines"].([]any)[0].(map[string]any)
+	pipeline["embedding_llm"] = map[string]any{
+		"provider": "voyage",
+		"model":    "voyage-3",
+		"api_key":  "voy-key",
+	}
+	pipeline["rerank"] = map[string]any{
+		"provider": "voyage",
+		"model":    "rerank-2",
+		// no api_key: embedding_llm already supplies one for voyage
+	}
+	cfg, errs := database.ParseRAGServiceConfig(config, false)
+	require.Empty(t, errs)
+	require.NotNil(t, cfg)
+	assert.Nil(t, cfg.Pipelines[0].Rerank.APIKey)
+}
+
+func TestParseRAGServiceConfig_Rerank_MissingAPIKeyWithoutEmbeddingVoyage(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["rerank"] = map[string]any{
+		"provider": "voyage",
+		"model":    "rerank-2",
+		// embedding_llm is openai in minimalRAGConfig, so no voyage key to reuse
+	}
+	_, errs := database.ParseRAGServiceConfig(config, false)
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Error(), "rerank.api_key")
+}
+
+func TestParseRAGServiceConfig_Rerank_MissingAPIKeyAllowedOnUpdate(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["rerank"] = map[string]any{
+		"provider": "voyage",
+		"model":    "rerank-2",
+	}
+	_, errs := database.ParseRAGServiceConfig(config, true)
+	require.Empty(t, errs)
+}
+
+func TestParseRAGServiceConfig_Rerank_MismatchedSharedProviderKey(t *testing.T) {
+	config := minimalRAGConfig()
+	pipeline := config["pipelines"].([]any)[0].(map[string]any)
+	pipeline["embedding_llm"] = map[string]any{
+		"provider": "voyage",
+		"model":    "voyage-3",
+		"api_key":  "voy-key-a",
+	}
+	pipeline["rerank"] = map[string]any{
+		"provider": "voyage",
+		"model":    "rerank-2",
+		"api_key":  "voy-key-b",
+	}
+	_, errs := database.ParseRAGServiceConfig(config, false)
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Error(), "rerank.api_key")
+}
+
+func TestParseRAGServiceConfig_Rerank_InvalidProvider(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["rerank"] = map[string]any{
+		"provider": "openai",
+		"model":    "some-model",
+		"api_key":  "sk-key",
+	}
+	_, errs := database.ParseRAGServiceConfig(config, false)
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Error(), "rerank.provider")
+}
+
+func TestParseRAGServiceConfig_Rerank_NegativeTopK(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["rerank"] = map[string]any{
+		"provider": "voyage",
+		"model":    "rerank-2",
+		"api_key":  "voy-key",
+		"top_k":    float64(-1),
+	}
+	_, errs := database.ParseRAGServiceConfig(config, false)
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Error(), "rerank.top_k")
+}
+
+func TestParseRAGServiceConfig_Rerank_TopKZeroIsValid(t *testing.T) {
+	config := minimalRAGConfig()
+	config["pipelines"].([]any)[0].(map[string]any)["rerank"] = map[string]any{
+		"provider": "voyage",
+		"model":    "rerank-2",
+		"api_key":  "voy-key",
+		"top_k":    float64(0),
+	}
+	cfg, errs := database.ParseRAGServiceConfig(config, false)
+	require.Empty(t, errs)
+	require.NotNil(t, cfg)
+	assert.Equal(t, 0, *cfg.Pipelines[0].Rerank.TopK)
 }
 
 func TestParseRAGServiceConfig_NegativeTopN(t *testing.T) {

--- a/server/internal/orchestrator/swarm/mcp_config.go
+++ b/server/internal/orchestrator/swarm/mcp_config.go
@@ -11,12 +11,14 @@ import (
 // mcpYAMLConfig mirrors the MCP server's Config struct for YAML generation.
 // Only fields the CP needs to set are included.
 type mcpYAMLConfig struct {
-	HTTP          mcpHTTPConfig       `yaml:"http"`
-	Databases     []mcpDatabaseConfig `yaml:"databases"`
-	LLM           *mcpLLMConfig       `yaml:"llm,omitempty"`
-	Embedding     *mcpEmbeddingConfig `yaml:"embedding,omitempty"`
-	Knowledgebase *mcpKBConfig        `yaml:"knowledgebase,omitempty"`
-	Builtins      mcpBuiltinsConfig   `yaml:"builtins"`
+	HTTP              mcpHTTPConfig       `yaml:"http"`
+	Databases         []mcpDatabaseConfig `yaml:"databases"`
+	LLM               *mcpLLMConfig       `yaml:"llm,omitempty"`
+	Embedding         *mcpEmbeddingConfig `yaml:"embedding,omitempty"`
+	Knowledgebase     *mcpKBConfig        `yaml:"knowledgebase,omitempty"`
+	Builtins          mcpBuiltinsConfig   `yaml:"builtins"`
+	TraceFile         string              `yaml:"trace_file,omitempty"`
+	TraceMetadataOnly *bool               `yaml:"trace_metadata_only,omitempty"`
 }
 
 type mcpHTTPConfig struct {
@@ -58,6 +60,7 @@ type mcpLLMConfig struct {
 	Model           string  `yaml:"model"`
 	AnthropicAPIKey string  `yaml:"anthropic_api_key,omitempty"`
 	OpenAIAPIKey    string  `yaml:"openai_api_key,omitempty"`
+	GeminiAPIKey    string  `yaml:"gemini_api_key,omitempty"`
 	OllamaURL       string  `yaml:"ollama_url,omitempty"`
 	Temperature     float64 `yaml:"temperature"`
 	MaxTokens       int     `yaml:"max_tokens"`
@@ -69,6 +72,7 @@ type mcpEmbeddingConfig struct {
 	Model        string `yaml:"model"`
 	VoyageAPIKey string `yaml:"voyage_api_key,omitempty"`
 	OpenAIAPIKey string `yaml:"openai_api_key,omitempty"`
+	GeminiAPIKey string `yaml:"gemini_api_key,omitempty"`
 	OllamaURL    string `yaml:"ollama_url,omitempty"`
 }
 
@@ -79,6 +83,7 @@ type mcpKBConfig struct {
 	EmbeddingModel        string `yaml:"embedding_model"`
 	EmbeddingVoyageAPIKey string `yaml:"embedding_voyage_api_key,omitempty"`
 	EmbeddingOpenAIAPIKey string `yaml:"embedding_openai_api_key,omitempty"`
+	EmbeddingGeminiAPIKey string `yaml:"embedding_gemini_api_key,omitempty"`
 }
 
 type mcpBuiltinsConfig struct {
@@ -148,6 +153,10 @@ func GenerateMCPConfig(params *MCPConfigParams) ([]byte, error) {
 			if cfg.OpenAIAPIKey != nil {
 				l.OpenAIAPIKey = *cfg.OpenAIAPIKey
 			}
+		case "gemini":
+			if cfg.GeminiAPIKey != nil {
+				l.GeminiAPIKey = *cfg.GeminiAPIKey
+			}
 		case "ollama":
 			if cfg.OllamaURL != nil {
 				l.OllamaURL = *cfg.OllamaURL
@@ -172,6 +181,8 @@ func GenerateMCPConfig(params *MCPConfigParams) ([]byte, error) {
 				emb.VoyageAPIKey = *cfg.EmbeddingAPIKey
 			case "openai":
 				emb.OpenAIAPIKey = *cfg.EmbeddingAPIKey
+			case "gemini":
+				emb.GeminiAPIKey = *cfg.EmbeddingAPIKey
 			}
 		}
 		if *cfg.EmbeddingProvider == "ollama" && cfg.OllamaURL != nil {
@@ -201,6 +212,8 @@ func GenerateMCPConfig(params *MCPConfigParams) ([]byte, error) {
 			k.EmbeddingVoyageAPIKey = *cfg.KBEmbeddingAPIKey
 		case "openai":
 			k.EmbeddingOpenAIAPIKey = *cfg.KBEmbeddingAPIKey
+		case "gemini":
+			k.EmbeddingGeminiAPIKey = *cfg.KBEmbeddingAPIKey
 		}
 		kb = k
 	}
@@ -238,6 +251,21 @@ func GenerateMCPConfig(params *MCPConfigParams) ([]byte, error) {
 		hosts[i] = mcpHostEntry{Host: h.Host, Port: h.Port}
 	}
 
+	// Audit trace: written inside the existing /app/data bind mount, so no
+	// new mount is needed. Metadata-only defaults to true when trace is
+	// enabled but the caller didn't say otherwise, so query text and result
+	// rows don't land on disk by default.
+	var traceFile string
+	var traceMetadataOnly *bool
+	if cfg.AuditTraceEnabled != nil && *cfg.AuditTraceEnabled {
+		traceFile = "/app/data/audit-trace.log"
+		metadataOnly := true
+		if cfg.AuditTraceMetadataOnly != nil {
+			metadataOnly = *cfg.AuditTraceMetadataOnly
+		}
+		traceMetadataOnly = &metadataOnly
+	}
+
 	yamlCfg := &mcpYAMLConfig{
 		HTTP: mcpHTTPConfig{
 			Enabled: true,
@@ -269,6 +297,8 @@ func GenerateMCPConfig(params *MCPConfigParams) ([]byte, error) {
 		Builtins: mcpBuiltinsConfig{
 			Tools: tools,
 		},
+		TraceFile:         traceFile,
+		TraceMetadataOnly: traceMetadataOnly,
 	}
 
 	data, err := yaml.Marshal(yamlCfg)

--- a/server/internal/orchestrator/swarm/mcp_config_test.go
+++ b/server/internal/orchestrator/swarm/mcp_config_test.go
@@ -313,6 +313,111 @@ func TestGenerateMCPConfig_ProviderKeys_OpenAI(t *testing.T) {
 	}
 }
 
+func TestGenerateMCPConfig_ProviderKeys_Gemini(t *testing.T) {
+	apiKey := "gm-test-key"
+	params := &MCPConfigParams{
+		Config: &database.MCPServiceConfig{
+			LLMEnabled:   utils.PointerTo(true),
+			LLMProvider:  "gemini",
+			LLMModel:     "gemini-2.5-flash",
+			GeminiAPIKey: &apiKey,
+		},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+
+	cfg := parseYAML(t, data)
+
+	if cfg.LLM == nil {
+		t.Fatal("llm section should be present")
+	}
+	if cfg.LLM.GeminiAPIKey != apiKey {
+		t.Errorf("llm.gemini_api_key = %q, want %q", cfg.LLM.GeminiAPIKey, apiKey)
+	}
+	if cfg.LLM.OpenAIAPIKey != "" {
+		t.Errorf("llm.openai_api_key should be empty for gemini provider, got %q", cfg.LLM.OpenAIAPIKey)
+	}
+}
+
+func TestGenerateMCPConfig_AuditTrace_Enabled_DefaultsMetadataOnly(t *testing.T) {
+	enabled := true
+	params := &MCPConfigParams{
+		Config: &database.MCPServiceConfig{
+			AuditTraceEnabled: &enabled,
+		},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+	cfg := parseYAML(t, data)
+
+	if cfg.TraceFile != "/app/data/audit-trace.log" {
+		t.Errorf("trace_file = %q, want %q", cfg.TraceFile, "/app/data/audit-trace.log")
+	}
+	if cfg.TraceMetadataOnly == nil || !*cfg.TraceMetadataOnly {
+		t.Errorf("trace_metadata_only = %v, want true (default)", cfg.TraceMetadataOnly)
+	}
+}
+
+func TestGenerateMCPConfig_AuditTrace_ExplicitMetadataOnlyFalse(t *testing.T) {
+	enabled := true
+	metadataOnly := false
+	params := &MCPConfigParams{
+		Config: &database.MCPServiceConfig{
+			AuditTraceEnabled:      &enabled,
+			AuditTraceMetadataOnly: &metadataOnly,
+		},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+	cfg := parseYAML(t, data)
+
+	if cfg.TraceMetadataOnly == nil || *cfg.TraceMetadataOnly {
+		t.Errorf("trace_metadata_only = %v, want false (explicit)", cfg.TraceMetadataOnly)
+	}
+}
+
+func TestGenerateMCPConfig_AuditTrace_DisabledOmitsTraceFile(t *testing.T) {
+	data, err := GenerateMCPConfig(&MCPConfigParams{
+		Config:        &database.MCPServiceConfig{},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	})
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+	cfg := parseYAML(t, data)
+
+	if cfg.TraceFile != "" {
+		t.Errorf("trace_file should be empty (omitted), got %q", cfg.TraceFile)
+	}
+	if cfg.TraceMetadataOnly != nil {
+		t.Errorf("trace_metadata_only should be nil (omitted), got %v", *cfg.TraceMetadataOnly)
+	}
+}
+
 func TestGenerateMCPConfig_ProviderKeys_Ollama(t *testing.T) {
 	ollamaURL := "http://localhost:11434"
 	params := &MCPConfigParams{
@@ -491,6 +596,41 @@ func TestGenerateMCPConfig_EmbeddingOpenAI(t *testing.T) {
 	}
 	if cfg.Embedding.VoyageAPIKey != "" {
 		t.Errorf("embedding.voyage_api_key should be empty for openai embedding, got %q", cfg.Embedding.VoyageAPIKey)
+	}
+}
+
+func TestGenerateMCPConfig_EmbeddingGemini(t *testing.T) {
+	embProvider := "gemini"
+	embModel := "gemini-embedding-001"
+	embAPIKey := "gm-embed-key"
+
+	params := &MCPConfigParams{
+		Config: &database.MCPServiceConfig{
+			EmbeddingProvider: &embProvider,
+			EmbeddingModel:    &embModel,
+			EmbeddingAPIKey:   &embAPIKey,
+		},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+
+	cfg := parseYAML(t, data)
+
+	if cfg.Embedding == nil {
+		t.Fatal("embedding section should be present")
+	}
+	if cfg.Embedding.GeminiAPIKey != "gm-embed-key" {
+		t.Errorf("embedding.gemini_api_key = %q, want %q", cfg.Embedding.GeminiAPIKey, "gm-embed-key")
+	}
+	if cfg.Embedding.OpenAIAPIKey != "" {
+		t.Errorf("embedding.openai_api_key should be empty for gemini embedding, got %q", cfg.Embedding.OpenAIAPIKey)
 	}
 }
 
@@ -805,6 +945,40 @@ func TestGenerateMCPConfig_KBEnabled_OpenAIProvider(t *testing.T) {
 	}
 	if cfg.Knowledgebase.EmbeddingVoyageAPIKey != "" {
 		t.Errorf("knowledgebase.embedding_voyage_api_key should be empty for openai provider, got %q", cfg.Knowledgebase.EmbeddingVoyageAPIKey)
+	}
+}
+
+func TestGenerateMCPConfig_KBEnabled_GeminiProvider(t *testing.T) {
+	params := &MCPConfigParams{
+		Config: &database.MCPServiceConfig{
+			KBEnabled:           utils.PointerTo(true),
+			KBEmbeddingProvider: strPtr("gemini"),
+			KBEmbeddingModel:    strPtr("gemini-embedding-001"),
+			KBEmbeddingAPIKey:   strPtr("gm-kb-key"),
+		},
+		DatabaseName:  "mydb",
+		DatabaseHosts: []database.ServiceHostEntry{{Host: "db-host", Port: 5432}},
+		Username:      "appuser",
+		Password:      "secret",
+	}
+
+	data, err := GenerateMCPConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateMCPConfig() error = %v", err)
+	}
+
+	cfg := parseYAML(t, data)
+	if cfg.Knowledgebase == nil {
+		t.Fatal("knowledgebase section should be present when kb_enabled is true")
+	}
+	if cfg.Knowledgebase.EmbeddingProvider != "gemini" {
+		t.Errorf("knowledgebase.embedding_provider = %q, want %q", cfg.Knowledgebase.EmbeddingProvider, "gemini")
+	}
+	if cfg.Knowledgebase.EmbeddingGeminiAPIKey != "gm-kb-key" {
+		t.Errorf("knowledgebase.embedding_gemini_api_key = %q, want %q", cfg.Knowledgebase.EmbeddingGeminiAPIKey, "gm-kb-key")
+	}
+	if cfg.Knowledgebase.EmbeddingOpenAIAPIKey != "" {
+		t.Errorf("knowledgebase.embedding_openai_api_key should be empty for gemini provider, got %q", cfg.Knowledgebase.EmbeddingOpenAIAPIKey)
 	}
 }
 

--- a/server/internal/orchestrator/swarm/rag_config.go
+++ b/server/internal/orchestrator/swarm/rag_config.go
@@ -12,7 +12,7 @@ import (
 // ragYAMLConfig mirrors the pgedge-rag-server Config struct for YAML generation.
 // Only the fields the control plane needs to set are included.
 type ragYAMLConfig struct {
-	Server    ragServerYAML    `yaml:"server"`
+	Server    ragServerYAML     `yaml:"server"`
 	Pipelines []ragPipelineYAML `yaml:"pipelines"`
 	Defaults  *ragDefaultsYAML  `yaml:"defaults,omitempty"`
 }
@@ -23,17 +23,19 @@ type ragServerYAML struct {
 }
 
 type ragPipelineYAML struct {
-	Name         string          `yaml:"name"`
-	Description  string          `yaml:"description,omitempty"`
-	Database     ragDatabaseYAML `yaml:"database"`
-	Tables       []ragTableYAML  `yaml:"tables"`
-	EmbeddingLLM ragLLMYAML      `yaml:"embedding_llm"`
-	RAGLLM       ragLLMYAML      `yaml:"rag_llm"`
-	APIKeys      *ragAPIKeysYAML `yaml:"api_keys,omitempty"`
-	TokenBudget  *int            `yaml:"token_budget,omitempty"`
-	TopN         *int            `yaml:"top_n,omitempty"`
-	SystemPrompt string          `yaml:"system_prompt,omitempty"`
-	Search       *ragSearchYAML  `yaml:"search,omitempty"`
+	Name                string          `yaml:"name"`
+	Description         string          `yaml:"description,omitempty"`
+	Database            ragDatabaseYAML `yaml:"database"`
+	Tables              []ragTableYAML  `yaml:"tables"`
+	EmbeddingLLM        ragLLMYAML      `yaml:"embedding_llm"`
+	RAGLLM              ragLLMYAML      `yaml:"rag_llm"`
+	APIKeys             *ragAPIKeysYAML `yaml:"api_keys,omitempty"`
+	TokenBudget         *int            `yaml:"token_budget,omitempty"`
+	TopN                *int            `yaml:"top_n,omitempty"`
+	SystemPrompt        string          `yaml:"system_prompt,omitempty"`
+	Search              *ragSearchYAML  `yaml:"search,omitempty"`
+	Rerank              *ragRerankYAML  `yaml:"rerank,omitempty"`
+	AllowIncludeSources bool            `yaml:"allow_include_sources,omitempty"`
 }
 
 type ragDatabaseYAML struct {
@@ -63,11 +65,20 @@ type ragAPIKeysYAML struct {
 	Anthropic string `yaml:"anthropic,omitempty"`
 	OpenAI    string `yaml:"openai,omitempty"`
 	Voyage    string `yaml:"voyage,omitempty"`
+	Gemini    string `yaml:"gemini,omitempty"`
 }
 
 type ragSearchYAML struct {
 	HybridEnabled *bool    `yaml:"hybrid_enabled,omitempty"`
 	VectorWeight  *float64 `yaml:"vector_weight,omitempty"`
+}
+
+// ragRerankYAML has no api_key field: the rerank stage draws its Voyage key
+// from the same api_keys.voyage slot embedding_llm uses (see ragAPIKeysYAML).
+type ragRerankYAML struct {
+	Provider string `yaml:"provider"`
+	Model    string `yaml:"model"`
+	TopK     *int   `yaml:"top_k,omitempty"`
 }
 
 type ragDefaultsYAML struct {
@@ -194,6 +205,16 @@ func buildRAGPipelineYAML(p database.RAGPipeline, params *RAGConfigParams) (ragP
 			VectorWeight:  p.Search.VectorWeight,
 		}
 	}
+	if p.Rerank != nil {
+		pipeline.Rerank = &ragRerankYAML{
+			Provider: p.Rerank.Provider,
+			Model:    p.Rerank.Model,
+			TopK:     p.Rerank.TopK,
+		}
+	}
+	if p.AllowIncludeSources != nil {
+		pipeline.AllowIncludeSources = *p.AllowIncludeSources
+	}
 
 	return pipeline, nil
 }
@@ -202,8 +223,12 @@ func buildRAGPipelineYAML(p database.RAGPipeline, params *RAGConfigParams) (ragP
 // corresponding bind-mounted key file path inside the container.
 // Embedding key: {keysDir}/{pipeline}_embedding.key
 // RAG key:       {keysDir}/{pipeline}_rag.key
+// Rerank key:    {keysDir}/{pipeline}_rerank.key (only when embedding_llm
+//
+//	isn't already using the same provider — see extractRAGAPIKeys)
+//
 // If embedding and RAG use the same provider, the RAG key path takes precedence
-// (both files contain the same value). Returns an error if both LLMs share a
+// (both files contain the same value). Returns an error if two roles share a
 // provider but were configured with different API keys.
 func buildRAGAPIKeysYAML(p database.RAGPipeline, keysDir string) (*ragAPIKeysYAML, error) {
 	// Reject mismatched keys for the same provider — the RAG server has a
@@ -215,19 +240,27 @@ func buildRAGAPIKeysYAML(p database.RAGPipeline, keysDir string) (*ragAPIKeysYAM
 		return nil, fmt.Errorf("pipeline %q: embedding_llm and rag_llm share provider %q but have different API keys",
 			p.Name, p.EmbeddingLLM.Provider)
 	}
+	if p.Rerank != nil && p.EmbeddingLLM.Provider == p.Rerank.Provider &&
+		p.EmbeddingLLM.APIKey != nil && *p.EmbeddingLLM.APIKey != "" &&
+		p.Rerank.APIKey != nil && *p.Rerank.APIKey != "" &&
+		*p.EmbeddingLLM.APIKey != *p.Rerank.APIKey {
+		return nil, fmt.Errorf("pipeline %q: embedding_llm and rerank share provider %q but have different API keys",
+			p.Name, p.EmbeddingLLM.Provider)
+	}
 
 	keys := &ragAPIKeysYAML{}
 
-	// Embedding provider key
+	// Embedding provider key. Anthropic has no embeddings API, so it is
+	// intentionally not handled here even though it is for rag_llm below.
 	if p.EmbeddingLLM.APIKey != nil && *p.EmbeddingLLM.APIKey != "" {
 		keyPath := path.Join(keysDir, p.Name+"_embedding.key")
 		switch p.EmbeddingLLM.Provider {
-		case "anthropic":
-			keys.Anthropic = keyPath
 		case "openai":
 			keys.OpenAI = keyPath
 		case "voyage":
 			keys.Voyage = keyPath
+		case "gemini":
+			keys.Gemini = keyPath
 		}
 	}
 
@@ -239,10 +272,20 @@ func buildRAGAPIKeysYAML(p database.RAGPipeline, keysDir string) (*ragAPIKeysYAM
 			keys.Anthropic = keyPath
 		case "openai":
 			keys.OpenAI = keyPath
+		case "gemini":
+			keys.Gemini = keyPath
 		}
 	}
 
-	if keys.Anthropic == "" && keys.OpenAI == "" && keys.Voyage == "" {
+	// Rerank provider key. Only voyage is supported. If embedding_llm already
+	// uses voyage, keys.Voyage already points at its key file and is reused
+	// as-is; otherwise the rerank stage gets its own key file.
+	if p.Rerank != nil && p.Rerank.Provider == "voyage" && keys.Voyage == "" &&
+		p.Rerank.APIKey != nil && *p.Rerank.APIKey != "" {
+		keys.Voyage = path.Join(keysDir, p.Name+"_rerank.key")
+	}
+
+	if keys.Anthropic == "" && keys.OpenAI == "" && keys.Voyage == "" && keys.Gemini == "" {
 		return nil, nil
 	}
 	return keys, nil

--- a/server/internal/orchestrator/swarm/rag_config_test.go
+++ b/server/internal/orchestrator/swarm/rag_config_test.go
@@ -215,6 +215,126 @@ func TestGenerateRAGConfig_APIKeyPaths_SameProvider_RAGTakesPrecedence(t *testin
 	}
 }
 
+func TestGenerateRAGConfig_AllowIncludeSources(t *testing.T) {
+	params := minimalRAGParams()
+	allow := true
+	params.Config.Pipelines[0].AllowIncludeSources = &allow
+
+	data, err := GenerateRAGConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateRAGConfig() error = %v", err)
+	}
+	cfg := parseRAGYAML(t, data)
+	if !cfg.Pipelines[0].AllowIncludeSources {
+		t.Error("allow_include_sources should be true")
+	}
+}
+
+func TestGenerateRAGConfig_Rerank_OwnKeyFile(t *testing.T) {
+	rerankKey := "voy-rerank-key"
+	topK := 5
+	params := minimalRAGParams()
+	params.Config.Pipelines[0].Rerank = &database.RAGRerankConfig{
+		Provider: "voyage",
+		Model:    "rerank-2",
+		APIKey:   &rerankKey,
+		TopK:     &topK,
+	}
+
+	data, err := GenerateRAGConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateRAGConfig() error = %v", err)
+	}
+	cfg := parseRAGYAML(t, data)
+	p := cfg.Pipelines[0]
+
+	if p.Rerank == nil {
+		t.Fatal("rerank should be present")
+	}
+	if p.Rerank.Provider != "voyage" || p.Rerank.Model != "rerank-2" {
+		t.Errorf("rerank = %+v, want provider=voyage model=rerank-2", p.Rerank)
+	}
+	if p.Rerank.TopK == nil || *p.Rerank.TopK != 5 {
+		t.Errorf("rerank.top_k = %v, want 5", p.Rerank.TopK)
+	}
+	if p.APIKeys == nil || p.APIKeys.Voyage != "/app/keys/default_rerank.key" {
+		t.Errorf("api_keys.voyage = %+v, want /app/keys/default_rerank.key", p.APIKeys)
+	}
+}
+
+func TestGenerateRAGConfig_Rerank_ReusesEmbeddingVoyageKeyFile(t *testing.T) {
+	voyageKey := "voy-shared-key"
+	antKey := "sk-ant"
+	params := &RAGConfigParams{
+		Config: &database.RAGServiceConfig{
+			Pipelines: []database.RAGPipeline{
+				{
+					Name:   "search",
+					Tables: []database.RAGPipelineTable{{Table: "t", TextColumn: "c", VectorColumn: "v"}},
+					EmbeddingLLM: database.RAGPipelineLLMConfig{
+						Provider: "voyage", Model: "voyage-3", APIKey: &voyageKey,
+					},
+					RAGLLM: database.RAGPipelineLLMConfig{
+						Provider: "anthropic", Model: "claude", APIKey: &antKey,
+					},
+					Rerank: &database.RAGRerankConfig{
+						Provider: "voyage",
+						Model:    "rerank-2",
+					},
+				},
+			},
+		},
+		DatabaseName: "mydb", DatabaseHost: "host", DatabasePort: 5432,
+		Username: "u", Password: "p", KeysDir: "/app/keys",
+	}
+
+	data, err := GenerateRAGConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateRAGConfig() error = %v", err)
+	}
+	cfg := parseRAGYAML(t, data)
+	keys := cfg.Pipelines[0].APIKeys
+
+	if keys == nil || keys.Voyage != "/app/keys/search_embedding.key" {
+		t.Errorf("api_keys.voyage = %+v, want reuse of /app/keys/search_embedding.key", keys)
+	}
+}
+
+func TestGenerateRAGConfig_GeminiEmbeddingAndRAGLLM(t *testing.T) {
+	geminiKey := "gm-shared-key"
+	params := &RAGConfigParams{
+		Config: &database.RAGServiceConfig{
+			Pipelines: []database.RAGPipeline{
+				{
+					Name:   "search",
+					Tables: []database.RAGPipelineTable{{Table: "t", TextColumn: "c", VectorColumn: "v"}},
+					EmbeddingLLM: database.RAGPipelineLLMConfig{
+						Provider: "gemini", Model: "gemini-embedding-001", APIKey: &geminiKey,
+					},
+					RAGLLM: database.RAGPipelineLLMConfig{
+						Provider: "gemini", Model: "gemini-2.5-flash", APIKey: &geminiKey,
+					},
+				},
+			},
+		},
+		DatabaseName: "mydb", DatabaseHost: "host", DatabasePort: 5432,
+		Username: "u", Password: "p", KeysDir: "/app/keys",
+	}
+
+	data, err := GenerateRAGConfig(params)
+	if err != nil {
+		t.Fatalf("GenerateRAGConfig() error = %v", err)
+	}
+	cfg := parseRAGYAML(t, data)
+	keys := cfg.Pipelines[0].APIKeys
+
+	// Same provider (gemini) on both roles with the same key -> rag_llm's
+	// path takes precedence, same as the existing openai/anthropic behavior.
+	if keys == nil || keys.Gemini != "/app/keys/search_rag.key" {
+		t.Errorf("api_keys.gemini = %+v, want rag key path %q", keys, "/app/keys/search_rag.key")
+	}
+}
+
 func TestGenerateRAGConfig_OllamaNoAPIKey(t *testing.T) {
 	// ollama providers have no API key — api_keys section must be absent.
 	params := &RAGConfigParams{

--- a/server/internal/orchestrator/swarm/rag_service_keys_resource.go
+++ b/server/internal/orchestrator/swarm/rag_service_keys_resource.go
@@ -226,6 +226,10 @@ func validateKeyFilename(name string) error {
 // extractRAGAPIKeys builds the filename→value map from a parsed RAGServiceConfig.
 // Filenames follow the convention: {pipeline_name}_embedding.key and {pipeline_name}_rag.key.
 // Providers that do not require an API key (e.g. ollama) produce no entry.
+// A pipeline's optional rerank stage gets its own {pipeline_name}_rerank.key
+// file only when it needs a key embedding_llm isn't already supplying (see
+// validateRAGRerankConfig) — when embedding_llm uses the same provider, the
+// rerank stage reuses that key file instead of writing a duplicate.
 func extractRAGAPIKeys(cfg *database.RAGServiceConfig) map[string]string {
 	keys := make(map[string]string)
 	for _, p := range cfg.Pipelines {
@@ -234,6 +238,13 @@ func extractRAGAPIKeys(cfg *database.RAGServiceConfig) map[string]string {
 		}
 		if p.RAGLLM.APIKey != nil && *p.RAGLLM.APIKey != "" {
 			keys[p.Name+"_rag.key"] = *p.RAGLLM.APIKey
+		}
+		if p.Rerank != nil && p.Rerank.APIKey != nil && *p.Rerank.APIKey != "" {
+			embeddingHasSameProvider := p.EmbeddingLLM.Provider == p.Rerank.Provider &&
+				p.EmbeddingLLM.APIKey != nil && *p.EmbeddingLLM.APIKey != ""
+			if !embeddingHasSameProvider {
+				keys[p.Name+"_rerank.key"] = *p.Rerank.APIKey
+			}
 		}
 	}
 	return keys

--- a/server/internal/orchestrator/swarm/rag_service_keys_resource_test.go
+++ b/server/internal/orchestrator/swarm/rag_service_keys_resource_test.go
@@ -233,6 +233,64 @@ func TestExtractRAGAPIKeys_MultiPipeline(t *testing.T) {
 	}
 }
 
+func TestExtractRAGAPIKeys_RerankOwnKeyFile(t *testing.T) {
+	embKey := "sk-openai-embed"
+	rerankKey := "voy-rerank-key"
+	cfg := &database.RAGServiceConfig{
+		Pipelines: []database.RAGPipeline{
+			{
+				Name: "default",
+				EmbeddingLLM: database.RAGPipelineLLMConfig{
+					Provider: "openai",
+					Model:    "text-embedding-3-small",
+					APIKey:   &embKey,
+				},
+				Rerank: &database.RAGRerankConfig{
+					Provider: "voyage",
+					Model:    "rerank-2",
+					APIKey:   &rerankKey,
+				},
+			},
+		},
+	}
+
+	keys := extractRAGAPIKeys(cfg)
+	if keys["default_rerank.key"] != rerankKey {
+		t.Errorf("default_rerank.key = %q, want %q", keys["default_rerank.key"], rerankKey)
+	}
+	if len(keys) != 2 {
+		t.Errorf("len(keys) = %d, want 2 (embedding + rerank)", len(keys))
+	}
+}
+
+func TestExtractRAGAPIKeys_RerankReusesEmbeddingVoyageKey(t *testing.T) {
+	voyageKey := "voy-shared-key"
+	cfg := &database.RAGServiceConfig{
+		Pipelines: []database.RAGPipeline{
+			{
+				Name: "search",
+				EmbeddingLLM: database.RAGPipelineLLMConfig{
+					Provider: "voyage",
+					Model:    "voyage-3",
+					APIKey:   &voyageKey,
+				},
+				Rerank: &database.RAGRerankConfig{
+					Provider: "voyage",
+					Model:    "rerank-2",
+				},
+			},
+		},
+	}
+
+	keys := extractRAGAPIKeys(cfg)
+	if _, ok := keys["search_rerank.key"]; ok {
+		t.Error("unexpected search_rerank.key: rerank should reuse embedding_llm's voyage key file, not write its own")
+	}
+	if keys["search_embedding.key"] != voyageKey {
+		t.Errorf("search_embedding.key = %q, want %q", keys["search_embedding.key"], voyageKey)
+	}
+}
+
 func TestGenerateRAGInstanceResources_IncludesKeysResource(t *testing.T) {
 	o := newTestOrchestrator(t)
 	spec := &database.ServiceInstanceSpec{

--- a/server/internal/orchestrator/swarm/service_spec.go
+++ b/server/internal/orchestrator/swarm/service_spec.go
@@ -32,6 +32,15 @@ const (
 	serviceHealthCheckRetries     = 3
 )
 
+// RAG-specific health check timing. RAG's /v1/health endpoint pings every
+// pipeline's configured providers (embedding and completion), each bounded
+// at roughly 10s to comfortably survive one retry, so Interval/Timeout need
+// more headroom than the shared constants above give postgrest/mcp.
+const (
+	ragHealthCheckInterval = 30 * time.Second
+	ragHealthCheckTimeout  = 20 * time.Second
+)
+
 func buildPostgRESTEnvVars() []string {
 	// Connection details (hosts, credentials) are embedded in the db-uri inside
 	// postgrest.conf by PostgRESTConfigResource — they must not appear as env vars.
@@ -217,12 +226,19 @@ func ServiceContainerSpec(opts *ServiceContainerSpecOptions) (swarm.ServiceSpec,
 		// TaskTemplate change and restarts the container when pipelines or API
 		// keys change. Without this, bind-mount updates are invisible to Swarm.
 		env = []string{"PGEDGE_CONFIG_VERSION=" + serviceConfigHash(opts.ServiceSpec.Config)}
-		// No curl in the RHEL minimal image — use a TCP probe instead.
+		// No curl/wget in the minimal runtime image — issue the HTTP request
+		// with bash builtins over /dev/tcp instead. /v1/health pings every
+		// pipeline's configured providers and always returns HTTP 200 (with
+		// "healthy"/"degraded" in the body), so this confirms the server is
+		// up and completed a health pass within the timeout below, which is
+		// set comfortably above /v1/health's own ~10s worst-case ping budget.
 		healthcheck = &container.HealthConfig{
-			Test:        []string{"CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080"},
+			Test: []string{"CMD-SHELL",
+				`exec 3<>/dev/tcp/127.0.0.1/8080 && printf 'GET /v1/health HTTP/1.0\r\n\r\n' >&3 && read -r status <&3 && [[ "$status" == *" 200 "* ]]`,
+			},
 			StartPeriod: serviceHealthCheckStartPeriod,
-			Interval:    serviceHealthCheckInterval,
-			Timeout:     serviceHealthCheckTimeout,
+			Interval:    ragHealthCheckInterval,
+			Timeout:     ragHealthCheckTimeout,
 			Retries:     serviceHealthCheckRetries,
 		}
 		mounts = []mount.Mount{

--- a/server/internal/orchestrator/swarm/version-manifest.json
+++ b/server/internal/orchestrator/swarm/version-manifest.json
@@ -130,6 +130,11 @@
       {
         "version": "1.0.0",
         "image": "postgres-mcp:1.0.0",
+        "stability": "stable"
+      },
+      {
+        "version": "1.1.0",
+        "image": "postgres-mcp:1.1.0",
         "stability": "stable",
         "default": true
       }
@@ -138,6 +143,11 @@
       {
         "version": "1.0.0",
         "image": "rag-server:1.0.0",
+        "stability": "stable"
+      },
+      {
+        "version": "2.0.0",
+        "image": "rag-server:2.0.0",
         "stability": "stable",
         "default": true
       }


### PR DESCRIPTION
## Summary
This PR updates the default service versions to MCP v1.1.0 and RAG v2.0.0, along with their new configuration options: Gemini provider support, RAG reranking, and MCP audit tracing.


## Changes
- Register `mcp@1.1.0` and `rag@2.0.0` in the version manifest as `"default": true`; `mcp@1.0.0`/`rag@1.0.0` remain registered and pinnable.
- Add RAG `rerank` (Voyage-only) and `allow_include_sources` per-pipeline config. The rerank stage shares a pipeline's existing Voyage key file when `embedding_llm` already uses Voyage, otherwise gets its own `_rerank.key` file.
- Add Gemini as a supported provider for both services: RAG's `embedding_llm`/`rag_llm`, and MCP's `llm_provider`/`embedding_provider`/`kb_embedding_provider`. Anthropic is rejected as a RAG embedding provider (confirmed against upstream — no embeddings API).
- Add MCP audit trace support (`audit_trace_enabled`, `audit_trace_metadata_only`), writing to the existing `/app/data` bind mount — no new mount.
- Replace RAG's healthcheck with a real HTTP probe against the new `/v1/health` endpoint (still bash-builtins-only via `/dev/tcp`, since the runtime image has no curl/wget).
- Pin documentation examples to explicit versions instead of `"latest"`, document all new fields/defaults, and note RAG 2.0.0's hybrid-search behavior change (vector arm is no longer silently dropped).


## Testing
Verification:
1. Create DB 
```
cp1-req create-database < /tmp/create_demo.json

HTTP/1.1 200 OK
Content-Type: application/json
Date: Wed, 09 Sep 2026 05:58:31 GMT

{
  database: {
    created_at: "2026-09-09T05:58:31Z"
    id: "storefront-plat-733-demo"
    spec: {
      database_name: "storefront"
      database_users: [
        {
          attributes: ["SUPERUSER", "LOGIN"]
          db_owner: true
          username: "admin"
        }
        {
          attributes: ["LOGIN"]
          db_owner: false
          username: "web_anon"
        }
      ]
      nodes: [
        {
          host_ids: ["host-1"]
          name: "n1"
        }
      ]
      postgres_version: "17.9"
      services: [
        {
          config: {
            defaults: {
              token_budget: 2000
              top_n: 10
            }
            pipelines: [
              {
                allow_include_sources: true
                description: "Public support articles pipeline - reranked, sources allowed"
                embedding_llm: {
                  model: "text-embedding-3-small"
                  provider: "openai"
                }
                name: "support-docs"
                rag_llm: {
                  model: "claude-sonnet-4-5"
                  provider: "anthropic"
                }
                rerank: {
                  model: "rerank-2"
                  provider: "voyage"
                  top_k: 5
                }
                search: {
                  hybrid_enabled: true
                  vector_weight: 0.7
                }
                tables: [
                  {
                    table: "support_docs_content_chunks"
                    text_column: "content"
                    vector_column: "embedding"
                  }
                ]
                token_budget: 4000
                top_n: 15
              }
              {
                allow_include_sources: false
                description: "Internal product catalog pipeline - Gemini end to end, no source exposure"
                embedding_llm: {
                  model: "gemini-embedding-001"
                  provider: "gemini"
                }
                name: "product-catalog"
                rag_llm: {
                  model: "gemini-2.5-flash"
                  provider: "gemini"
                }
                tables: [
                  {
                    id_column: "id"
                    table: "product_catalog_content_chunks"
                    text_column: "content"
                    vector_column: "embedding"
                  }
                ]
              }
            ]
          }
          connect_as: "admin"
          host_ids: ["host-1"]
          port: 0
          service_id: "rag"
          service_type: "rag"
          version: "2.0.0"
        }
        {
          config: {
            allow_writes: false
            audit_trace_enabled: true
            audit_trace_metadata_only: true
            embedding_model: "voyage-3"
            embedding_provider: "voyage"
            kb_enabled: false
            llm_enabled: true
            llm_model: "gemini-2.5-flash"
            llm_provider: "gemini"
          }
          connect_as: "admin"
          host_ids: ["host-1"]
          port: 0
          service_id: "mcp"
          service_type: "mcp"
          version: "1.1.0"
        }
        {
          config: {
            db_anon_role: "web_anon"
            db_schemas: "public"
          }
          connect_as: "admin"
          host_ids: ["host-1"]
          port: 0
          service_id: "postgrest"
          service_type: "postgrest"
          version: "14.5"
        }
      ]
      spock_version: "5"
    }
    state: "creating"
    updated_at: "2026-09-09T05:58:31Z"
  }
  task: {
    created_at: "2026-09-09T05:58:31Z"
    database_id: "storefront-plat-733-demo"
    entity_id: "storefront-plat-733-demo"
    scope: "database"
    status: "pending"
    task_id: "01a084bf-1808-7697-a565-48150bc32316"
    type: "create"
  }
}

```
2. Confirmed services 
```
 control-plane git:(feature/PLAT-733/adopt-mcp-rag-versions) ✗ docker ps --filter "name=storefront-plat-733-demo" --format '{{.Names}}\t{{.Image}}\t{{.Status}}'

storefront-plat-733-demo-rag-689qacsi.1.n6t124cocmqxd5p34her5lfey	ghcr.io/pgedge/rag-server:2.0.0	Up About a minute (healthy)
storefront-plat-733-demo-postgrest-689qacsi.1.5yvc88ykiafpierjzsf6fb7zv	ghcr.io/pgedge/postgrest:14.5	Up About a minute (healthy)
storefront-plat-733-demo-mcp-689qacsi.1.z8hgio0vbaay9dp94s3k4zywt	ghcr.io/pgedge/postgres-mcp:1.1.0	Up About a minute (healthy)
```

## Checklist

- [x] Tests added or updated (unit and/or e2e, as needed)
- [x] Documentation updated (if needed)

[PLAT-733](https://pgedge.atlassian.net/browse/PLAT-733)

[PLAT-733]: https://pgedge.atlassian.net/browse/PLAT-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ