### PR TITLE
fix: infer pg/spock version from image tag

### DIFF
--- a/server/internal/database/service.go
+++ b/server/internal/database/service.go
@@ -585,6 +585,19 @@ func (s *Service) PopulateSpecDefaults(ctx context.Context, spec *Spec) error {
 	if err != nil {
 		return fmt.Errorf("unable to find greatest common default version among specified hosts: %w", err)
 	}
+	// If the user supplied an image override, prefer the versions encoded in
+	// its tag over the host default so the image and spec version don't end
+	// up in conflict.
+	if spec.PostgresVersion == "" || spec.SpockVersion == "" {
+		if pgVer, spockVer, ok := versionsFromImage(spec.OrchestratorOpts.swarmImage()); ok {
+			if spec.PostgresVersion == "" {
+				spec.PostgresVersion = pgVer
+			}
+			if spec.SpockVersion == "" {
+				spec.SpockVersion = spockVer
+			}
+		}
+	}
 	if spec.PostgresVersion == "" {
 		spec.PostgresVersion = defaultVersion.PostgresVersion.String()
 	}
@@ -605,6 +618,13 @@ func (s *Service) PopulateSpecDefaults(ctx context.Context, spec *Spec) error {
 	}
 	// Second pass on nodes to validate node-level overrides
 	for idx, node := range spec.Nodes {
+		// A node-level image override similarly implies its own Postgres
+		// version if one isn't otherwise specified for the node.
+		if node.PostgresVersion == "" {
+			if pgVer, _, ok := versionsFromImage(node.OrchestratorOpts.swarmImage()); ok {
+				node.PostgresVersion = pgVer
+			}
+		}
 		for _, hostID := range node.HostIDs {
 			h, ok := hostsByID[hostID]
 			if !ok {

--- a/server/internal/database/spec.go
+++ b/server/internal/database/spec.go
@@ -286,6 +286,35 @@ func (o *OrchestratorOpts) Clone() *OrchestratorOpts {
 	}
 }
 
+// swarmImage returns the swarm image override configured in o, or "" if none
+// is set.
+func (o *OrchestratorOpts) swarmImage() string {
+	if o == nil || o.Swarm == nil {
+		return ""
+	}
+	return o.Swarm.Image
+}
+
+// versionsFromImage parses the Postgres and Spock versions encoded in a
+// pgEdge image tag (e.g. "16.14-spock5.0.10-standard-1"), normalized to the
+// major.minor / major format used elsewhere in the API (e.g. "16.14" / "5").
+// Returns ok=false if the image is empty or doesn't follow the recognized
+// pgEdge tag format (e.g. a dev build).
+func versionsFromImage(image string) (postgresVersion, spockVersion string, ok bool) {
+	if image == "" {
+		return "", "", false
+	}
+	pgVer, spockVer, ok := ds.ParseImageTag(image)
+	if !ok {
+		return "", "", false
+	}
+	normalized, err := (&ds.PgEdgeVersion{PostgresVersion: pgVer, SpockVersion: spockVer}).Normalize()
+	if err != nil {
+		return "", "", false
+	}
+	return normalized.PostgresVersion.String(), normalized.SpockVersion.String(), true
+}
+
 func (d *SwarmOpts) Clone() *SwarmOpts {
 	if d == nil {
 		return nil

--- a/server/internal/database/spec_internal_test.go
+++ b/server/internal/database/spec_internal_test.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionsFromImage(t *testing.T) {
+	cases := []struct {
+		name      string
+		image     string
+		wantPg    string
+		wantSpock string
+		wantOk    bool
+	}{
+		{"empty image", "", "", "", false},
+		{"pgEdge tag", "127.0.0.1:5001/pgedge/pgedge-postgres:16.14-spock5.0.10-standard-1", "16.14", "5", true},
+		{"pgEdge tag with digest", "ghcr.io/pgedge/pgedge-postgres:17.9-spock5.0.6-standard-2@sha256:abc123", "17.9", "5", true},
+		{"unrecognized dev tag", "127.0.0.1:5001/pgedge/pgedge-postgres:my-dev-build", "", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pg, spock, ok := versionsFromImage(tc.image)
+			assert.Equal(t, tc.wantOk, ok)
+			if tc.wantOk {
+				assert.Equal(t, tc.wantPg, pg)
+				assert.Equal(t, tc.wantSpock, spock)
+			}
+		})
+	}
+}
+
+func TestOrchestratorOptsSwarmImage(t *testing.T) {
+	assert.Equal(t, "", (*OrchestratorOpts)(nil).swarmImage())
+	assert.Equal(t, "", (&OrchestratorOpts{}).swarmImage())
+	assert.Equal(t, "my-image", (&OrchestratorOpts{Swarm: &SwarmOpts{Image: "my-image"}}).swarmImage())
+}

--- a/server/internal/ds/image_tag.go
+++ b/server/internal/ds/image_tag.go
@@ -1,0 +1,41 @@
+package ds
+
+import (
+	"regexp"
+	"strings"
+)
+
+// imageTagRegexp matches the pgEdge image tag format:
+// {pgver}-spock{spockver}-{variant}[-{build}]
+// e.g. 17.9-spock5.0.6-standard-2, 17.10-spock5-standard
+// The Postgres version requires at least major.minor; the Spock version may be
+// major-only (e.g. spock5) to support mutable channel tags.
+var imageTagRegexp = regexp.MustCompile(`^(\d+\.\d+(?:\.\d+)?)-spock(\d+(?:\.\d+){0,2})-`)
+
+// ParseImageTag extracts the Postgres and Spock versions from an image
+// reference following the pgEdge tag format. Returns ok=false if the tag
+// does not match the expected format (e.g. a dev build tag like "my-build").
+// Digest suffixes (e.g. @sha256:…) are stripped before parsing.
+func ParseImageTag(image string) (pgVer, spockVer *Version, ok bool) {
+	// Strip any digest suffix before extracting the tag.
+	if idx := strings.Index(image, "@"); idx >= 0 {
+		image = image[:idx]
+	}
+	tag := image
+	if idx := strings.LastIndex(image, ":"); idx >= 0 {
+		tag = image[idx+1:]
+	}
+	m := imageTagRegexp.FindStringSubmatch(tag)
+	if m == nil {
+		return nil, nil, false
+	}
+	pg, err := ParseVersion(m[1])
+	if err != nil {
+		return nil, nil, false
+	}
+	spock, err := ParseVersion(m[2])
+	if err != nil {
+		return nil, nil, false
+	}
+	return pg, spock, true
+}

--- a/server/internal/orchestrator/swarm/image_tag.go
+++ b/server/internal/orchestrator/swarm/image_tag.go
@@ -1,45 +1,16 @@
 package swarm
 
 import (
-	"regexp"
-	"strings"
-
 	"github.com/pgEdge/control-plane/server/internal/ds"
 )
-
-// imageTagRegexp matches the pgEdge image tag format:
-// {pgver}-spock{spockver}-{variant}[-{build}]
-// e.g. 17.9-spock5.0.6-standard-2, 17.10-spock5-standard
-// The Postgres version requires at least major.minor; the Spock version may be
-// major-only (e.g. spock5) to support mutable channel tags.
-var imageTagRegexp = regexp.MustCompile(`^(\d+\.\d+(?:\.\d+)?)-spock(\d+(?:\.\d+){0,2})-`)
 
 // parseImageTag extracts the Postgres and Spock versions from an image
 // reference following the pgEdge tag format. Returns ok=false if the tag
 // does not match the expected format (e.g. a dev build tag like "my-build").
-// Digest suffixes (e.g. @sha256:…) are stripped before parsing.
+// See ds.ParseImageTag, which also backs version inference from a
+// user-supplied image (database.PopulateSpecDefaults).
 func parseImageTag(image string) (pgVer, spockVer *ds.Version, ok bool) {
-	// Strip any digest suffix before extracting the tag.
-	if idx := strings.Index(image, "@"); idx >= 0 {
-		image = image[:idx]
-	}
-	tag := image
-	if idx := strings.LastIndex(image, ":"); idx >= 0 {
-		tag = image[idx+1:]
-	}
-	m := imageTagRegexp.FindStringSubmatch(tag)
-	if m == nil {
-		return nil, nil, false
-	}
-	pg, err := ds.ParseVersion(m[1])
-	if err != nil {
-		return nil, nil, false
-	}
-	spock, err := ds.ParseVersion(m[2])
-	if err != nil {
-		return nil, nil, false
-	}
-	return pg, spock, true
+	return ds.ParseImageTag(image)
 }
 
 // versionHasPrefix reports whether tagVer starts with all components of specVer.


### PR DESCRIPTION
## Summary
This PR updates the control plane to infer the PostgreSQL and Spock versions from the image tag when `orchestrator_opts.swarm.image` is provided without explicit `postgres_version` or `spock_version` values.

## Changes
- `PopulateSpecDefaults` now infers `postgres_version`/`spock_version` from a pgEdge-formatted image tag (e.g. `16.14-spock5.0.10-standard-1`) when the corresponding spec field is left unset, before falling back to the host's default version. Applied at both the database-level and per-node `orchestrator_opts.swarm.image` overrides.
- Explicit `postgres_version`/`spock_version` values are untouched — a genuine mismatch between an explicit version and the image is still rejected by the existing `ValidateInstanceSpecs` check.
- Unrecognizable tags (non-pgEdge format, dev builds) are unaffected and continue to fall back to the host default, same as before.
- Moved the pgEdge image tag regex parser from `orchestrator/swarm` into `ds.ParseImageTag` so it's shared between the `swarm` and `database` packages without an import cycle; `swarm.parseImageTag` now delegates to it (no behavior change).


## Testing
Verification:
  1.  Image-only, no explicit version → versions now inferred correctly (`16.14`/`5`), database created and reached `available` on all 3 nodes
```
 curl -s -X POST http://localhost:3000/v1/databases \
  -H "Content-Type: application/json" \
  -d '{
    "spec": {
      "database_name": "verify1",
      "database_users": [{"attributes": ["LOGIN","SUPERUSER"], "db_owner": true, "password": "password", "username": "admin"}],
      "port": 0,
      "nodes": [{"name": "n1", "host_ids": ["host-4"]}],
      "orchestrator_opts": {"swarm": {"image": "127.0.0.1:5000/pgedge/pgedge-postgres:16.14-spock5.0.9-standard-1"}}
    }
  }' | python3 -m json.tool

{
    "task": {
        "scope": "database",
        "entity_id": "656f5bb3-9bba-421a-815e-beb9ec5ed74c",
        "database_id": "656f5bb3-9bba-421a-815e-beb9ec5ed74c",
        "task_id": "01a09063-d074-786b-9667-4bfa5b05b6bf",
        "created_at": "2026-09-11T12:14:15Z",
        "type": "create",
        "status": "pending"
    },
    "database": {
        "id": "656f5bb3-9bba-421a-815e-beb9ec5ed74c",
        "created_at": "2026-09-11T12:14:15Z",
        "updated_at": "2026-09-11T12:14:15Z",
        "state": "creating",
        "spec": {
            "database_name": "verify1",
            "postgres_version": "16.14",
            "spock_version": "5",
            "port": 0,
            "nodes": [
                {
                    "name": "n1",
                    "host_ids": [
                        "host-4"
                    ]
                }
            ],
            "database_users": [
                {
                    "username": "admin",
                    "db_owner": true,
                    "attributes": [
                        "LOGIN",
                        "SUPERUSER"
                    ]
                }
            ],
            "orchestrator_opts": {
                "swarm": {
                    "image": "127.0.0.1:5000/pgedge/pgedge-postgres:16.14-spock5.0.9-standard-1"
                }
            }
        }
    }
}

```
  2.  No image, no explicit version → still defaults from host (unchanged)
 ```
curl -s -X POST http://localhost:3000/v1/databases \
  -H "Content-Type: application/json" \
  -d '{
    "spec": {
      "database_name": "verify2",
      "database_users": [{"attributes": ["LOGIN","SUPERUSER"], "db_owner": true, "password": "password", "username": "admin"}],
      "port": 0,
      "nodes": [{"name": "n1", "host_ids": ["host-5"]}]
    }
  }' | python3 -m json.tool

{
    "task": {
        "scope": "database",
        "entity_id": "4252f2f8-a526-4a44-a8fc-44d69ca022a4",
        "database_id": "4252f2f8-a526-4a44-a8fc-44d69ca022a4",
        "task_id": "01a09066-c14c-7576-a2a2-5dfda26ad8e7",
        "created_at": "2026-09-11T12:17:28Z",
        "type": "create",
        "status": "pending"
    },
    "database": {
        "id": "4252f2f8-a526-4a44-a8fc-44d69ca022a4",
        "created_at": "2026-09-11T12:17:28Z",
        "updated_at": "2026-09-11T12:17:28Z",
        "state": "creating",
        "spec": {
            "database_name": "verify2",
            "postgres_version": "18.6",
            "spock_version": "5",
            "port": 0,
            "nodes": [
                {
                    "name": "n1",
                    "host_ids": [
                        "host-5"
                    ]
                }
            ],
            "database_users": [
                {
                    "username": "admin",
                    "db_owner": true,
                    "attributes": [
                        "LOGIN",
                        "SUPERUSER"
                    ]
                }
            ]
        }
    }
}
```
  3. Image + matching explicit version → still succeeds (unchanged)
```
curl -s -X POST http://localhost:3000/v1/databases \
  -H "Content-Type: application/json" \
  -d '{
    "spec": {
      "database_name": "verify3",
      "postgres_version": "16.14",
      "spock_version": "5",
      "database_users": [{"attributes": ["LOGIN","SUPERUSER"], "db_owner": true, "password": "password", "username": "admin"}],
      "port": 0,
      "nodes": [{"name": "n1", "host_ids": ["host-6"]}],
      "orchestrator_opts": {"swarm": {"image": "127.0.0.1:5000/pgedge/pgedge-postgres:16.14-spock5.0.9-standard-1"}}
    }
  }' | python3 -m json.tool

{
    "task": {
        "scope": "database",
        "entity_id": "c3ac869d-842e-45c0-b507-b6da260ce320",
        "database_id": "c3ac869d-842e-45c0-b507-b6da260ce320",
        "task_id": "01a090b1-d504-7d80-8746-ebabbc570762",
        "created_at": "2026-09-11T13:39:28Z",
        "type": "create",
        "status": "pending"
    },
    "database": {
        "id": "c3ac869d-842e-45c0-b507-b6da260ce320",
        "created_at": "2026-09-11T13:39:28Z",
        "updated_at": "2026-09-11T13:39:28Z",
        "state": "creating",
        "spec": {
            "database_name": "verify3",
            "postgres_version": "16.14",
            "spock_version": "5",
            "port": 0,
            "nodes": [
                {
                    "name": "n1",
                    "host_ids": [
                        "host-6"
                    ]
                }
            ],
            "database_users": [
                {
                    "username": "admin",
                    "db_owner": true,
                    "attributes": [
                        "LOGIN",
                        "SUPERUSER"
                    ]
                }
            ],
            "orchestrator_opts": {
                "swarm": {
                    "image": "127.0.0.1:5000/pgedge/pgedge-postgres:16.14-spock5.0.9-standard-1"
                }
            }
        }
    }
}
```
  4. Image + conflicting explicit version → still correctly rejected with the mismatch error (regression guard intact)
 ```
curl -s -X POST http://localhost:3000/v1/databases \
  -H "Content-Type: application/json" \
  -d '{
    "spec": {
      "database_name": "verify4",
      "postgres_version": "17.9",
      "spock_version": "5",
      "database_users": [{"attributes": ["LOGIN","SUPERUSER"], "db_owner": true, "password": "password", "username": "admin"}],
      "port": 0,
      "nodes": [{"name": "n1", "host_ids": ["host-1"]}],
      "orchestrator_opts": {"swarm": {"image": "127.0.0.1:5000/pgedge/pgedge-postgres:16.14-spock5.0.9-standard-1"}}
    }
  }'
echo

{"name":"invalid_input","message":"validation error for node n1, host host-1: image tag postgres version 16.14 does not match spec version 17.9"}
```
  
  5.  Spock 6
```
 curl -s -X POST http://localhost:3000/v1/databases \
  -H "Content-Type: application/json" \
  -d '{
    "spec": {
      "database_name": "verify5a",
      "database_users": [{"attributes": ["LOGIN","SUPERUSER"], "db_owner": true, "password": "password", "username": "admin"}],
      "port": 0,
      "nodes": [{"name": "n1", "host_ids": ["host-2"]}],
      "orchestrator_opts": {"swarm": {"image": "127.0.0.1:5000/pgedge/pgedge-postgres:18.6-spock6-standard"}}
    }
  }' | python3 -m json.tool

{
    "task": {
        "scope": "database",
        "entity_id": "8ae50582-ed33-40b2-80a5-d417ebfb0c3e",
        "database_id": "8ae50582-ed33-40b2-80a5-d417ebfb0c3e",
        "task_id": "01a09073-8263-7038-bb27-8df1b14c96f3",
        "created_at": "2026-09-11T12:31:24Z",
        "type": "create",
        "status": "pending"
    },
    "database": {
        "id": "8ae50582-ed33-40b2-80a5-d417ebfb0c3e",
        "created_at": "2026-09-11T12:31:24Z",
        "updated_at": "2026-09-11T12:31:24Z",
        "state": "creating",
        "spec": {
            "database_name": "verify5a",
            "postgres_version": "18.6",
            "spock_version": "6",
            "port": 0,
            "nodes": [
                {
                    "name": "n1",
                    "host_ids": [
                        "host-2"
                    ]
                }
            ],
            "database_users": [
                {
                    "username": "admin",
                    "db_owner": true,
                    "attributes": [
                        "LOGIN",
                        "SUPERUSER"
                    ]
                }
            ],
            "orchestrator_opts": {
                "swarm": {
                    "image": "127.0.0.1:5000/pgedge/pgedge-postgres:18.6-spock6-standard"
                }
            }
        }
    }
}

```

## Checklist

- [x] Tests added or updated (unit and/or e2e, as needed)

[PLAT-707](https://pgedge.atlassian.net/browse/PLAT-707)

[PLAT-707]: https://pgedge.atlassian.net/browse/PLAT-707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ